### PR TITLE
Reduce the PHAR size

### DIFF
--- a/tools/phar/box.json
+++ b/tools/phar/box.json
@@ -1,18 +1,25 @@
 {
   "base-path": "../../",
-  "force-autodiscovery": true,
-  "finder": [
-    {
-      "in": ".",
-      "name": [
-        "watcher",
-        "watcher.exe"
-      ]
-    }
+  "files": [
+    "watcher/bin/watcher",
+    "watcher/bin/watcher.exe"
   ],
   "blacklist": [
-    ".castor"
+    ".castor",
+    "LICENSE",
+    "Test",
+    "tools",
+    "vendor/psr/event-dispatcher",
+    "vendor/symfony/error-handler",
+    "vendor/symfony/event-dispatcher-contracts",
+    "vendor/symfony/http-foundation",
+    "vendor/symfony/service-contracts"
   ],
+  "compactors": [
+    "KevinGH\\Box\\Compactor\\Php"
+  ],
+  "compression": "GZ",
+  "check-requirements": false,
   "git-version": "package_version",
   "main": "bin/castor",
   "output": "tools/phar/build/castor.phar"


### PR DESCRIPTION
Before: 

```
>…/dev/github.com/jolicode/castor/tools/phar(main %) ll build/castor.phar
-rwxr-xr-x 1 gregoire gregoire 8,7M mai   25 08:49 build/castor.phar

>…/dev/github.com/jolicode/castor/tools/phar(main %) et extracted/vendor/ -l1
vendor (6.11 MiB)
├─ symfony (2.57 MiB)
├─ psr (15.47 KiB)
├─ monolog (416.68 KiB)
├─ autoload.php (771 B)
├─ composer (247.00 KiB)
└─ jolicode (2.88 MiB)
```

After

```
>…/dev/github.com/jolicode/castor/tools/phar(main %) ll build/castor.phar
-rwxr-xr-x 1 gregoire gregoire 2,9M mai   25 08:51 build/castor.phar

>…/dev/github.com/jolicode/castor/tools/phar(phar-optmization %) et extracted/vendor/ -l1
vendor (4.70 MiB)
├─ symfony (1.44 MiB)
├─ psr (3.50 KiB)
├─ autoload.php (771 B)
├─ monolog (217.17 KiB)
├─ composer (195.52 KiB)
└─ jolicode (2.86 MiB)
```

We can even go further by inlining this class: https://github.com/symfony/symfony/blob/6.4/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
