### PR TITLE
Document the minimum php version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         }
     },
     "require": {
+        "php": ">=8.1",
         "jolicode/jolinotif": "^2.5",
         "monolog/monolog": "^3.3",
         "nikic/php-parser": "^4.15",
@@ -43,7 +44,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.1"
+            "php": "8.1.19"
         }
     },
     "require-dev": {


### PR DESCRIPTION
This constraint is already imposed by the symfony dependencies, but it's best to have direct constraints for the features that are used in your code. Best for documentation. 

Also, the `config.platform.php` is best with the latest minor version to prevent any packages incompatibility with 8.1.0.