### PR TITLE
Fix curl download in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ files. Download the correct one and make it available in your shell:
 
 Example for Linux:
 ```bash
-curl "https://github.com/jolicode/castor/releases/latest/download/castor.linux-amd64.phar" --output $HOME/.local/bin/castor && chmod u+x $HOME/.local/bin/castor
+curl "https://github.com/jolicode/castor/releases/latest/download/castor.linux-amd64.phar" -Lso $HOME/.local/bin/castor && chmod u+x $HOME/.local/bin/castor
 ```
 
 There are other ways to install Castor, please refer to the

--- a/doc/01-installation.md
+++ b/doc/01-installation.md
@@ -19,7 +19,7 @@ files. Download the correct one and make it available in your shell:
 
 Example for Linux:
 ```bash
-curl "https://github.com/jolicode/castor/releases/latest/download/castor.linux-amd64.phar" --output $HOME/.local/bin/castor && chmod u+x $HOME/.local/bin/castor
+curl "https://github.com/jolicode/castor/releases/latest/download/castor.linux-amd64.phar" -Lso $HOME/.local/bin/castor && chmod u+x $HOME/.local/bin/castor
 ```
 
 ### Globally with Composer


### PR DESCRIPTION
The link to `latest` trigger an HTTP redirection to the latest release, so curl must follow redirects to download the phar.