### PR TITLE
Expiremental: add a section output to track current running command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Rename `get_application()` to `app()`
 * Rename `get_command()` to `task()`
 * Fix parallel when one of the callback fails, wait for the others to finish to throw exception
+* Experimental display with sections, allow better output when using parallel function, you can test this by using `CASTOR_USE_SECTION=true castor [task]`
 
 ## 0.7.1 (2023-07-11)
 

--- a/examples/parallel.php
+++ b/examples/parallel.php
@@ -9,27 +9,22 @@ use function Castor\run;
 
 function sleep_5(int $sleep = 5): string
 {
-    echo "sleep {$sleep}\n";
-    run(['sleep', $sleep]);
-
-    echo "re sleep {$sleep}\n";
-    run(['sleep', $sleep]);
+    run("echo 'sleep {$sleep}'; sleep {$sleep}");
+    run("echo 're sleep {$sleep}'; sleep {$sleep}");
 
     return 'foo';
 }
 
 function sleep_7(int $sleep = 7): string
 {
-    echo "sleep {$sleep}\n";
-    run(['sleep', $sleep]);
+    run("echo 'sleep {$sleep}'; sleep {$sleep}");
 
     return 'bar';
 }
 
 function sleep_10(int $sleep = 10): string
 {
-    echo "sleep {$sleep}\n";
-    run(['sleep', $sleep]);
+    run("echo 'sleep {$sleep}'; sleep {$sleep}");
 
     return "sleep {$sleep}";
 }
