### PR TITLE
feat(context): allow to set default context with an env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `ssh_upload()` and `ssh_download()` functions to upload/download files via SSH
 * Rename `ssh()` to `ssh_run()`
+* Allow to set default context with an env variable
 
 ## 0.9.1 (2023-10-09)
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -10,6 +10,7 @@ use Castor\ContextRegistry;
 use Castor\FunctionFinder;
 use Castor\GlobalHelper;
 use Castor\Monolog\Processor\ProcessProcessor;
+use Castor\PlatformUtil;
 use Castor\SectionOutput;
 use Castor\Stub\StubsGenerator;
 use Castor\TaskDescriptor;
@@ -119,13 +120,16 @@ class Application extends SymfonyApplication
         $this->contextRegistry->setDefaultIfEmpty();
 
         $contextNames = $this->contextRegistry->getNames();
+
         if ($contextNames) {
+            $defaultContext = PlatformUtil::getEnv('CASTOR_CONTEXT') ?: $this->contextRegistry->getDefault();
+
             $this->getDefinition()->addOption(new InputOption(
                 'context',
                 '_complete' === $input->getFirstArgument() || 'list' === $input->getFirstArgument() ? null : 'c',
                 InputOption::VALUE_REQUIRED,
                 sprintf('The context to use (%s)', implode('|', $contextNames)),
-                $this->contextRegistry->getDefault(),
+                $defaultContext,
                 $contextNames,
             ));
         }


### PR DESCRIPTION
The goal is to be able to have a way to avoid setting the context for each command by using an env variable.

It only overrides the default context, a command executed with `--context=test` will use the test context regardless of the env variable definition