### PR TITLE
run no exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It comes with many helpers to make your life easier:
 
 * arguments and options parsing
 * autocomplete
-* process execution
+* process executing
 * parallel processing
 * file watching
 * notification
@@ -24,12 +24,12 @@ a file `castor.php` with the following content:
 namespace hello;
 
 use Castor\Attribute\AsTask;
-use function Castor\exec;
+use function Castor\run;
 
 #[AsTask]
 function castor(): void
 {
-    exec('echo "Hello castor"');
+    run('echo "Hello castor"');
 }
 ```
 
@@ -66,7 +66,7 @@ function destroy(
 
     log('Destroying the infrastructure...')
 
-    exec('docker-compose down -v --remove-orphans --volumes --rmi=local');
+    run('docker-compose down -v --remove-orphans --volumes --rmi=local');
 
     notify('The infrastructure has been destroyed.')
 }
@@ -182,7 +182,7 @@ alias castor='docker run -it --rm -v `pwd`:/project -v "/var/run/docker.sock:/va
 Discover more by reading the docs:
 
 * [Basic usage](doc/01-basic-usage.md)
-* [The exec function](doc/02-exec.md)
+* [The `run()` function](doc/02-run.md)
 * [Command arguments](doc/03-arguments.md)
 * [Using the context](doc/04-context.md)
 * [Asking something, progress bar and more](doc/05-helper.md)

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -40,7 +40,7 @@ $commandFilterList = [
     'log:with-context',
     'parallel:sleep',
     'run:run-parallel',
-    'run:run',
+    'run:run-ls',
 ];
 $optionFilterList = array_flip(['help', 'quiet', 'verbose', 'version', 'ansi', 'no-ansi', 'no-interaction', 'context']);
 foreach ($applicationDescription['commands'] as $command) {
@@ -79,7 +79,7 @@ foreach ($applicationDescription['commands'] as $command) {
     add_test($args, $class, $task, $methodName);
 }
 
-add_test(['context:context', '--context', 'exec'], 'ContextContextExec', 'context:context');
+add_test(['context:context', '--context', 'run'], 'ContextContextRun', 'context:context');
 add_test(['context:context', '--context', 'my_default', '-vvv'], 'ContextContextMyDefault', 'context:context');
 add_test(['context:context', '--context', 'no_no_exist'], 'ContextContextDoNotExist', 'context:context');
 add_test(['context:context', '--context', 'production'], 'ContextContextProduction', 'context:context');

--- a/doc/02-run.md
+++ b/doc/02-run.md
@@ -1,19 +1,19 @@
-## Exec function
+## The `run()` function
 
-Castor provides a `Castor\exec()` function to execute commands. It allows to run a
-sub process and execute whatever you want:
+Castor provides a `Castor\run()` function to run commands. It allows to run a
+process:
 
 ```php
 <?php
 
 use Castor\Attribute\AsTask;
-use function Castor\exec;
+use function Castor\run;
 
 #[AsTask]
 function foo(): void
 {
-    exec('echo "bar"');
-    exec(['echo', 'bar']);
+    run('echo "bar"');
+    run(['echo', 'bar']);
 }
 ```
 
@@ -24,14 +24,14 @@ string, arguments will not be escaped - use it carefully.
 
 Under the hood, Castor uses the
 [`Symfony\Component\Process\Process`](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Process/Process.php)
-object to execute the command. The `exec()` function will return this object. So
+object to run the command. The `run()` function will return this object. So
 you can use the API of this class to interact with the process:
 
 ```php
 #[AsTask]
 function foo(): void
 {
-    $process = exec('echo "bar"');
+    $process = run('echo "bar"');
     $process->isSuccessful(); // will return true
 }
 ```
@@ -45,13 +45,13 @@ that by setting the `allowFailure` option to `true`:
 #[AsTask]
 function foo(): void
 {
-    exec('a_command_that_does_not_exist', allowFailure: true);
+    run('a_command_that_does_not_exist', allowFailure: true);
 }
 ```
 
 ### Working directory
 
