### PR TITLE
Adjust the composer global installation documentation

### DIFF
--- a/doc/01-installation.md
+++ b/doc/01-installation.md
@@ -58,7 +58,8 @@ composer config --list --global | grep -F "[home]"
 ```
 
 With this knowledge, we can now add the correct path.
-Instead of `/home/<my_username>` you can use `$HOME` and then append `/vendor/bin`.
+Instead of `/home/<my_username>` you can use `$HOME` and then append the
+composer path from `[home]` and append `/vendor/bin`.
 With my system the final path looks like this: `$HOME/.config/composer/vendor/bin`
 
 ```bash

--- a/doc/01-installation.md
+++ b/doc/01-installation.md
@@ -46,10 +46,23 @@ You can install Castor globally with Composer:
 composer global require jolicode/castor
 ```
 
-Then make sure that the Composer global bin directory is in your `PATH`:
+Then make sure that the Composer global bin directory is in your `PATH`.
+The global Composer path may vary depending on the operating system.
+It is best to run the following command and look at the "[home]" path.
 
 ```bash
-export PATH="$HOME/.composer/vendor/bin:$PATH"
+composer config --list --global | grep -F "[home]"
+
+# On my Ubuntu the output looks like this:
+# [home] /home/<my_username>/.config/composer
+```
+
+With this knowledge, we can now add the correct path.
+Instead of `/home/<my_username>` you can use `$HOME` and then append `/vendor/bin`.
+With my system the final path looks like this: `$HOME/.config/composer/vendor/bin`
+
+```bash
+export PATH="$HOME/.config/composer/vendor/bin:$PATH"
 ```
 
 ### Manually

--- a/doc/01-installation.md
+++ b/doc/01-installation.md
@@ -47,24 +47,30 @@ composer global require jolicode/castor
 ```
 
 Then make sure that the Composer global bin directory is in your `PATH`.
-The global Composer path may vary depending on the operating system.
-It is best to run the following command and look at the "[home]" path.
+
+> **Note**
+> The global Composer path may vary depending on your operating system.
+
+You can run the following command to determine it:
 
 ```bash
 composer config --list --global | grep -F "[home]"
 
-# On my Ubuntu the output looks like this:
-# [home] /home/<my_username>/.config/composer
+# It may looks like this on some Linux systems:
+# [home] /home/<your_username>/.config/composer
+# Or like this too:
+# [home] /home/<your_username>/.composer
 ```
 
-With this knowledge, we can now add the correct path.
-Instead of `/home/<my_username>` you can use `$HOME` and then append the
-composer path from `[home]` and append `/vendor/bin`.
-With my system the final path looks like this: `$HOME/.config/composer/vendor/bin`
+You can optionally replace `/home/<your_username>` with the Unix
+`$HOME` environment variable. Now, append `/vendor/bin` to that path to get the
+Composer global bin directory to add to your `PATH`:
 
 ```bash
 export PATH="$HOME/.config/composer/vendor/bin:$PATH"
 ```
+
+Any binary globally installed with Composer will now work everywhere.
 
 ### Manually
 


### PR DESCRIPTION
I've opened a Issue #210 yesterday, because my composer path was different than in the documentation.

- Closes https://github.com/jolicode/castor/issues/210
