### PR TITLE
feat(watcher): Support multiple paths to watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for registering `Context` programmatically
 * Add `load_dot_env()` function for loading the context's environment from a dotenv file
+* Add support for multiple paths in `watch()` function
 
 ## 0.5.2 (2023-06-24)
 

--- a/doc/07-watch.md
+++ b/doc/07-watch.md
@@ -61,3 +61,22 @@ function watch(): void
     echo 'stopped watching'; // will print "stopped watching" once a file has been modified in the src folder
 }
 ```
+
+## Watching multiple paths
+
+The `watch()` function can watch multiple paths at the same time:
+
+```php
+use Castor\Attribute\AsTask;
+
+use function Castor\watch;
+
+#[AsTask]
+function watch(): void
+{
+    // watch recursively inside the src and tests folders
+    watch(['src/...', 'tests/...'], function (string $file, string $action) {
+        echo "File {$file} has been {$action}\n";
+    });
+}
+```


### PR DESCRIPTION
~For supporting multiple path, I took my inspiration from the environment variable `PATH`: `/path/to/foo:/path/to/bar`.
It keeps the only one argument for the watcher's CLI and should be proof to path enumeration.~

Fix #137 