### PR TITLE
feat: Provide a docker ready environment for developing locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,32 @@ Everybody should be able to help. Here's how you can do it:
 
 Here's some tips to make you the best contributor ever:
 
+* [Getting started](#getting-started)
 * [Rules](#rules)
 * [Green tests](#green-tests)
 * [Standard code](#standard-code)
 * [Keeping your fork up-to-date](#keeping-your-fork-up-to-date)
+
+## Getting started
+
+Contribute using the docker environment
+
+> Composer vendor is directly install during the container run. (You can also run `composer install` in the container)
+
+1. Start the container:
+    ```shell
+    docker compose up -d --build --wait
+    ```
+
+2. Access the container:
+    ```shell
+    docker compose exec php bash
+    ```
+   
+3. Test castor withing the container:
+    ```shell
+    castor --version
+    ```
 
 ## Rules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,41 @@ RUN if [ "$WITH_DOCKER" = "1" ]; then \
 
 WORKDIR /project
 ENTRYPOINT [ "/usr/local/bin/castor" ]
+
+FROM boxproject/box:4.6.1 as box
+
+FROM ubuntu:22.04 as dev
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    wget \
+    software-properties-common \
+    && add-apt-repository ppa:ondrej/php -y
+
+RUN apt-get update && apt-get install -y \
+    php8.2-cli \
+    php8.2-curl \
+    php8.2-mbstring \
+    php8.2-xml \
+    php8.2-zip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=box /box.phar /usr/local/bin/box
+
+COPY --from=composer:2.6.6 /usr/bin/composer /usr/bin/composer
+
+COPY . ./
+
+RUN ln -s /app/bin/castor /usr/local/bin/castor
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+version: '3.9'
+
+services:
+    php:
+        build:
+            target: dev
+        working_dir: /app
+        volumes:
+            - "./:/app"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,5 +3,9 @@
 # Install composer dependencies
 composer install --no-interaction --no-progress --no-suggest
 
+# Install tools dependencies
+cd tools/php-cs-fixer && composer install --no-interaction --no-progress --no-suggest && cd ../..
+cd tools/phpstan && composer install --no-interaction --no-progress --no-suggest && cd ../..
+
 # Keep container running
 tail -f /dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Install composer dependencies
+composer install --no-interaction --no-progress --no-suggest
+
+# Keep container running
+tail -f /dev/null


### PR DESCRIPTION
## Docker-Ready Development Environment

### Overview

This PR permit to includes Docker support to streamline the local development process. With Docker, contributors can set up a ready-to-use development environment without the need to install any tools locally.

I don't know if this can bu useful for all of us, but is a thing that is missing for my case, feel free to close if PR is not suitable

### To know

I've used `ubuntu:22.04` as docker base image, because the PHP 8.2 image doesn't contain the `SIGUSR2` constant, so if anyone has a solution I'd love to hear from you!

### How to Use Docker for Local Development

1. **Clone this repository:**

    ```bash
    git clone https://github.com/jolicode/castor
    ```

2. **Navigate to the project directory:**

    ```bash
    cd castor
    ```

3. **Build and Running the Docker Container:**

    ```bash
    docker compose up -d --build --wait
    ```

4. **Run bash into the Docker container:**

    ```bash
    docker compose exec php bash
    ```