### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ execute processes.
 
 ## Usage
 
-As an example you could create a command that print "Hello castor" by creating a
-file in `.castor.php` with the following content:
+As an example, you could create a command that print "Hello castor" by creating a
+file `.castor.php` with the following content:
 
 ```php
 <?php


### PR DESCRIPTION
> The name of the file without the extension is the namespace of the command, in
this case `hello`. The name of the function is the name of the command, in this
case `castor`.

It's the filename (without extension) or the php namespace?
There's a missleading info between the `.castor.php` (it's a file? a dir?), the exemple and the result. Right?