-By default, Castor will execute the command in the same directory as
+By default, Castor will run the command in the same directory as
 the `castor.php` file. You can change that by setting the `path` argument. It
 can be either a relative or an absolute path:
 
@@ -59,8 +59,8 @@ can be either a relative or an absolute path:
 #[AsTask]
 function foo(): void
 {
-    exec('pwd', path: '../'); // execute the command in the parent directory of the castor.php file
-    exec('pwd', path: '/tmp'); // execute the command in the /tmp directory
+    run('pwd', path: '../'); // run the command in the parent directory of the castor.php file
+    run('pwd', path: '/tmp'); // run the command in the /tmp directory
 }
 ```
 
@@ -74,7 +74,7 @@ the `environment` argument:
 #[AsTask]
 function foo(): void
 {
-    exec('echo $FOO', environment: ['FOO' => 'bar']); // will print "bar"
+    run('echo $FOO', environment: ['FOO' => 'bar']); // will print "bar"
 }
 ```
 
@@ -88,7 +88,7 @@ option to `true`:
 #[AsTask]
 function foo(): void
 {
-    exec('echo "bar"', quiet: true); // will not print anything
+    run('echo "bar"', quiet: true); // will not print anything
 }
 ```
 
@@ -99,14 +99,14 @@ the `Symfony\Component\Process\Process` object:
 #[AsTask]
 function foo(): void
 {
-    $process = exec('echo "bar"', quiet: true); // will not print anything
+    $process = run('echo "bar"', quiet: true); // will not print anything
     $output = $process->getOutput(); // will return "bar\n"
 }
 ```
 
 ### PTY & TTY
 
-By default, Castor will use a pseudo terminal (PTY) to execute the command,
+By default, Castor will use a pseudo terminal (PTY) to run the command,
 which allows to have nice output in most cases.
 For some commands you may want to disable the PTY and use a TTY instead. You can
 do that by setting the `tty` option to `true`:
@@ -115,7 +115,7 @@ do that by setting the `tty` option to `true`:
 #[AsTask]
 function foo(): void
 {
-    exec('echo "bar"', tty: true);
+    run('echo "bar"', tty: true);
 }
 ```
 
@@ -132,6 +132,6 @@ the command:
 #[AsTask]
 function foo(): void
 {
-    exec('echo "bar"', pty: false);
+    run('echo "bar"', pty: false);
 }
 ```

--- a/doc/03-arguments.md
+++ b/doc/03-arguments.md
@@ -9,7 +9,7 @@ function command(
     string $firstArg,
     string $secondArg
 ) {
-    exec(['echo', $firstArg, $secondArg]);
+    run(['echo', $firstArg, $secondArg]);
 }
 ```
 
@@ -30,7 +30,7 @@ function command(
     string $firstArg,
     string $default = 'default'
 ) {
-    exec(['echo', $firstArg, $secondArg]);
+    run(['echo', $firstArg, $secondArg]);
 }
 ```
 
@@ -52,7 +52,7 @@ function command(
     #[AsArgument(name: 'foo', description: 'This is the foo argument')]
     string $arg = 'bar',
 ) {
-    exec(['echo', $arg]);
+    run(['echo', $arg]);
 }
 ```
 
@@ -72,7 +72,7 @@ function command(
     #[AsOption(name: 'foo', description: 'This is the foo option')]
     string $arg = 'bar',
 ) {
-    exec(['echo', $arg]);
+    run(['echo', $arg]);
 }
 ```
 

--- a/doc/04-context.md
+++ b/doc/04-context.md
@@ -1,7 +1,7 @@
 ## Context
 
