### PR TITLE
Replace specials helpers arguments by dedicated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 0.4.0 (not released yet)
 
+* [BC Break] replace specials helpers arguments by dedicated functions
 * Add `capture()` function to easily run a process and returns the output
 * Display warning and update instructions when a new version is available
-* Better error reporting when a call to run() fail or when import() is not possible
+* Better error reporting when a call to `run()` fails or when `import()` is not possible
 * Fix stubs generation
 
 ## 0.3.0 (2023-06-07)
@@ -14,11 +15,11 @@
 
 ## 0.2.0 (2023-06-02)
 
-* Add a way to get the command instance in a task
+* Add a way to get the `Command` instance in a task
 * Add support for better handling of option without value
 * Fix the stubs generation when castor is installed via composer
-* Fix the initial castor.php file generated for new projects
-* Fix watch() function
+* Fix the initial `castor.php` file generated for new projects
+* Fix `watch()` function
 
 ## 0.1.0 (2023-05-21)
 

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Then, you can go wild and create more complex commands:
 
 ```php
 #[AsTask(description: 'Clean the infrastructure (remove container, volume, networks)')]
-function destroy(SymfonyStyle $io, bool $force = false)
+function destroy(bool $force = false)
 {
     if (!$force) {
-        $io->warning('This will permanently remove all containers, volumes, networks... created for this project.');
-        $io->comment('You can use the --force option to avoid this confirmation.');
+        io()->warning('This will permanently remove all containers, volumes, networks... created for this project.');
+        io()->comment('You can use the --force option to avoid this confirmation.');
 
-        if (!$io->confirm('Are you sure?', false)) {
-            $io->comment('Aborted.');
+        if (!io()->confirm('Are you sure?', false)) {
+            io()->comment('Aborted.');
 
             return;
         }

--- a/bin/castor
+++ b/bin/castor
@@ -11,4 +11,4 @@ if (file_exists($file = __DIR__ . '/../vendor/autoload.php')) {
     throw new \RuntimeException('Unable to find autoloader.');
 }
 
-ApplicationFactory::run();
+ApplicationFactory::create()->run();

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -5,14 +5,13 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Castor\Console\ApplicationFactory;
 use Castor\Tests\OutputCleaner;
-use Psr\Log\NullLogger;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Process\Process;
 
 use function Symfony\Component\String\u;
 
-$application = ApplicationFactory::create(new NullLogger());
+$application = ApplicationFactory::create();
 $application->setAutoExit(false);
 $application
     ->run(new ArrayInput(['command' => 'list', '--format' => 'json']), $o = new BufferedOutput())

--- a/doc/01-installation.md
+++ b/doc/01-installation.md
@@ -111,7 +111,7 @@ definition of classes and methods from Castor and some of its dependencies.
 
 This is useful when you install Castor from a PHAR, from a global composer
 install, etc. Without it, your IDE would complain that it does not understand some
-classes and would not provide any autocompletion in your castor files. 
+classes and would not provide any autocompletion in your castor files.
 
 We suggest you to add this file to your `.gitignore` to not version it in git.
 Castor will automatically update this file the first time you run Castor after

--- a/doc/02-basic-usage.md
+++ b/doc/02-basic-usage.md
@@ -36,6 +36,8 @@ function bar(): void
 You will have two commands: `hello:castor` and `foo:bar`. If there is no
 namespace then the command will have no namespace.
 
+From now on, we will omit the leading `<?php` in all doc examples.
+
 ## Splitting commands in multiple files
 
 ### Using a directory
@@ -54,7 +56,6 @@ This function takes a file path, or a directory as an argument.
 When using a directory as an argument, Castor will load all the PHP files in it:
 
 ```php
-
 use function Castor\import;
 
 import(__DIR__ . '/custom-commands.php');

