### PR TITLE
Make global context internal, context is now immutable

### DIFF
--- a/.castor/cd.php
+++ b/.castor/cd.php
@@ -3,14 +3,14 @@
 namespace cd;
 
 use Castor\Attribute\Task;
+use Castor\Context;
 
-use function Castor\cd;
 use function Castor\exec;
 
 #[Task(description: 'A simple command that changes directory')]
-function directory()
+function directory(Context $context)
 {
-    exec(['pwd']);
-    cd('../');
-    exec(['pwd']);
+    exec(['pwd'], context: $context);
+    exec(['pwd'], context: $context->withCd('..'));
+    exec(['pwd'], context: $context);
 }

--- a/.castor/context.php
+++ b/.castor/context.php
@@ -6,6 +6,8 @@ use Castor\Attribute\AsContext;
 use Castor\Attribute\Task;
 use Castor\Context;
 
+use function Castor\exec;
+
 #[AsContext(name: 'production')]
 function productionContext(): Context
 {
@@ -16,6 +18,14 @@ function productionContext(): Context
 function defaultContext(): Context
 {
     return new Context(['production' => false]);
+}
+
+#[AsContext(name: 'exec')]
+function execContext(): Context
+{
+    $production = trim(exec('echo $PRODUCTION')->getOutput());
+
+    return new Context(['production' => (bool) $production]);
 }
 
 #[Task(description: 'A simple task that uses context')]

--- a/.castor/context.php
+++ b/.castor/context.php
@@ -11,13 +11,13 @@ use function Castor\exec;
 #[AsContext(name: 'production')]
 function productionContext(): Context
 {
-    return new Context(['production' => true]);
+    return defaultContext()->withData(['production' => true]);
 }
 
 #[AsContext(default: true)]
 function defaultContext(): Context
 {
-    return new Context(['production' => false]);
+    return new Context(['production' => false, 'foo' => 'bar']);
 }
 
 #[AsContext(name: 'exec')]
@@ -36,4 +36,6 @@ function context(Context $context)
     } else {
         echo "development\n";
     }
+
+    echo "foo: {$context['foo']}\n";
 }

--- a/.castor/context.php
+++ b/.castor/context.php
@@ -23,7 +23,7 @@ function defaultContext(): Context
 #[AsContext(name: 'exec')]
 function execContext(): Context
 {
-    $production = trim(exec('echo $PRODUCTION')->getOutput());
+    $production = trim(exec('echo $PRODUCTION', quiet: true)->getOutput());
 
     return new Context(['production' => (bool) $production]);
 }

--- a/.castor/env.php
+++ b/.castor/env.php
@@ -17,7 +17,9 @@ function context_env(): Context
 }
 
 #[Task(description: 'A simple task that uses environment variables')]
