### PR TITLE
feat: Allow usage of force in fingerprint method + fix cache with new path for fingerprint tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released yet
 
-* Add `--force` option to `fingerprint()` method to force run the callable, even if fingerprint is same
+* Add `force` argument to `fingerprint()` method to force run the callable, even if fingerprint is same
 * Fix directory for fingerprinted test
 
 ## 0.10.0 (2023-11-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Not released yet
 
+* Add `--force` option to `fingerprint()` method to force run the callable, even if fingerprint is same
+* Fix directory for fingerprinted test
+
 ## 0.10.0 (2023-11-14)
 
 * Add `ssh_upload()` and `ssh_download()` functions to upload/download files via SSH

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -52,6 +52,7 @@ $commandFilterList = [
     'run:run-parallel',
     'fingerprint:task-with-some-fingerprint', // Tested in Castor\Tests\Fingerprint\FingerprintTaskWithSomeFingerprintTest
     'fingerprint:task-with-some-fingerprint-with-helper', // Tested in Castor\Tests\Fingerprint\FingerprintTaskWithSomeFingerprintWithHelperTest
+    'fingerprint:task-with-some-fingerprint-and-force', // Tested in Castor\Tests\Fingerprint\FingerprintTaskWithSomeFingerprintWithForceOptionTest
 ];
 $optionFilterList = array_flip(['help', 'quiet', 'verbose', 'version', 'ansi', 'no-ansi', 'no-interaction', 'context']);
 foreach ($applicationDescription['commands'] as $command) {

--- a/examples/fingerprint.php
+++ b/examples/fingerprint.php
@@ -2,6 +2,7 @@
 
 namespace fingerprint;
 
+use Castor\Attribute\AsOption;
 use Castor\Attribute\AsTask;
 use Castor\Fingerprint\FileHashStrategy;
 
@@ -35,6 +36,23 @@ function task_with_some_fingerprint_with_helper(): void
             run('echo "Cool, no fingerprint ! Executing..."');
         },
         fingerprint: fingerprintCheck()
+    );
+
+    run('echo "Cool ! I finished !"');
+}
+
+#[AsTask(description: 'Run a command and run part of it only if the fingerprint has changed (with force option)')]
+function task_with_some_fingerprint_and_force(
+    #[AsOption(description: 'Force the command to run even if the fingerprint has not changed')] bool $force = false
+): void {
+    run('echo "Hello Task with Fingerprint !"');
+
+    fingerprint(
+        callback: function () {
+            run('echo "Cool, no fingerprint ! Executing..."');
+        },
+        fingerprint: fingerprintCheck(),
+        force: $force // This option will force the command to run even if the fingerprint has not changed
     );
 
     run('echo "Cool ! I finished !"');

--- a/src/GlobalHelper.php
+++ b/src/GlobalHelper.php
@@ -175,10 +175,9 @@ class GlobalHelper
     public static function setupDefaultCache(): void
     {
         if (!isset(self::$cache)) {
-            $home = PlatformUtil::getUserDirectory();
-            $directory = $home ? $home . '/.cache' : sys_get_temp_dir();
+            $directory = PlatformUtil::getCacheDirectory();
 
-            self::setCache(new FilesystemAdapter(directory: $directory . '/castor'));
+            self::setCache(new FilesystemAdapter(directory: $directory));
         }
     }
 

--- a/src/PlatformUtil.php
+++ b/src/PlatformUtil.php
@@ -47,4 +47,12 @@ class PlatformUtil
 
         throw new \RuntimeException('Could not determine user directory.');
     }
+
+    public static function getCacheDirectory(): string
+    {
+        $home = self::getUserDirectory();
+        $directory = $home ? $home . '/.cache' : sys_get_temp_dir();
+
+        return $directory . '/castor';
+    }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -830,9 +830,9 @@ function fingerprint_save(string $fingerprint): void
     FingerprintHelper::postProcessFingerprintForHash($fingerprint);
 }
 
