### PR TITLE
fix(update-command-message): follow redirects with curl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add support for re-packing a castor application into a new phar file
+* Fix the update command message to follow redirects with curl
 
 ## 0.6.0 (2023-06-30)
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -206,7 +206,7 @@ class Application extends SymfonyApplication
 
             if (OsHelper::isUnix()) {
                 $symfonyStyle->block('Run the following command to update Castor:');
-                $symfonyStyle->block(sprintf('<comment>curl "%s" --output castor && chmod u+x castor && mv castor %s</comment>', $latestReleaseUrl, $pharPath), escape: false);
+                $symfonyStyle->block(sprintf('<comment>curl "%s" -Lso castor && chmod u+x castor && mv castor %s</comment>', $latestReleaseUrl, $pharPath), escape: false);
             } else {
                 $symfonyStyle->block(sprintf('Download the latest version at <comment>%s</comment>', $latestReleaseUrl), escape: false);
             }


### PR DESCRIPTION
In the documentation, we are using the curl flags `Lso` both in the [README](https://github.com/jolicode/castor/blob/d2e2f351d3a5c3e39dca77b5cbd2764a172a2304/README.md?plain=1#L104) and in the [01-installation.md](https://github.com/jolicode/castor/blob/d2e2f351d3a5c3e39dca77b5cbd2764a172a2304/doc/01-installation.md?plain=1#L22).

But in the update command message, the `-L` flag is missing. It results in an empty file if we copy/paste the suggested update command.

So, this PR adds this flag.