-function env()
+function env(Context $context)
 {
-    exec('echo foo: \"$FOO\", bar: \"$BAR\"', environment: ['BAR' => 'tata']);
+    exec('echo foo: \"$FOO\", bar: \"$BAR\"', context: $context->withEnvironment([
+        'BAR' => 'tata',
+    ]));
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -14,15 +14,111 @@ class Context extends \ArrayObject
     public string $currentDirectory;
 
     /**
-     * @param array<(int|string), TValue> $array The input parameter accepts an array or an Object
+     * @param array<(int|string), TValue> $data The input parameter accepts an array or an Object
      * @param array<string, string> $environment a list of environment variables to add to the command
      */
     public function __construct(
-        public array $array = [],
+        array $data = [],
         public array $environment = [],
+        string $currentDirectory = null,
+        public bool $tty = false,
+        public bool $pty = true,
+        public float|null $timeout = 60,
     ) {
-        parent::__construct($array, \ArrayObject::ARRAY_AS_PROPS);
+        parent::__construct($data, \ArrayObject::ARRAY_AS_PROPS);
 
-        $this->currentDirectory = PathHelper::getRoot();
+        $this->currentDirectory = $currentDirectory ?? PathHelper::getRoot();
+    }
+
+    public function cd(string $path): void
+    {
+        // if path is absolute
+        if (str_starts_with($path, '/')) {
+            $this->currentDirectory = $path;
+        } else {
+            $this->currentDirectory = PathHelper::realpath($this->currentDirectory . '/' . $path);
+        }
+    }
+
+    /** @param array<(int|string), TValue> $data */
+    public function with(array $data, bool $keepExisting = true): self
+    {
+        return new self(
+            $keepExisting ? array_merge($this->getArrayCopy(), $data) : $data,
+            $this->environment,
+            $this->currentDirectory,
+            $this->tty,
+            $this->pty,
+            $this->timeout,
+        );
+    }
+
+    /** @param array<string, string> $environment */
+    public function withEnvironment(array $environment, bool $keepExisting = true): self
+    {
+        return new self(
+            $this->getArrayCopy(),
+            $keepExisting ? array_merge($this->environment, $environment) : $environment,
+            $this->currentDirectory,
+            $this->tty,
+            $this->pty,
+            $this->timeout,
+        );
+    }
+
+    public function withCd(string $path): self
+    {
+        $context = clone $this;
+        $context->cd($path);
+
+        return $context;
+    }
+
+    public function withDirectory(string $directory): self
+    {
+        return new self(
+            $this->getArrayCopy(),
+            $this->environment,
+            $directory,
+            $this->tty,
+            $this->pty,
+            $this->timeout,
+        );
+    }
+
+    public function withTty(bool $tty = true): self
+    {
+        return new self(
+            $this->getArrayCopy(),
+            $this->environment,
+            $this->currentDirectory,
+            $tty,
+            $this->pty,
+            $this->timeout,
+        );
+    }
+
+    public function withPty(bool $pty = true): self
+    {
+        return new self(
+            $this->getArrayCopy(),
+            $this->environment,
+            $this->currentDirectory,
+            $this->tty,
+            $pty,
+            $this->timeout,
+        );
+    }
+
+    public function withTimeout(float|null $timeout): self
+    {
+        return new self(
+            $this->getArrayCopy(),
+            $this->environment,
+            $this->currentDirectory,
+            $this->tty,
+            $this->pty,
+            $timeout,
+        );
     }
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -2,49 +2,30 @@
 
 namespace Castor;
 
-use ArrayObject;
-
-/**
- * @template TValue
- *
- * @template-extends ArrayObject<(int|string), TValue>
- */
-class Context extends \ArrayObject
+class Context implements \ArrayAccess
 {
-    public string $currentDirectory;
+    public readonly string $currentDirectory;
 
     /**
-     * @param array<(int|string), TValue> $data The input parameter accepts an array or an Object
+     * @param array<(int|string), mixed> $data The input parameter accepts an array or an Object
      * @param array<string, string> $environment a list of environment variables to add to the command
      */
     public function __construct(
-        array $data = [],
-        public array $environment = [],
+        public readonly array $data = [],
+        public readonly array $environment = [],
         string $currentDirectory = null,
-        public bool $tty = false,
-        public bool $pty = true,
-        public float|null $timeout = 60,
+        public readonly bool $tty = false,
+        public readonly bool $pty = true,
+        public readonly float|null $timeout = 60,
     ) {
-        parent::__construct($data, \ArrayObject::ARRAY_AS_PROPS);
-
         $this->currentDirectory = $currentDirectory ?? PathHelper::getRoot();
     }
 
-    public function cd(string $path): void
-    {
-        // if path is absolute
-        if (str_starts_with($path, '/')) {
-            $this->currentDirectory = $path;
-        } else {
-            $this->currentDirectory = PathHelper::realpath($this->currentDirectory . '/' . $path);
-        }
-    }
-
-    /** @param array<(int|string), TValue> $data */
-    public function with(array $data, bool $keepExisting = true): self
+    /** @param array<(int|string), mixed> $data */
+    public function withData(array $data, bool $keepExisting = true): self
     {
         return new self(
-            $keepExisting ? array_merge($this->getArrayCopy(), $data) : $data,
+            $keepExisting ? array_merge($this->data, $data) : $data,
             $this->environment,
             $this->currentDirectory,
             $this->tty,
@@ -57,7 +38,7 @@ class Context extends \ArrayObject
     public function withEnvironment(array $environment, bool $keepExisting = true): self
     {
         return new self(
-            $this->getArrayCopy(),
+            $this->data,
             $keepExisting ? array_merge($this->environment, $environment) : $environment,
             $this->currentDirectory,
             $this->tty,
@@ -68,16 +49,27 @@ class Context extends \ArrayObject
 
     public function withCd(string $path): self
     {
-        $context = clone $this;
-        $context->cd($path);
+        // if path is absolute
+        if (str_starts_with($path, '/')) {
+            $newCurrentDirectory = $path;
+        } else {
+            $newCurrentDirectory = PathHelper::realpath($this->currentDirectory . '/' . $path);
+        }
 
-        return $context;
+        return new self(
+            $this->data,
+            $this->environment,
+            str_starts_with($path, '/') ? $path : PathHelper::realpath($this->currentDirectory . '/' . $path),
+            $this->tty,
+            $this->pty,
+            $this->timeout,
+        );
     }
 
     public function withDirectory(string $directory): self
     {
         return new self(
-            $this->getArrayCopy(),
+            $this->data,
             $this->environment,
             $directory,
             $this->tty,
@@ -89,7 +81,7 @@ class Context extends \ArrayObject
     public function withTty(bool $tty = true): self
     {
         return new self(
-            $this->getArrayCopy(),
+            $this->data,
             $this->environment,
             $this->currentDirectory,
             $tty,
@@ -101,7 +93,7 @@ class Context extends \ArrayObject
     public function withPty(bool $pty = true): self
     {
         return new self(
-            $this->getArrayCopy(),
+            $this->data,
             $this->environment,
             $this->currentDirectory,
             $this->tty,
@@ -113,12 +105,32 @@ class Context extends \ArrayObject
     public function withTimeout(float|null $timeout): self
     {
         return new self(
-            $this->getArrayCopy(),
+            $this->data,
             $this->environment,
             $this->currentDirectory,
             $this->tty,
             $this->pty,
             $timeout,
         );
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->data[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->data[$offset] ?? throw new \RuntimeException(sprintf('The property "%s" does not exist in the current context.', $offset));
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException('Context is immutable');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException('Context is immutable');
     }
 }

--- a/src/ContextRegistry.php
+++ b/src/ContextRegistry.php
@@ -4,8 +4,6 @@ namespace Castor;
 
 class ContextRegistry
 {
-    private static Context $currentContext;
-
     /** @var array<string, ContextBuilder> */
     private array $contexts = [];
 
@@ -25,15 +23,5 @@ class ContextRegistry
     public function getContextNames(): array
     {
         return array_keys($this->contexts);
-    }
-
-    public static function setCurrentContext(Context $context): void
-    {
-        self::$currentContext = $context;
-    }
-
-    public static function getCurrentContext(): Context
-    {
-        return self::$currentContext ??= new Context();
     }
 }

--- a/src/ContextRegistry.php
+++ b/src/ContextRegistry.php
@@ -4,7 +4,7 @@ namespace Castor;
 
 class ContextRegistry
 {
-    public static Context $currentContext;
+    private static Context $currentContext;
 
     /** @var array<string, ContextBuilder> */
     private array $contexts = [];
@@ -25,5 +25,15 @@ class ContextRegistry
     public function getContextNames(): array
     {
         return array_keys($this->contexts);
+    }
+
+    public static function setCurrentContext(Context $context): void
+    {
+        self::$currentContext = $context;
+    }
+
+    public static function getCurrentContext(): Context
+    {
+        return self::$currentContext ??= new Context();
     }
 }

--- a/src/ContextRegistry.php
+++ b/src/ContextRegistry.php
@@ -2,8 +2,11 @@
 
 namespace Castor;
 
+/** @internal */
 class ContextRegistry
 {
+    private static Context $currentContext;
+
     /** @var array<string, ContextBuilder> */
     private array $contexts = [];
 
@@ -23,5 +26,15 @@ class ContextRegistry
     public function getContextNames(): array
     {
         return array_keys($this->contexts);
+    }
+
+    public static function setCurrentContext(Context $context): void
+    {
+        self::$currentContext = $context;
+    }
+
+    public static function getCurrentContext(): Context
+    {
+        return self::$currentContext ??= new Context();
     }
 }

--- a/src/TaskAsCommand.php
+++ b/src/TaskAsCommand.php
@@ -72,6 +72,7 @@ class TaskAsCommand extends Command
         $contextBuilder = $this->contextRegistry->getContext($contextName);
 
         $context = $contextBuilder->build();
+        ContextRegistry::setCurrentContext($context);
 
         foreach ($this->function->getParameters() as $parameter) {
             $name = SluggerHelper::slug($parameter->getName());

--- a/src/TaskAsCommand.php
+++ b/src/TaskAsCommand.php
@@ -72,7 +72,7 @@ class TaskAsCommand extends Command
         $contextBuilder = $this->contextRegistry->getContext($contextName);
 
         $context = $contextBuilder->build();
-        ContextRegistry::$currentContext = $context;
+        ContextRegistry::setCurrentContext($context);
 
         foreach ($this->function->getParameters() as $parameter) {
             $name = SluggerHelper::slug($parameter->getName());

--- a/src/TaskAsCommand.php
+++ b/src/TaskAsCommand.php
@@ -72,7 +72,6 @@ class TaskAsCommand extends Command
         $contextBuilder = $this->contextRegistry->getContext($contextName);
 
         $context = $contextBuilder->build();
-        ContextRegistry::setCurrentContext($context);
 
         foreach ($this->function->getParameters() as $parameter) {
             $name = SluggerHelper::slug($parameter->getName());

--- a/src/functions.php
+++ b/src/functions.php
@@ -45,6 +45,7 @@ function parallel(callable ...$callbacks): array
 /**
  * @param string|array<string> $command
  * @param (callable(string, string, Process) :void)|null $callback
+ * @param array<string, string>|null $environment
  */
 function exec(
     string|array $command,
@@ -55,8 +56,18 @@ function exec(
     Context $context = null,
     bool|null $tty = null,
     bool|null $pty = null,
+    string $path = null,
+    array $environment = null,
 ): Process {
-    $context ??= new Context();
+    $context ??= ContextRegistry::getCurrentContext();
+
+    if ($path) {
+        $context = $context->withCd($path);
+    }
+
+    if ($environment) {
+        $context = $context->withEnvironment($environment);
+    }
 
     if (\is_array($command)) {
         $process = new Process($command, $context->currentDirectory, $context->environment, null, $context->timeout);
@@ -129,7 +140,7 @@ function notify(string $message): void
 /** @param (callable(string, string) : (false|null)) $function */
 function watch(string $path, callable $function, Context $context = null): void
 {
-    $context ??= new Context();
+    $context ??= ContextRegistry::getCurrentContext();
     $binary = 'watcher';
 
     if ('\\' === \DIRECTORY_SEPARATOR) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -59,7 +59,7 @@ function exec(
     bool $allowFailure = false,
     bool $notify = false,
 ): Process {
-    $context = ContextRegistry::$currentContext;
+    $context = ContextRegistry::getCurrentContext();
 
     if (null === $workingDirectory) {
         $workingDirectory = $context->currentDirectory;
@@ -119,7 +119,7 @@ function exec(
 
 function cd(string $path): void
 {
-    $context = ContextRegistry::$currentContext;
+    $context = ContextRegistry::getCurrentContext();
 
     // if path is absolute
     if (0 === strpos($path, '/')) {


### PR DESCRIPTION
Since we already have a way to pass the context to the function without having to call the registry, i think it may be better to put more options / features in the context and remove the static context instance from the registry.

This avoid a lot of potential problems (when one would change directory in one function, then call another function that will not work since it's not the good directory)

Also add method to change context and clone him in the same time 

EDIT : 

Context is now immutable
Context is back again "global" but only for internal use (to avoid a lot of code repetition in usage)