@@ -48,7 +43,7 @@ function embed_sleep(int $sleep5 = 5, int $sleep7 = 7): array
 function sleep(int $sleep5 = 5, int $sleep7 = 7, int $sleep10 = 10): void
 {
     $start = microtime(true);
-    [[$foo, $bar], $sleep10] = parallel(fn () => embed_sleep($sleep5, $sleep7), fn () => sleep_10($sleep10));
+    [$sleep10, [$foo, $bar]] = parallel(fn () => sleep_10($sleep10), fn () => embed_sleep($sleep5, $sleep7));
     $end = microtime(true);
 
     $duration = (int) ($end - $start);

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -10,6 +10,7 @@ use Castor\ContextRegistry;
 use Castor\FunctionFinder;
 use Castor\GlobalHelper;
 use Castor\Monolog\Processor\ProcessProcessor;
+use Castor\SectionOutput;
 use Castor\Stub\StubsGenerator;
 use Castor\TaskDescriptor;
 use Castor\VerbosityLevel;
@@ -54,12 +55,15 @@ class Application extends SymfonyApplication
     // is registered
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
+        $sectionOutput = new SectionOutput($output);
+
         GlobalHelper::setApplication($this);
         GlobalHelper::setInput($input);
-        GlobalHelper::setOutput($output);
-        GlobalHelper::setLogger(new Logger('castor',
+        GlobalHelper::setSectionOutput($sectionOutput);
+        GlobalHelper::setLogger(new Logger(
+            'castor',
             [
-                new ConsoleHandler($output),
+                new ConsoleHandler($sectionOutput->getConsoleOutput()),
             ],
             [
                 new ProcessProcessor(),

--- a/src/GlobalHelper.php
+++ b/src/GlobalHelper.php
@@ -19,7 +19,7 @@ class GlobalHelper
 {
     private static Application $application;
     private static InputInterface $input;
-    private static OutputInterface $output;
+    private static SectionOutput $sectionOutput;
     private static SymfonyStyle $symfonyStyle;
     private static Logger $logger;
     private static ContextRegistry $contextRegistry;
@@ -49,14 +49,19 @@ class GlobalHelper
         return self::$input ?? throw new \LogicException('Input not available yet.');
     }
 
-    public static function setOutput(OutputInterface $output): void
-    {
-        self::$output = $output;
-    }
-
     public static function getOutput(): OutputInterface
     {
-        return self::$output ?? throw new \LogicException('Output not available yet.');
+        return self::getSectionOutput()->getConsoleOutput();
+    }
+
+    public static function setSectionOutput(SectionOutput $output): void
+    {
+        self::$sectionOutput = $output;
+    }
+
+    public static function getSectionOutput(): SectionOutput
+    {
+        return self::$sectionOutput ?? throw new \LogicException('Section output not available yet.');
     }
 
     public static function getSymfonyStyle(): SymfonyStyle

--- a/src/SectionOutput.php
+++ b/src/SectionOutput.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Castor;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+/** @internal */
+class SectionOutput
+{
+    private OutputInterface|ConsoleSectionOutput $consoleOutput;
+
+    private ConsoleOutput|null $mainOutput;
+
+    /** @var array{ConsoleSectionOutput, ConsoleSectionOutput, float, string}[] */
+    private array $sections = [];
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->mainOutput = null;
+        $this->consoleOutput = $output;
+
+        if ($output instanceof ConsoleOutput && posix_isatty(\STDOUT) && 'true' === getenv('CASTOR_USE_SECTION')) {
+            $this->mainOutput = $output;
+            $this->consoleOutput = $output->section();
+        }
+    }
+
+    public function getConsoleOutput(): OutputInterface
+    {
+        return $this->consoleOutput;
+    }
+
+    public function writeProcessOutput(string $type, string $bytes, Process $process): void
+    {
+        if (!$this->mainOutput) {
+            if (Process::OUT === $type) {
+                fwrite(\STDOUT, $bytes);
+            } else {
+                fwrite(\STDERR, $bytes);
+            }
+
+            return;
+        }
+
+        /** @var ConsoleSectionOutput $section */
+        [$section] = $this->getSection($process);
+        $section->write($bytes);
+        $this->tickProcess($process);
+    }
+
+    public function initProcess(Process $process): void
+    {
+        if (!$this->mainOutput) {
+            return;
+        }
+
+        $this->getSection($process);
+    }
+
+    public function finishProcess(Process $process): void
+    {
+        if (!$this->mainOutput) {
+            return;
+        }
+
+        [$outputSection, $progressBarSection, $start, $index] = $this->getSection($process);
+        $outputContent = $outputSection->getContent();
+        $time = number_format(microtime(true) - $start, 2);
+
+        $fg = 0 === $process->getExitCode() ? 'green' : 'red';
+        $status = 0 === $process->getExitCode() ? 'success' : 'failure';
+
+        $this->consoleOutput->writeln("[RUN] [{$index}] <fg={$fg}>{$process->getCommandLine()}</> {$status} after {$time}s");
+        $this->consoleOutput->write($outputContent);
+
+        $outputSection->clear();
+        $progressBarSection->clear();
+    }
+
+    public function tickProcess(Process $process): void
+    {
+        if (!$this->mainOutput) {
+            return;
+        }
+
+        /* @var $progressBar ProgressBar */
+        [, $progressBarSection, $start, $index] = $this->getSection($process);
+        $time = number_format(microtime(true) - $start, 2);
+        $progressBarSection->writeln("[RUN] [{$index}] '<fg=yellow>{$process->getCommandLine()}</>' running for {$time}s");
+    }
+
+    /**
+     * @return array{ConsoleSectionOutput, ConsoleSectionOutput, float, string}
+     */
+    private function getSection(Process $process): array
+    {
+        if (!$this->mainOutput) {
+            throw new \LogicException('Cannot call getSection() without a main output.');
+        }
+
+        $id = spl_object_hash($process);
+
+        if (!isset($this->sections[$id]) || ('' === $this->sections[$id][1]->getContent())) {
+            $progressBarSection = $this->mainOutput->section();
+            $section = $this->mainOutput->section();
+            $index = sprintf('%02d', \count($this->sections) + 1);
+            $progressBarSection->writeln("[RUN] [{$index}] '<fg=yellow>{$process->getCommandLine()}</>' starting...");
+            $progressBarSection->setDecorated(true);
+            $progressBarSection->setMaxHeight(1);
+
+            $this->sections[$id] = [$section, $progressBarSection, microtime(true), $index];
+        }
+
+        return $this->sections[$id];
+    }
+}

--- a/tests/Examples/ParallelExceptionTest.php.err.txt
+++ b/tests/Examples/ParallelExceptionTest.php.err.txt
@@ -1,5 +1,5 @@
 
-In parallel.php line 67:
+In parallel.php line 62:
                         
   This is an exception  
                         
@@ -7,7 +7,7 @@ In parallel.php line 67:
 parallel:exception
 
 
-In parallel.php line 65:
+In parallel.php line 60:
                                 
   The command "exit 1" failed.  
                                 

--- a/tests/Examples/ParallelSleepTest.php
+++ b/tests/Examples/ParallelSleepTest.php
@@ -13,6 +13,8 @@ class ParallelSleepTest extends TaskTestCase
         $process = $this->runTask(['parallel:sleep', '--sleep5', '0', '--sleep7', '0', '--sleep10', '0']);
 
         $this->assertSame(0, $process->getExitCode());
+        // normalize line endings
+        $output = str_replace("\r", '', $process->getOutput());
 
         $startWith = <<<'OUTPUT'
             sleep 0
@@ -22,7 +24,7 @@ class ParallelSleepTest extends TaskTestCase
             OUTPUT;
 
         try {
-            $this->assertStringStartsWith($startWith, $process->getOutput());
+            $this->assertStringStartsWith($startWith, $output);
         } catch (ExpectationFailedException) {
             // The order of the fibers might be different. So we try another
             // order.
@@ -32,7 +34,7 @@ class ParallelSleepTest extends TaskTestCase
                 sleep 0
                 re sleep 0
                 OUTPUT;
-            $this->assertStringStartsWith($startWith, $process->getOutput());
+            $this->assertStringStartsWith($startWith, $output);
         }
 
         $endWith = <<<'OUTPUT'
@@ -42,7 +44,7 @@ class ParallelSleepTest extends TaskTestCase
             Duration: 0
 
             OUTPUT;
-        $this->assertStringEndsWith($endWith, $process->getOutput());
+        $this->assertStringEndsWith($endWith, $output);
         $this->assertSame('', $process->getErrorOutput());
     }
 }


### PR DESCRIPTION
Add a new way to output log for castor which will do the following : 

 * Create a "main" section where all users logs (using the log function) will go
 * For each run process create 2 new sections : 
    * One for the progress
    * One for the log of the process
 * When a process is running it output it's content in the created section
 * When a process has finish running it clear its sections and add the content of thoses section in the main (top) section, this allow to have a history of each process in order even when there is parallelism
 
Currently this output is only available when using the `CASTOR_USE_SECTION=true` env variable, we can make this default later, but it will be better to first test this output and existing project as an expiremental approach so we can iterate on this with real use case

[test-2023-08-11_18.08.05.webm](https://github.com/jolicode/castor/assets/90466/939d8804-0945-4941-9070-7ed764f3c52c)

Need https://github.com/symfony/symfony/pull/51355 to work
Need https://github.com/symfony/symfony/pull/51378 for better output (too many new lines)