### PR TITLE
typo : fix typo on error message in functions.php

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -195,7 +195,7 @@ function run(
     }
 
     if (0 !== $exitCode) {
-        log(sprintf('Command finished with and error (exit code=%d).', $process->getExitCode()), 'notice');
+        log(sprintf('Command finished with an error (exit code=%d).', $process->getExitCode()), 'notice');
         if (!$context->allowFailure) {
             if ($context->verbosityLevel->isVeryVerbose()) {
                 throw new ProcessFailedException($process);


### PR DESCRIPTION
Fixed a typo on error message

![image](https://github.com/jolicode/castor/assets/11477247/09f38c6b-a3d0-4671-aab7-1e8c0298abc1)