--- a/doc/03-run.md
+++ b/doc/03-run.md
@@ -4,9 +4,8 @@ Castor provides a `Castor\run()` function to run commands. It allows to run a
 process:
 
 ```php
-<?php
-
 use Castor\Attribute\AsTask;
+
 use function Castor\run;
 
 #[AsTask]
@@ -28,6 +27,10 @@ object to run the command. The `run()` function will return this object. So
 you can use the API of this class to interact with the process:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function foo(): void
 {
@@ -42,6 +45,10 @@ By default, Castor will throw an exception if the command fails. You can disable
 that by setting the `allowFailure` option to `true`:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function foo(): void
 {
@@ -56,6 +63,10 @@ the `castor.php` file. You can change that by setting the `path` argument. It
 can be either a relative or an absolute path:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function foo(): void
 {
@@ -71,6 +82,10 @@ process. You can add or override environment variables by setting
 the `environment` argument:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function foo(): void
 {
@@ -85,6 +100,10 @@ If you do not want to print the output of the command you can set the `quiet`
 option to `true`:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function foo(): void
 {
@@ -96,6 +115,10 @@ You can also fetch the output of the command by using the API of
 the `Symfony\Component\Process\Process` object:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function foo(): void
 {
@@ -108,6 +131,10 @@ Castor also provides a `capture()` function that will run the command quietly,
 trims the output, then returns it:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\capture;
+
 #[AsTask()]
 function whoami()
 {
@@ -125,6 +152,10 @@ For some commands you may want to disable the PTY and use a TTY instead. You can
 do that by setting the `tty` option to `true`:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function foo(): void
 {
@@ -141,6 +172,9 @@ and `tty` are both set to `false`, the standard input will not be forwarded to
 the command:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
 
 #[AsTask]
 function foo(): void

--- a/doc/04-arguments.md
+++ b/doc/04-arguments.md
@@ -4,6 +4,10 @@ When creating a function that will be used as a command, all the parameters of
 the function will be used as arguments or options of the command:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function command(
     string $firstArg,
@@ -25,6 +29,10 @@ foo bar
 You can make an argument optional by giving it a default value:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function command(
     string $firstArg,
@@ -47,6 +55,11 @@ You can override the name and description of an argument by using
 the `Castor\Attribute\AsArgument` attribute:
 
 ```php