-function fingerprint(callable $callback, string $fingerprint): void
+function fingerprint(callable $callback, string $fingerprint, bool $force = false): void
 {
-    if (!fingerprint_exists($fingerprint)) {
+    if (!fingerprint_exists($fingerprint) || $force) {
         try {
             $callback();
             fingerprint_save($fingerprint);

--- a/tests/Examples/ListTest.php.output.txt
+++ b/tests/Examples/ListTest.php.output.txt
@@ -29,6 +29,7 @@ failure:failure                                      A failing task not authoriz
 filesystem:filesystem                                Performs some operations on the filesystem
 filesystem:find                                      Search files and directories on the filesystem
 fingerprint:task-with-some-fingerprint               Run a command and run part of it only if the fingerprint has changed
+fingerprint:task-with-some-fingerprint-and-force     Run a command and run part of it only if the fingerprint has changed (with force option)
 fingerprint:task-with-some-fingerprint-with-helper   Run a command only if the fingerprint has changed
 foo:foo                                              Prints foo
 log:all-level                                        Logs some messages with different levels

--- a/tests/Fingerprint/FingerprintCleaner.php
+++ b/tests/Fingerprint/FingerprintCleaner.php
@@ -2,16 +2,17 @@
 
 namespace Castor\Tests\Fingerprint;
 
+use Castor\PlatformUtil;
 use Symfony\Component\Finder\Finder;
 
 class FingerprintCleaner
 {
     public static function clearFingerprintsCache(): void
     {
-        if (is_dir('/tmp/castor')) {
+        if (is_dir(PlatformUtil::getCacheDirectory())) {
             foreach (
                 (new Finder())
-                    ->in('/tmp/castor')
+                    ->in(PlatformUtil::getCacheDirectory())
                     ->contains('.fingerprint')
                     ->files() as $file
             ) {
@@ -20,7 +21,7 @@ class FingerprintCleaner
 
             foreach (
                 (new Finder())
-                    ->in('/tmp/castor')
+                    ->in(PlatformUtil::getCacheDirectory())
                     ->notContains('.fingerprint')
                     ->directories() as $directory
             ) {

--- a/tests/Fingerprint/FingerprintTaskWithSomeFingerprintTest.php
+++ b/tests/Fingerprint/FingerprintTaskWithSomeFingerprintTest.php
@@ -8,7 +8,7 @@ class FingerprintTaskWithSomeFingerprintTest extends TaskTestCase
 {
     use FingerprintedTest;
 
-    // fingerprint:in-method
+    // fingerprint:task-with-some-fingerprint
     public function test(): void
     {
         // Run for the first time, should run

--- a/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithForceOptionTest.php
+++ b/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithForceOptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Castor\Tests\Fingerprint;
+
+use Castor\Tests\TaskTestCase;
+
+class FingerprintTaskWithSomeFingerprintWithForceOptionTest extends TaskTestCase
+{
+    use FingerprintedTest;
+
+    // fingerprint:task-with-some-fingerprint-and-force
+    public function test(): void
+    {
+        $filepath = \dirname(__DIR__, 2) . '/examples/fingerprint_file.fingerprint_single
+        ';
+        if (file_exists($filepath)) {
+            unlink($filepath);
+        }
+
+        file_put_contents($filepath, 'Hello');
+
+        $processFirstRun = $this->runTask(['fingerprint:task-with-some-fingerprint-and-force']);
+        $processSecondRun = $this->runTask(['fingerprint:task-with-some-fingerprint-and-force', '--force']);
+        $processThirdRun = $this->runTask(['fingerprint:task-with-some-fingerprint-and-force']);
+
+        $this->assertStringEqualsFile(__FILE__ . '.output_runnable.txt', $processFirstRun->getOutput());
+        $this->assertStringEqualsFile(__FILE__ . '.output_runnable.txt', $processSecondRun->getOutput());
+        $this->assertStringEqualsFile(__FILE__ . '.output_not_runnable.txt', $processThirdRun->getOutput());
+
+        file_put_contents($filepath, 'Hello World');
+        // If we don't force, it should re-run the task
+        $processFourthRun = $this->runTask(['fingerprint:task-with-some-fingerprint-and-force']);
+        $this->assertStringEqualsFile(__FILE__ . '.output_runnable.txt', $processFourthRun->getOutput());
+
+        foreach ([$processFirstRun, $processSecondRun, $processThirdRun, $processFourthRun] as $process) {
+            $this->assertSame(0, $process->getExitCode());
+        }
+    }
+}

--- a/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithForceOptionTest.php
+++ b/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithForceOptionTest.php
@@ -11,8 +11,8 @@ class FingerprintTaskWithSomeFingerprintWithForceOptionTest extends TaskTestCase
     // fingerprint:task-with-some-fingerprint-and-force
     public function test(): void
     {
-        $filepath = \dirname(__DIR__, 2) . '/examples/fingerprint_file.fingerprint_single
-        ';
+        $filepath = \dirname(__DIR__, 2) . '/examples/fingerprint_file.fingerprint_single';
+
         if (file_exists($filepath)) {
             unlink($filepath);
         }

--- a/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithForceOptionTest.php.output_not_runnable.txt
+++ b/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithForceOptionTest.php.output_not_runnable.txt
@@ -1,0 +1,2 @@
+Hello Task with Fingerprint !
+Cool ! I finished !

--- a/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithForceOptionTest.php.output_runnable.txt
+++ b/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithForceOptionTest.php.output_runnable.txt
@@ -1,0 +1,3 @@
+Hello Task with Fingerprint !
+Cool, no fingerprint ! Executing...
+Cool ! I finished !

--- a/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithHelperTest.php
+++ b/tests/Fingerprint/FingerprintTaskWithSomeFingerprintWithHelperTest.php
@@ -8,7 +8,7 @@ class FingerprintTaskWithSomeFingerprintWithHelperTest extends TaskTestCase
 {
     use FingerprintedTest;
 
-    // fingerprint:in-method
+    // fingerprint:task-with-some-fingerprint-with-helper
     public function test(): void
     {
         // Run for the first time, should run


### PR DESCRIPTION
Hey,

The first thing of this PR was to provide the possibility to pass `--force` option to a task and provide it to `fingerprint(force: $force)`

This is a case i have in some projects, when i want to force run the task even if already runned.

I want your return about `fingerprint_save(...)`, should be only saved in the case of "non-force" case or save it anyway the value of force ?

Additional : 

This PR include changes for fixes some tests (fingerprint)

When running multiple times the tests locally, the second run fail because the new path of cache as changed recently

