### PR TITLE
fixed transcient tests

### DIFF
--- a/tests/Examples/ParallelSleepTest.php
+++ b/tests/Examples/ParallelSleepTest.php
@@ -3,6 +3,7 @@
 namespace Castor\Tests\Examples;
 
 use Castor\Tests\TaskTestCase;
+use PHPUnit\Framework\ExpectationFailedException;
 
 class ParallelSleepTest extends TaskTestCase
 {
@@ -12,11 +13,36 @@ class ParallelSleepTest extends TaskTestCase
         $process = $this->runTask(['parallel:sleep', '--sleep5', '0', '--sleep7', '0', '--sleep10', '0']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
-        if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
-        } else {
-            $this->assertSame('', $process->getErrorOutput());
+
+        $startWith = <<<'OUTPUT'
+            sleep 0
+            sleep 0
+            re sleep 0
+            sleep 0
+            OUTPUT;
+
+        try {
+            $this->assertStringStartsWith($startWith, $process->getOutput());
+        } catch (ExpectationFailedException) {
+            // The order of the fibers might be different. So we try another
+            // order.
+            $startWith = <<<'OUTPUT'
+                sleep 0
+                sleep 0
+                sleep 0
+                re sleep 0
+                OUTPUT;
+            $this->assertStringStartsWith($startWith, $process->getOutput());
         }
+
+        $endWith = <<<'OUTPUT'
+            Foo: foo
+            Bar: bar
+            Sleep 10: sleep 0
+            Duration: 0
+
+            OUTPUT;
+        $this->assertStringEndsWith($endWith, $process->getOutput());
+        $this->assertSame('', $process->getErrorOutput());
     }
 }

--- a/tests/Examples/ParallelSleepTest.php.output.txt
+++ b/tests/Examples/ParallelSleepTest.php.output.txt
@@ -1,8 +1,0 @@
-sleep 0
-sleep 0
-re sleep 0
-sleep 0
-Foo: foo
-Bar: bar
-Sleep 10: sleep 0
-Duration: 0


### PR DESCRIPTION
```
>…egoire/dev/github.com/jolicode/castor(fix-transient-test *+) vendor/bin/simple-phpunit tests/Examples/ParallelSleepTest.php --repeat 1000 --stop-on-failure
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.6
Configuration: /home/gregoire/dev/github.com/jolicode/castor/phpunit.xml

Testing
.............................................................   61 / 1000 (  6%)
.............................................................  122 / 1000 ( 12%)
.............................................................  183 / 1000 ( 18%)
.............................................................  244 / 1000 ( 24%)
.............................................................  305 / 1000 ( 30%)
.............................................................  366 / 1000 ( 36%)
.............................................................  427 / 1000 ( 42%)
.............................................................  488 / 1000 ( 48%)
.............................................................  549 / 1000 ( 54%)
.............................................................  610 / 1000 ( 61%)
.............................................................  671 / 1000 ( 67%)
.............................................................  732 / 1000 ( 73%)
.............................................................  793 / 1000 ( 79%)
.............................................................  854 / 1000 ( 85%)
.............................................................  915 / 1000 ( 91%)
.............................................................  976 / 1000 ( 97%)
........................                                      1000 / 1000 (100%)

Time: 01:33.362, Memory: 4.00 MB

OK (1000 tests, 4018 assertions)
```