+use Castor\Attribute\AsArgument;
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function command(
     #[AsArgument(name: 'foo', description: 'This is the foo argument')]
@@ -67,6 +80,11 @@ If you prefer, you can force an argument to be an option by using the
 `Castor\Attribute\AsOption` attribute:
 
 ```php
+use Castor\Attribute\AsOption;
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function command(
     #[AsOption(name: 'foo', description: 'This is the foo option')]
@@ -85,6 +103,11 @@ You can also configure the `mode` of the option. The `mode` determines how the
 option must be configured:
 
 ```php
+use Castor\Attribute\AsOption;
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function command(
     #[AsOption(description: 'This is the foo option', mode: InputOption::VALUE_NONE)]

--- a/doc/05-context.md
+++ b/doc/05-context.md
@@ -12,18 +12,46 @@ context is created.
 
 ## Using the context
 
-The context is passed to the function if it has an argument type-hinted
-with `Castor\Context`:
+You can get the initial context thanks to the `get_context()` function:
 
 ```php
-use Castor\Context;
+use Castor\Attribute\AsTask;
+
+use function Castor\get_context;
+use function Castor\run;
 
 #[AsTask]
-function foo(Context $context): void
+function foo(): void
 {
+    $context = get_context();
+
     echo $context->currentDirectory; // will print the directory of the castor.php file
-    $context = $context->withPath('/tmp'); // will create a new context with the current directory set to /tmp
-    run('pwd', context: $context); // will print /tmp
+
+    $context = $context->withPath('/tmp'); // will create a new context where the current directory is /tmp
+    run('pwd', context: $context); // will print "/tmp"
+}
+```
+
+There is a `variable()` function to get a value stored in the `Context`:
+
+```php
+use Castor\Attribute\AsTask;
+
+use function Castor\get_context;
+use function Castor\variable;
+
+#[AsTask]
+function foo(): void
+{
+    $foobar = variable('foobar', 'default value');
+
+    // Same as:
+    $context = get_context();
+    try {
+        $foobar = $context['foobar'];
+    } catch (\OutOfBoundsException) {
+        $foobar = 'default value;
+    }
 }
 ```
 
@@ -35,6 +63,8 @@ the `Castor\Attribute\AsContext` attribute:
 ```php
 use Castor\Attribute\AsContext;
 use Castor\Context;
+
+use function Castor\run;
 
 #[AsContext]
 function my_context(): Context
@@ -72,6 +102,8 @@ setting the `default` argument to `true` in the `AsContext` attribute:
 ```php
 use Castor\Attribute\AsContext;
 use Castor\Context;
+
+use function Castor\run;
 
 #[AsContext(default: true, name: 'my_context')]
 function create_default_context(): Context

--- a/doc/06-helper.md
+++ b/doc/06-helper.md
@@ -1,40 +1,48 @@
 # Helpers
 
-Some helpers are built-in with Castor.
+Some helpers are built-in with Castor. They allow you to:
+
+* play with input / output
+* interact with the filesystem
+* search for files in a directory hierarchy
+* retrieve console related objects
+* and more
 
 ## SymfonyStyle
 
-The `Symfony\Component\Console\Style\SymfonyStyle` class provides methods to
-interact with the user and to display information. You can retrieve this class
-by type hinting it in your function:
+The `io()` returns an object that provides methods to interact with the user and
+to display information. It returns an instance of
+`Symfony\Component\Console\Style\SymfonyStyle`:
 
 ```php
-use Symfony\Component\Console\Style\SymfonyStyle;
+use Castor\Attribute\AsTask;
+
+use function Castor\io;
 
 #[AsTask]
-function foo(SymfonyStyle $io): void
+function foo(): void
 {
-    $io->title('This is a title');
+    io()->title('This is a title');
 
-    $io->comment('With IO, you can ask questions ...');
-    $value = $io->ask('Tell me something');
-    $io->writeln('You said: ' . $value);
+    io()->comment('With IO, you can ask questions ...');
+    $value = io()->ask('Tell me something');
+    io()->writeln('You said: ' . $value);
 
-    $io->comment('... show progress bars ...');
-    $io->progressStart(100);
+    io()->comment('... show progress bars ...');
+    io()->progressStart(100);
     for ($i = 0; $i < 100; ++$i) {
-        $io->progressAdvance();
+        io()->progressAdvance();
         usleep(1000);
     }
-    $io->progressFinish();
+    io()->progressFinish();
 
-    $io->comment('... show table ...');
-    $io->table(['Name', 'Age'], [
+    io()->comment('... show table ...');
+    io()->table(['Name', 'Age'], [
         ['Alice', 21],
         ['Bob', 42],
     ]);
 
-    $io->success('This is a success message');
+    io()->success('This is a success message');
 }
 ```
 
@@ -42,32 +50,35 @@ You can check
 the [Symfony documentation](https://symfony.com/doc/current/console/style.html)
 for more information about this class and how to use it.
 
-# Filesystem
+## Filesystem
 
-The `Symfony\Component\Filesystem\Filesystem` class provides OS-independent
-utilities for filesystem operations and for file/directory paths manipulation.
+The `fs()` function returns an object that provides OS-independent utilities for
+filesystem operations and for file/directory paths manipulation. It returns an
+instance of `Symfony\Component\Filesystem\Filesystem`.
 
-You can retrieve an instance of this class by using the `fs()` function.
 You can also use static methods of the class
-`Symfony\Component\Filesystem\Path`.
+`Symfony\Component\Filesystem\Path`:
 
 ```php
+use Castor\Attribute\AsTask;
+use Symfony\Component\Filesystem\Path;
+
+use function Castor\fs;
+
 #[AsTask]
 function foo()
 {
-    $fs = fs();
-
     $dir = '/tmp/foo';
 
-    echo $dir, ' directory exist: ', $fs->exists($dir) ? 'yes' : 'no', \PHP_EOL;
+    echo $dir, ' directory exist: ', fs()->exists($dir) ? 'yes' : 'no', \PHP_EOL;
 
-    $fs->mkdir($dir);
-    $fs->touch($dir . '/bar.md');
+    fs()->mkdir($dir);
+    fs()->touch($dir . '/bar.md');
 
     echo $dir, ' is an absolute path: ', Path::isAbsolute($dir) ? 'yes' : 'no', \PHP_EOL;
     echo '../ is an absolute path: ', Path::isAbsolute('../') ? 'yes' : 'no', \PHP_EOL;
 
-    $fs->remove($dir);
+    fs()->remove($dir);
 
     echo 'Absolute path: ', Path::makeAbsolute('../', $dir), \PHP_EOL;
 }
@@ -77,24 +88,47 @@ You can check
 the [Symfony documentation](https://symfony.com/doc/current/components/filesystem.html)
 for more information about this component and how to use it.
 
-# Finder
+## Finder
 
-The `Symfony\Component\Finder\Finder` class finds files and directories based
+The `finder()` function returns an object that finds files and directories based
 on different criteria (name, file size, modification time, etc.) via an
-intuitive fluent interface.
-
-You can retrieve an instance of this class by using the `finder()` function:
+intuitive fluent interface. It returns an instance of
+`Symfony\Component\Finder\Finder`:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\finder;
+
 #[AsTask]
 function foo()
 {
-    $finder = finder();
-
-    echo 'Number of PHP files: ', $finder->name('*.php')->in(__DIR__)->count(), \PHP_EOL;
+    echo 'Number of PHP files: ', finder()->name('*.php')->in(__DIR__)->count(), \PHP_EOL;
 }
 ```
 
 You can check
 the [Symfony documentation](https://symfony.com/doc/current/components/finder.html)
 for more information about this class and how to use it.
+
+## Console related helpers
+
+There are some low level helpers to access internal stuff:
+
+* `get_application()` returns the current
+  [`Application`](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Console/Application.php)
+* `get_command()` returns the running command
+  [`Command`](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Console/Command/Command.php)
+* `get_input()` returns the current
+  [`Input`](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Console/Output/OutputInterface.php)
+* `get_output()` returns the current
+  [`Output`](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Console/Input/InputInterface.php)
+
+## Other helpers
+
+* `get_context()` returns the initial `Context`. See the [context
+  documentation](./05-context.md) for mor information
+* `variable()` returns a variable stored in the  `Context`. See the [context
+  documentation](./05-context.md) for mor information
+* `get_loger()` returns the current `Logger`. See the [logger
+  documentation](./10-log.md) for more information

--- a/doc/07-watch.md
+++ b/doc/07-watch.md
@@ -4,6 +4,10 @@ Castor provides a `watch()` function that will watch a file or a directory and
 call a callback function when the file or directory changes:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\watch;
+
 #[AsTask]
 function watch(): void
 {
@@ -22,6 +26,10 @@ By default the `watch()` function will not watch subdirectories. You can change
 that by passing a path suffixed by `/...`:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\watch;
+
 #[AsTask]
 function watch(): void
 {
@@ -38,6 +46,10 @@ The `watch()` function will look at the return value of the callback function. I
 the callback function returns `false` the watch will stop:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\watch;
+
 #[AsTask]
 function watch(): void
 {

--- a/doc/08-parallel.md
+++ b/doc/08-parallel.md
@@ -4,6 +4,10 @@ The `parallel()` function provides a way to run functions in parallel,
 so you do not have to wait for a function to finish before starting another one:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\parallel;
+
 #[AsTask]
 function foo(): void
 {
@@ -34,6 +38,10 @@ run the functions in parallel.
 You can also watch in parallel multiple directories:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\parallel;
+
 #[AsTask]
 function parallel_change()
 {

--- a/doc/09-notify.md
+++ b/doc/09-notify.md
@@ -5,6 +5,10 @@ display notifications.
 You can use the `notify()` function to display a desktop notification:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\notify;
+
 #[AsTask]
 function notify()
 {
@@ -12,12 +16,16 @@ function notify()
 }
 ```
 
-## Notify on run
+## Notify with `run()`
 
 You can use the `notify` argument of the `run()` function to display a
 notification when a command has been executed:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+
 #[AsTask]
 function notify()
 {

--- a/doc/10-log.md
+++ b/doc/10-log.md
@@ -22,6 +22,10 @@ you need more information, you can re-run the command with the `-v` option.
 You can use the `log()` function to log a message:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\log;
+
 #[AsTask]
 function log()
 {
@@ -32,6 +36,10 @@ function log()
 You can also attach a context to the log message:
 
 ```php
+use Castor\Attribute\AsTask;
+
+use function Castor\log;
+
 #[AsTask]
 function log()
 {
@@ -49,3 +57,25 @@ use the `OutputInterface`. Here is a small guide:
 * Don't use `echo`, it's not a good practice;
 * Use the `OutputInterface` when you want to display something to the user;
 * Use the `log()` function when you want to add some **debug** information.
+
+## Accessing the raw logger
+
+If you need to access the raw logger instance, you can get it with the
+`get_logger()` function:
+
+```php
+use Castor\Attribute\AsContext;
+use Castor\Context;
+use Castor\PathHelper;
+use Monolog\Handler\StreamHandler;
+
+use function Castor\get_logger;
+
+#[AsContext(name: 'preprod')]
+function preprodContext(): Context
+{
+    get_logger()->pushHandler(new StreamHandler(PathHelper::getRoot() . '/preprod.log'));
+
+    //return new Context(...);
+}
+```

--- a/examples/context.php
+++ b/examples/context.php
@@ -5,9 +5,11 @@ namespace context;
 use Castor\Attribute\AsContext;
 use Castor\Attribute\AsTask;
 use Castor\Context;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
+use function Castor\get_context;
+use function Castor\io;
 use function Castor\run;
+use function Castor\variable;
 
 #[AsContext(default: true, name: 'my_default')]
 function defaultContext(): Context
@@ -44,10 +46,10 @@ function runContext(): Context
 }
 
 #[AsContext(name: 'interactive')]
-function interactiveContext(SymfonyStyle $io): Context
+function interactiveContext(): Context
 {
-    $production = $io->confirm('Are you in production?', 'no');
-    $foo = $io->ask('What is the "foo" value?', null);
+    $production = io()->confirm('Are you in production?', 'no');
+    $foo = io()->ask('What is the "foo" value?', null);
 
     return new Context([
         'name' => 'interactive',
@@ -57,10 +59,11 @@ function interactiveContext(SymfonyStyle $io): Context
 }
 
 #[AsTask(description: 'Displays information about the context')]
-function context(Context $context)
+function context()
 {
-    echo 'context name: ' . ($context->offsetExists('name') ? $context['name'] : 'N/A') . "\n";
-    echo 'Production? ' . ($context->offsetExists('production') && $context['production'] ? 'yes' : 'no') . "\n";
+    $context = get_context();
+    echo 'context name: ' . variable('name', 'N/A') . "\n";
+    echo 'Production? ' . (variable('production', false) ? 'yes' : 'no') . "\n";
     echo "verbosity: {$context->verbosityLevel->value}\n";
-    echo 'context: ' . ($context->offsetExists('foo') ? $context['foo'] : 'N/A') . "\n";
+    echo 'context: ' . variable('foo', 'N/A') . "\n";
 }

--- a/examples/log.php
+++ b/examples/log.php
@@ -3,15 +3,15 @@
 namespace log;
 
 use Castor\Attribute\AsTask;
-use Symfony\Component\Console\Output\OutputInterface;
 
+use function Castor\get_output;
 use function Castor\log;
 
 #[AsTask(description: 'Logs an "info" message')]
-function info(OutputInterface $output): void
+function info(): void
 {
-    if (!$output->isVeryVerbose()) {
-        $output->writeln('Re-run with -vv, -vvv to different output.');
+    if (!get_output()->isVeryVerbose()) {
+        get_output()->writeln('Re-run with -vv, -vvv to different output.');
     }
 
     log('Hello, this is an "info" log message.', 'info');
@@ -24,10 +24,10 @@ function error(): void
 }
 
 #[AsTask(description: 'Logs an "error" message')]
-function with_context(OutputInterface $output): void
+function with_context(): void
 {
-    if (!$output->isVerbose()) {
-        $output->writeln('Re-run with -v, -vv, -vvv to different output.');
+    if (!get_output()->isVerbose()) {
+        get_output()->writeln('Re-run with -v, -vv, -vvv to different output.');
     }
 
     log('Hello, I\'have a context!', 'error', context: [
@@ -36,10 +36,10 @@ function with_context(OutputInterface $output): void
 }
 
 #[AsTask(description: 'Logs some messages with different levels')]
-function all_level(OutputInterface $output): void
+function all_level(): void
 {
-    if (!$output->isVerbose()) {
-        $output->writeln('Re-run with -v, -vv, -vvv to different output.');
+    if (!get_output()->isVerbose()) {
+        get_output()->writeln('Re-run with -v, -vv, -vvv to different output.');
     }
 
     $levels = [

--- a/examples/output.php
+++ b/examples/output.php
@@ -3,33 +3,34 @@
 namespace output;
 
 use Castor\Attribute\AsTask;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function Castor\get_command;
+use function Castor\io;
 
 #[AsTask(description: 'Plays with Symfony Style')]
-function output(SymfonyStyle $io, Command $command)
+function output()
 {
-    $io->title('This is a title');
+    io()->title('This is a title');
 
-    $io->text(sprintf('This is the command "%s"', $command->getName()));
+    io()->text(sprintf('This is the command "%s"', get_command()->getName()));
 
-    $io->comment('With IO, you can ask questions ...');
-    $value = $io->ask('Tell me something');
-    $io->writeln('You said: ' . $value);
+    io()->comment('With IO, you can ask questions ...');
+    $value = io()->ask('Tell me something');
+    io()->writeln('You said: ' . $value);
 
-    $io->comment('... show progress bars ...');
-    $io->progressStart(100);
+    io()->comment('... show progress bars ...');
+    io()->progressStart(100);
     for ($i = 0; $i < 100; ++$i) {
-        $io->progressAdvance();
+        io()->progressAdvance();
         usleep(20_000);
     }
-    $io->progressFinish();
+    io()->progressFinish();
 
-    $io->comment('... show table ...');
-    $io->table(['Name', 'Age'], [
+    io()->comment('... show table ...');
+    io()->table(['Name', 'Age'], [
         ['Alice', 21],
         ['Bob', 42],
     ]);
 
-    $io->success('This is a success message');
+    io()->success('This is a success message');
 }

--- a/examples/run.php
+++ b/examples/run.php
@@ -3,10 +3,10 @@
 namespace run;
 
 use Castor\Attribute\AsTask;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Output\OutputInterface;
 
 use function Castor\capture;
+use function Castor\get_application;
+use function Castor\get_output;
 use function Castor\run;
 
 #[AsTask(description: 'Run a sub-process and display information about it')]
@@ -31,12 +31,12 @@ function whoami()
 }
 
 #[AsTask(description: 'Run a sub-process and display information about it, with ProcessHelper')]
-function with_process_helper(Application $application, OutputInterface $output)
+function with_process_helper()
 {
-    if (!$output->isVeryVerbose()) {
-        $output->writeln('Re-run with -vv, -vvv to see the output of the process.');
+    if (!get_output()->isVeryVerbose()) {
+        get_output()->writeln('Re-run with -vv, -vvv to see the output of the process.');
     }
     /** @var ProcessHelper */
-    $helper = $application->getHelperSet()->get('process');
-    $helper->run($output, ['ls', '-alh']);
+    $helper = get_application()->getHelperSet()->get('process');
+    $helper->run(get_output(), ['ls', '-alh']);
 }

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -3,40 +3,19 @@
 namespace Castor\Console;
 
 use Castor\Console\Command\CastorFileNotFoundCommand;
-use Castor\GlobalHelper;
 use Castor\PathHelper;
-use Monolog\Logger;
-use Psr\Log\LoggerInterface;
-use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\SingleCommandApplication;
 
 /** @internal */
 class ApplicationFactory
 {
-    public static function run(): void
-    {
-        $input = new ArgvInput();
-        $output = new ConsoleOutput();
-
-        $logger = new Logger('castor', [
-            new ConsoleHandler($output),
-        ]);
-
-        $application = self::create($logger);
-        $application->run($input, $output);
-    }
-
-    public static function create(LoggerInterface $logger): Application|SingleCommandApplication
+    public static function create(): Application|SingleCommandApplication
     {
         try {
             $rootDir = PathHelper::getRoot();
         } catch (\RuntimeException $e) {
             return new CastorFileNotFoundCommand($e);
         }
-
-        GlobalHelper::setLogger($logger);
 
         return new Application($rootDir);
     }

--- a/src/Context.php
+++ b/src/Context.php
@@ -195,7 +195,7 @@ class Context implements \ArrayAccess
     public function offsetGet(mixed $offset): mixed
     {
         if (!\array_key_exists($offset, $this->data)) {
-            throw new \RuntimeException(sprintf('The property "%s" does not exist in the current context.', $offset));
+            throw new \OutOfBoundsException(sprintf('The property "%s" does not exist in the current context.', $offset));
         }
 
         return $this->data[$offset];

--- a/src/GlobalHelper.php
+++ b/src/GlobalHelper.php
@@ -2,12 +2,74 @@
 
 namespace Castor;
 
-use Psr\Log\LoggerInterface;
+use Castor\Console\Application;
+use Monolog\Logger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
 
 class GlobalHelper
 {
+    private static Application $application;
+    private static InputInterface $input;
+    private static OutputInterface $output;
+    private static SymfonyStyle $symfonyStyle;
+    private static Logger $logger;
+    private static Command $command;
     private static Context $initialContext;
-    private static LoggerInterface $logger;
+    private static Filesystem $fs;
+
+    public static function setApplication(Application $application): void
+    {
+        self::$application = $application;
+    }
+
+    public static function getApplication(): Application
+    {
+        return self::$application ?? throw new \LogicException('Application not set yet.');
+    }
+
+    public static function setInput(InputInterface $input): void
+    {
+        self::$input = $input;
+    }
+
+    public static function getInput(): InputInterface
+    {
+        return self::$input ?? throw new \LogicException('Input not set yet.');
+    }
+
+    public static function setOutput(OutputInterface $output): void
+    {
+        self::$output = $output;
+    }
+
+    public static function getOutput(): OutputInterface
+    {
+        return self::$output ?? throw new \LogicException('Output not set yet.');
+    }
+
+    public static function getSymfonyStyle(): SymfonyStyle
+    {
+        return self::$symfonyStyle ??= new SymfonyStyle(self::getInput(), self::getOutput());
+    }
+
+    public static function setLogger(Logger $logger): void
+    {
+        self::$logger = $logger;
+    }
+
+    public static function getLogger(): Logger
+    {
+        return self::$logger ?? throw new \LogicException('Logger not set yet.');
+    }
+
+    public static function setCommand(Command $command): void
+    {
+        self::$command = $command;
+    }
 
     public static function setInitialContext(Context $initialContext): void
     {
@@ -20,13 +82,24 @@ class GlobalHelper
         return self::$initialContext ?? new Context();
     }
 
-    public static function setLogger(LoggerInterface $logger): void
+    public static function getVariable(string $key, mixed $defaultValue = null): mixed
     {
-        self::$logger = $logger;
+        $initialContext = self::getInitialContext();
+
+        if (!isset($initialContext[$key])) {
+            return $defaultValue;
+        }
+
+        return $initialContext[$key];
     }
 
-    public static function getLogger(): LoggerInterface
+    public static function getCommand(): Command
     {
-        return self::$logger ?? throw new \LogicException('Logger not set yet.');
+        return self::$command ?? throw new \LogicException('Command not set yet.');
+    }
+
+    public static function getFilesystem(): Filesystem
+    {
+        return self::$fs ??= new Filesystem();
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,9 +2,17 @@
 
 namespace Castor;
 
+use Castor\Console\Application;
 use Joli\JoliNotif\Notification;
 use Joli\JoliNotif\NotifierFactory;
 use Joli\JoliNotif\Util\OsHelper;
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\ProcessFailedException;
@@ -266,19 +274,57 @@ function watch(string $path, callable $function, Context $context = null): void
 
 /**
  * @param array<string, mixed> $context
+ *
+ * @phpstan-param Level|LogLevel::* $level
  */
-function log(string $message, string $level = 'info', array $context = []): void
+function log(string|\Stringable $message, mixed $level = 'info', array $context = []): void
 {
     GlobalHelper::getLogger()->log($level, $message, $context);
 }
 
+function get_application(): Application
+{
+    return GlobalHelper::getApplication();
+}
+
+function get_input(): InputInterface
+{
+    return GlobalHelper::getInput();
+}
+
+function get_output(): OutputInterface
+{
+    return GlobalHelper::getOutput();
+}
+
+function io(): SymfonyStyle
+{
+    return GlobalHelper::getSymfonyStyle();
+}
+
+function get_logger(): Logger
+{
+    return GlobalHelper::getLogger();
+}
+
+function get_context(): Context
+{
+    return GlobalHelper::getInitialContext();
+}
+
+function variable(string $key, mixed $defaultValue = null): mixed
+{
+    return GlobalHelper::getVariable($key, $defaultValue);
+}
+
+function get_command(): Command
+{
+    return GlobalHelper::getCommand();
+}
+
 function fs(): Filesystem
 {
-    static $filesystem;
-
-    $filesystem ??= new Filesystem();
-
-    return $filesystem;
+    return GlobalHelper::getFilesystem();
 }
 
 function finder(): Finder


### PR DESCRIPTION
fixes https://github.com/jolicode/castor/pull/108

TODO:

* [x] Update code
* [x] update example / tests
* [x] Update doc

---

**Important**

* this is **not possible** to name a function `var()` (reserved keyword)
* it's a bad idea to name function application, command, context, because it will conflict with associated types!