### PR TITLE
Add support for re-packing a castor application into a new phar file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 * Better error reporting when a call to `run()` fails or when `import()` is not possible
 * Fix stubs generation
 
+* Add support for re-packing a castor application into a new phar file
+
 ## 0.3.0 (2023-06-07)
 
 * Enhance the documentation

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -17,6 +17,11 @@ class ApplicationFactory
             return new CastorFileNotFoundCommand($e);
         }
 
+        if (class_exists(\RepackedApplication::class)) {
+            // @phpstan-ignore-next-line
+            return new \RepackedApplication($rootDir);
+        }
+
         return new Application($rootDir);
     }
 }

--- a/src/Console/Command/RepackCommand.php
+++ b/src/Console/Command/RepackCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Castor\Console\Command;
+
+use Castor\Console\Application;
+use Castor\FunctionFinder;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+class RepackCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('repack')
+            ->addOption('output', null, InputOption::VALUE_REQUIRED, 'The path of the phar file', 'my-app.phar')
+            ->addOption('app-name', null, InputOption::VALUE_REQUIRED, 'The name of the phar application', Application::NAME)
+            ->addOption('app-version', null, InputOption::VALUE_REQUIRED, 'The version of the phar application', Application::VERSION)
+            ->setHidden(true)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $pharOutput = $input->getOption('output');
+
+        if (str_starts_with(__FILE__, 'phar:')) {
+            copy(\Phar::running(false), $pharOutput);
+        } elseif (file_exists($f = __DIR__ . '/../../../tools/phar/build/castor.linux-amd64.phar')) {
+            copy($f, $pharOutput);
+        } else {
+            throw new \RuntimeException('You must run this command from a phar or from a dev environment with the phar built.');
+        }
+
+        $phar = new \Phar($pharOutput);
+        foreach (FunctionFinder::$files as $file) {
+            $phar->addFile($file, $file);
+        }
+
+        $filesAsStrings = var_export(FunctionFinder::$files, true);
+        $appName = $input->getOption('app-name');
+        $appVersion = $input->getOption('app-version');
+        $entryPoint = str_replace(
+            $tail = 'ApplicationFactory::create()->run();',
+            <<<PHP
+            class RepackedApplication extends Castor\\Console\\Application
+            {
+                const NAME = '{$appName}';
+                const VERSION = '{$appVersion}';
+
+                public static array \$files = {$filesAsStrings};
+            }
+
+            {$tail};
+            PHP,
+            $phar['bin/castor']->getContent()
+        );
+        $phar->addFromString('bin/castor', $entryPoint);
+
+        chmod($pharOutput, 0o755);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/FunctionFinder.php
+++ b/src/FunctionFinder.php
@@ -5,19 +5,17 @@ namespace Castor;
 use Castor\Attribute\AsContext;
 use Castor\Attribute\AsTask;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 
 /** @internal */
 class FunctionFinder
 {
-    private static bool $inFindFunctions = false;
+    /** @var array<string> */
+    public static array $files = [];
 
     /** @return iterable<TaskDescriptor|ContextDescriptor> */
-    public static function findFunctions(string $path): iterable
+    public function findFunctions(string $path): iterable
     {
-        self::$inFindFunctions = true;
-
-        yield from self::doFindFunctions([new SplFileInfo($path . '/castor.php', 'castor.php', 'castor')]);
+        yield from self::doFindFunctions([new \SplFileInfo($path . '/castor.php')]);
 
         $castorDirectory = $path . '/castor';
 
@@ -30,23 +28,16 @@ class FunctionFinder
 
             yield from self::doFindFunctions($files);
         }
-
-        self::$inFindFunctions = false;
-    }
-
-    public static function isInFindFunctions(): bool
-    {
-        return self::$inFindFunctions;
     }
 
     /**
-     * @param iterable<SplFileInfo> $files
+     * @param iterable<\SplFileInfo> $files
      *
      * @return iterable<TaskDescriptor|ContextDescriptor>
      *
      * @throws \ReflectionException
      */
-    private static function doFindFunctions(iterable $files): iterable
+    public function doFindFunctions(iterable $files): iterable
     {
         $existingFunctions = get_defined_functions()['user'];
 
@@ -109,5 +100,7 @@ class FunctionFinder
 /** @internal */
 function castor_require(string $file): void
 {
+    FunctionFinder::$files[] = $file;
+
     require_once $file;
 }

--- a/src/PathHelper.php
+++ b/src/PathHelper.php
@@ -15,7 +15,13 @@ class PathHelper
 
             while (!file_exists($path . '/castor.php')) {
                 if ('/' === $path) {
-                    throw new \RuntimeException('Could not find root "castor.php" file.');
+                    if (!class_exists(\RepackedApplication::class)) {
+                        throw new \RuntimeException('Could not find root "castor.php" file.');
+                    }
+
+                    $path = (getcwd() ?: '.');
+
+                    break;
                 }
 
                 $path = Path::getDirectory($path);

--- a/src/functions.php
+++ b/src/functions.php
@@ -443,10 +443,6 @@ function get_cache(): CacheItemPoolInterface&CacheInterface
 
 function import(string $path): void
 {
-    if (!FunctionFinder::isInFindFunctions()) {
-        throw fix_exception(new \LogicException('The import function cannot be dynamically invoked, use it a the root of the PHP file.'));
-    }
-
     if (!file_exists($path)) {
         throw fix_exception(new \InvalidArgumentException(sprintf('The file "%s" does not exist.', $path)));
     }


### PR DESCRIPTION
ping @jacquesbh

There are custom commands in an application:

```
>/tmp/foobar/castor castor
castor v0.3.0

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  and-another-one  
  another-task     Another Task
  completion       Dump the shell completion script
  hello            Welcome to Castor!
  help             Display help for a command
  list             List commands
```
We repack the application
```
>/tmp/foobar/castor castor repack
```
We go to another directory to ensure we don't load `castor.php` files
```
>/tmp/foobar/castor cd ../
>/tmp/foobar php castor/my-app.phar 
castor v0.3.0

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  and-another-one  
  another-task     Another Task
  completion       Dump the shell completion script
  hello            Welcome to Castor!
  help             Display help for a command
  list             List commands

```