-For every command that castor execute, it uses a `Context` object. This object
-contains the default values for the `exec` or `watch` function (directory,
+For every command that castor run, it uses a `Context` object. This object
+contains the default values for the `run` or `watch` function (directory,
 environment variables, pty, tty, etc...).
 
 It also contains custom values that can be set by the user and reused in
@@ -23,7 +23,7 @@ function foo(Context $context): void
 {
     echo $context->currentDirectory; // will print the directory of the castor.php file
     $context = $context->withPath('/tmp'); // will create a new context with the current directory set to /tmp
-    exec('pwd', context: $context); // will print /tmp
+    run('pwd', context: $context); // will print /tmp
 }
 ```
 
@@ -45,7 +45,7 @@ function my_context(): Context
 #[AsTask]
 function foo(): void
 {
-    exec('echo $FOO');
+    run('echo $FOO');
 }
 ```
 
@@ -82,7 +82,7 @@ function create_default_context(): Context
 #[AsTask]
 function foo(Context $context): void
 {
-    exec(['echo', $context['foo']]); // will print bar even if you do not use the --context option
-    exec('pwd'); // will print /tmp
+    run(['echo', $context['foo']]); // will print bar even if you do not use the --context option
+    run('pwd'); // will print /tmp
 }
 ```

--- a/doc/07-parallel.md
+++ b/doc/07-parallel.md
@@ -1,6 +1,6 @@
 ## Parallel execution
 
-The `parallel()` function provides a way to execute functions in parallel,
+The `parallel()` function provides a way to run functions in parallel,
 so you do not have to wait for a function to finish before starting another one:
 
 ```php
@@ -9,10 +9,10 @@ function foo(): void
 {
     [$foo, $bar] = parallel(
         function () {
-            return exec('sleep 2 && echo foo', quiet: true);
+            return run('sleep 2 && echo foo', quiet: true);
         },
         function () {
-            return exec('sleep 2 && echo bar', quiet: true);
+            return run('sleep 2 && echo bar', quiet: true);
         }
     );
 
@@ -22,12 +22,12 @@ function foo(): void
 ```
 
 The `parallel()` function use the [`\Fiber`](https://www.php.net/Fiber) class to
-execute the functions in parallel.
+run the functions in parallel.
 
 > **Note**
 > The code is not executed in parallel. Only functions using this concept
 > will be executed in parallel, which is the case for
-> the `exec()` and `watch()` function.
+> the `run()` and `watch()` function.
 
 ### Watching in parallel
 

--- a/doc/08-notify.md
+++ b/doc/08-notify.md
@@ -12,16 +12,16 @@ function notify()
 }
 ```
 
-### Notify on exec
+### Notify on run
 
-You can use the `notify()` argument of the `exec()` function to display a
+You can use the `notify` argument of the `run()` function to display a
 notification when a command has been executed:
 
 ```php
 #[AsTask]
 function notify()
 {
-    exec(['echo', 'notify'], notify: true); // will display a success notification
-    exec('command_that_does_not_exist', notify: true); // will display a failure notification
+    run(['echo', 'notify'], notify: true); // will display a success notification
+    run('command_that_does_not_exist', notify: true); // will display a failure notification
 }
 ```

--- a/examples/args.php
+++ b/examples/args.php
@@ -7,7 +7,7 @@ use Castor\Attribute\AsOption;
 use Castor\Attribute\AsTask;
 use Symfony\Component\Console\Input\InputOption;
 
-use function Castor\exec;
+use function Castor\run;
 
 #[AsTask(description: 'Dumps all arguments and options, with custom configuration')]
 function args(
@@ -28,5 +28,5 @@ function another_args(
     string $required,
     int $test2 = 1
 ) {
-    exec(['echo', $required, $test2]);
+    run(['echo', $required, $test2]);
 }

--- a/examples/cd.php
+++ b/examples/cd.php
@@ -5,12 +5,12 @@ namespace cd;
 use Castor\Attribute\AsTask;
 use Castor\Context;
 
-use function Castor\exec;
+use function Castor\run;
 
 #[AsTask(description: 'Changes directory')]
 function directory(Context $context)
 {
-    exec(['pwd'], context: $context);
-    exec(['pwd'], context: $context->withPath('src/Attribute'));
-    exec(['pwd'], context: $context);
+    run(['pwd'], context: $context);
+    run(['pwd'], context: $context->withPath('src/Attribute'));
+    run(['pwd'], context: $context);
 }

--- a/examples/context.php
+++ b/examples/context.php
@@ -7,7 +7,7 @@ use Castor\Attribute\AsTask;
 use Castor\Context;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function Castor\exec;
+use function Castor\run;
 
 #[AsContext(default: true, name: 'my_default')]
 function defaultContext(): Context
@@ -30,14 +30,14 @@ function productionContext(): Context
     ;
 }
 
-#[AsContext(name: 'exec')]
-function execContext(): Context
+#[AsContext(name: 'run')]
+function runContext(): Context
 {
-    $production = (bool) trim(exec('echo $PRODUCTION', quiet: true)->getOutput());
-    $foo = trim(exec('echo $FOO', quiet: true)->getOutput()) ?: 'no defined';
+    $production = (bool) trim(run('echo $PRODUCTION', quiet: true)->getOutput());
+    $foo = trim(run('echo $FOO', quiet: true)->getOutput()) ?: 'no defined';
 
     return new Context([
-        'name' => 'exec',
+        'name' => 'run',
         'production' => (bool) $production,
         'foo' => $foo,
     ]);

--- a/examples/env.php
+++ b/examples/env.php
@@ -5,7 +5,7 @@ namespace env;
 use Castor\Attribute\AsTask;
 use Castor\Context;
 
-use function Castor\exec;
+use function Castor\run;
 
 #[AsTask(description: 'Display environment variables')]
 function env(Context $context)
@@ -13,5 +13,5 @@ function env(Context $context)
     $context = $context->withEnvironment([
         'FOO' => 'toto',
     ]);
-    exec('echo \"$FOO\"', context: $context);
+    run('echo \"$FOO\"', context: $context);
 }

--- a/examples/failure.php
+++ b/examples/failure.php
@@ -4,16 +4,16 @@ namespace failure;
 
 use Castor\Attribute\AsTask;
 
-use function Castor\exec;
+use function Castor\run;
 
 #[AsTask(description: 'A failing task not authorized to fail')]
 function failure()
 {
-    exec('i_do_not_exist', path: '/tmp');
+    run('i_do_not_exist', path: '/tmp');
 }
 
 #[AsTask(description: 'A failing task authorized to fail')]
 function allow_failure()
 {
-    exec('i_do_not_exist', allowFailure: true);
+    run('i_do_not_exist', allowFailure: true);
 }

--- a/examples/notify.php
+++ b/examples/notify.php
@@ -4,13 +4,13 @@ namespace notify;
 
 use Castor\Attribute\AsTask;
 
-use function Castor\exec;
 use function Castor\notify;
+use function Castor\run;
 
 #[AsTask(description: 'Sends a notification when the task finishes')]
 function notify_on_finish()
 {
-    exec(['sleep', '1'], notify: true);
+    run(['sleep', '1'], notify: true);
 }
 
 #[AsTask(description: 'Sends a notification')]

--- a/examples/parallel.php
+++ b/examples/parallel.php
@@ -4,16 +4,16 @@ namespace parallel;
 
 use Castor\Attribute\AsTask;
 
-use function Castor\exec;
 use function Castor\parallel;
+use function Castor\run;
 
 function sleep_5(int $sleep = 5)
 {
     echo "sleep {$sleep}\n";
-    exec(['sleep', $sleep]);
+    run(['sleep', $sleep]);
 
     echo "re sleep {$sleep}\n";
-    exec(['sleep', $sleep]);
+    run(['sleep', $sleep]);
 
     return 'foo';
 }
@@ -21,7 +21,7 @@ function sleep_5(int $sleep = 5)
 function sleep_7(int $sleep = 7)
 {
     echo "sleep {$sleep}\n";
-    exec(['sleep', $sleep]);
+    run(['sleep', $sleep]);
 
     return 'bar';
 }
@@ -29,7 +29,7 @@ function sleep_7(int $sleep = 7)
 function sleep_10(int $sleep = 10)
 {
     echo "sleep {$sleep}\n";
-    exec(['sleep', $sleep]);
+    run(['sleep', $sleep]);
 
     return "sleep {$sleep}";
 }

--- a/examples/quiet.php
+++ b/examples/quiet.php
@@ -4,10 +4,10 @@ namespace quiet;
 
 use Castor\Attribute\AsTask;
 
-use function Castor\exec;
+use function Castor\run;
 
 #[AsTask(description: 'Executes something but does not output anything')]
 function quiet()
 {
-    exec('ls -alh', quiet: true);
+    run('ls -alh', quiet: true);
 }

--- a/examples/run.php
+++ b/examples/run.php
@@ -6,12 +6,12 @@ use Castor\Attribute\AsTask;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use function Castor\exec;
+use function Castor\run;
 
 #[AsTask(description: 'Run a sub-process and display information about it')]
-function run()
+function run_ls()
 {
-    $process = exec('ls -alh', quiet: true);
+    $process = run('ls -alh', quiet: true);
 
     echo "Output: \n" . $process->getOutput();
     echo "\nError output: \n" . $process->getErrorOutput();

--- a/examples/shell.php
+++ b/examples/shell.php
@@ -4,16 +4,16 @@ namespace shell;
 
 use Castor\Attribute\AsTask;
 
-use function Castor\exec;
+use function Castor\run;
 
 #[AsTask(description: 'Runs a bash')]
 function bash()
 {
-    exec('bash', tty: true);
+    run('bash', tty: true);
 }
 
 #[AsTask(description: 'Runs a sh')]
 function sh()
 {
-    exec('sh', tty: true);
+    run('sh', tty: true);
 }

--- a/src/Console/Command/TaskCommand.php
+++ b/src/Console/Command/TaskCommand.php
@@ -129,7 +129,15 @@ class TaskCommand extends Command
             $args[] = $input->getOption($name);
         }
 
-        $result = $this->function->invoke(...$args);
+        try {
+            $result = $this->function->invoke(...$args);
+        } catch (\Error $e) {
+            if ('Call to undefined function run()' === $e->getMessage()) {
+                throw new \LogicException(sprintf('Call to undefined function run(). Did you forget to import it? Try to add "use function Castor\run;" in top of "%s" file.', $this->function->getFileName()));
+            }
+
+            throw $e;
+        }
 
         if (null === $result) {
             return Command::SUCCESS;

--- a/src/GlobalHelper.php
+++ b/src/GlobalHelper.php
@@ -16,7 +16,7 @@ class GlobalHelper
 
     public static function getInitialContext(): Context
     {
-        // We always need a default context, for example when using exec() in a context builder
+        // We always need a default context, for example when using run() in a context builder
         return self::$initialContext ?? new Context();
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -50,7 +50,7 @@ function parallel(callable ...$callbacks): array
  * @param (callable(string, string, Process) :void)|null $callback
  * @param array<string, string>|null                     $environment
  */
-function exec(
+function run(
     string|array $command,
     array|null $environment = null,
     string|null $path = null,
@@ -210,7 +210,7 @@ function watch(string $path, callable $function, Context $context = null): void
     $command = [$binaryPath, $path];
     $buffer = '';
 
-    exec($command, callback: static function ($type, $bytes, $process) use ($function, &$buffer) {
+    run($command, callback: static function ($type, $bytes, $process) use ($function, &$buffer) {
         if (Process::OUT === $type) {
             $data = $buffer . $bytes;
             $lines = explode("\n", $data);

--- a/tests/Examples/ContextContextRun.php
+++ b/tests/Examples/ContextContextRun.php
@@ -4,12 +4,12 @@ namespace Castor\Tests\Examples;
 
 use Castor\Tests\TaskTestCase;
 
-class ContextContextExec extends TaskTestCase
+class ContextContextRun extends TaskTestCase
 {
     // context:context
     public function test(): void
     {
-        $process = $this->runTask(['context:context', '--context', 'exec']);
+        $process = $this->runTask(['context:context', '--context', 'run']);
 
         $this->assertSame(0, $process->getExitCode());
         $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());

--- a/tests/Examples/ContextContextRun.php.output.txt
+++ b/tests/Examples/ContextContextRun.php.output.txt
@@ -1,4 +1,4 @@
-context name: exec
+context name: run
 Production? no
 verbosity: 1
 context: no defined

--- a/tests/Examples/ListTest.php.output.txt
+++ b/tests/Examples/ListTest.php.output.txt
@@ -24,7 +24,7 @@ notify:send-notify            Sends a notification
 output:output                 Plays with Symfony Style
 parallel:sleep                Sleeps for 5, 7, and 10 seconds in parallel
 quiet:quiet                   Executes something but does not output anything
-run:run                       Run a sub-process and display information about it
+run:run-ls                    Run a sub-process and display information about it
 run:run-with-process-helper   Run a sub-process and display information about it, with ProcessHelper
 shell:bash                    Runs a bash
 shell:sh                      Runs a sh

--- a/tests/Examples/RunRunLsTest.php
+++ b/tests/Examples/RunRunLsTest.php
@@ -4,12 +4,12 @@ namespace Castor\Tests\Examples;
 
 use Castor\Tests\TaskTestCase;
 
-class RunRunTest extends TaskTestCase
+class RunRunLsTest extends TaskTestCase
 {
-    // run:run
+    // run:run-ls
     public function testRunRun(): void
     {
-        $process = $this->runTask(['run:run']);
+        $process = $this->runTask(['run:run-ls']);
         $this->assertSame(0, $process->getExitCode());
         $this->assertStringContainsString('Output:', $process->getOutput());
         $this->assertStringContainsString('Error output:', $process->getOutput());

--- a/tools/watcher/castor/build.php
+++ b/tools/watcher/castor/build.php
@@ -3,29 +3,29 @@
 use Castor\Attribute\AsTask;
 use Castor\Context;
 
-use function Castor\exec;
 use function Castor\parallel;
+use function Castor\run;
 
 #[AsTask(description: 'Build watcher for Linux system', namespace: 'watcher')]
 function linux(Context $c)
 {
     $c = $c->withPath(__DIR__ . '/..');
-    exec('go build -o bin/watcher-linux -ldflags="-s -w" main.go', environment: ['GOOS' => 'linux', 'CGO_ENABLED' => '0'], context: $c);
-    exec('upx --brute bin/watcher-linux', context: $c);
+    run('go build -o bin/watcher-linux -ldflags="-s -w" main.go', environment: ['GOOS' => 'linux', 'CGO_ENABLED' => '0'], context: $c);
+    run('upx --brute bin/watcher-linux', context: $c);
 }
 
 #[AsTask(description: 'Build watcher for MacOS system', namespace: 'watcher')]
 function darwin(Context $c)
 {
     $c = $c->withPath(__DIR__ . '/..');
-    exec('go build -o bin/watcher-darwin -ldflags="-s -w" main.go', environment: ['GOOS' => 'darwin', 'CGO_ENABLED' => '0'], context: $c);
+    run('go build -o bin/watcher-darwin -ldflags="-s -w" main.go', environment: ['GOOS' => 'darwin', 'CGO_ENABLED' => '0'], context: $c);
 }
 
 #[AsTask(description: 'Build watcher for Windows system', namespace: 'watcher')]
 function windows(Context $c)
 {
     $c = $c->withPath(__DIR__ . '/..');
-    exec('go build -o bin/watcher-windows.exe -ldflags="-s -w" main.go', environment: ['GOOS' => 'windows', 'CGO_ENABLED' => '0'], context: $c);
+    run('go build -o bin/watcher-windows.exe -ldflags="-s -w" main.go', environment: ['GOOS' => 'windows', 'CGO_ENABLED' => '0'], context: $c);
 }
 
 #[AsTask(description: 'Build watcher for all systems', namespace: 'watcher')]


### PR DESCRIPTION
- Rename exec() to run() to avoid confusion with default PHP function
- add a nice help when run() function is not imported
- Extends this system to all castor functions
