### PR TITLE
introduce .castor.php file

### DIFF
--- a/.castor.php
+++ b/.castor.php
@@ -1,0 +1,9 @@
+<?php
+
+use Castor\Attribute\Task;
+
+#[Task(description: 'hello')]
+function hello(): void
+{
+    echo 'Hello world!';
+}

--- a/.castor/notify.php
+++ b/.castor/notify.php
@@ -10,7 +10,7 @@ use function Castor\notify;
 #[Task(description: 'Send a notification when the task finishes')]
 function notifyOnFinish()
 {
-    exec(['sleep', '2'], notifyOnFinish: true);
+    exec(['sleep', '2'], notify: true);
 }
 
 #[Task(description: 'Send a notification')]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ execute processes.
 ## Usage
 
 As an example you could create a command that print "Hello castor" by creating a
-file in `.castor/hello.php` with the following content:
+file in `.castor.php` with the following content:
 
 ```php
 <?php

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -10,7 +10,7 @@ class ApplicationFactory
     public static function create(): Application
     {
         $finder = new FunctionFinder();
-        $path = PathHelper::getCwd();
+        $path = PathHelper::getRoot();
 
         // Find all potential commands / context
         $functions = $finder->findFunctions($path);

--- a/src/Context.php
+++ b/src/Context.php
@@ -23,6 +23,6 @@ class Context extends \ArrayObject
     ) {
         parent::__construct($array, \ArrayObject::ARRAY_AS_PROPS);
 
-        $this->currentDirectory = PathHelper::getCwd();
+        $this->currentDirectory = PathHelper::getRoot();
     }
 }

--- a/src/FunctionFinder.php
+++ b/src/FunctionFinder.php
@@ -12,6 +12,8 @@ class FunctionFinder
     /** @return iterable<TaskDescriptor|ContextBuilder> */
     public function findFunctions(string $path): iterable
     {
+        yield from $this->doFindFunctions([new SplFileInfo($path . '/.castor.php', '.castor.php', '.castor')]);
+
         $finder = Finder::create()
             ->directories()
             ->ignoreDotFiles(false)

--- a/src/PathHelper.php
+++ b/src/PathHelper.php
@@ -4,15 +4,25 @@ namespace Castor;
 
 class PathHelper
 {
-    public static function getCwd(): string
+    public static function getRoot(): string
     {
-        $cwd = getcwd();
+        static $root;
 
-        if (false === $cwd) {
-            throw new \RuntimeException('Unable to get current working directory.');
+        if (null === $root) {
+            $path = getcwd() ?: '/';
+
+            while (!file_exists($path . '/.castor.php')) {
+                if ('/' === $path) {
+                    throw new \RuntimeException('Could not find root `.castor.php` file.');
+                }
+
+                $path = \dirname($path);
+            }
+
+            $root = $path;
         }
 
-        return $cwd;
+        return $root;
     }
 
     public static function realpath(string $path): string


### PR DESCRIPTION
Use a `.castor.php` file so we can execute castor in subdirectory and looking for the first `.castor.php` in parent directories, still load `.castor` directories inside so we can split our functions without having an include