### PR TITLE
Refactor how the application is wired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Allow to override `AsTask` and `AsContext` attributes
 * Add `force` argument to `fingerprint()` method to force run the callable, even if fingerprint is same
 * Fix directory for fingerprinted test
+* Remove almost all setters in the GlobalHelper class
 
 ## 0.10.0 (2023-11-14)
 

--- a/examples/context.php
+++ b/examples/context.php
@@ -38,8 +38,9 @@ function productionContext(): Context
 #[AsContext(name: 'run')]
 function runContext(): Context
 {
-    $production = (bool) trim(run('echo $PRODUCTION', quiet: true)->getOutput());
-    $foo = trim(run('echo $FOO', quiet: true)->getOutput()) ?: 'no defined';
+    $blankContext = new Context();
+    $production = (bool) trim(run('echo $PRODUCTION', quiet: true, context: $blankContext)->getOutput());
+    $foo = trim(run('echo $FOO', quiet: true, context: $blankContext)->getOutput()) ?: 'no defined';
 
     return new Context([
         'name' => 'run',

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -9,17 +9,20 @@ use Castor\ContextDescriptor;
 use Castor\ContextRegistry;
 use Castor\Event\AfterApplicationInitializationEvent;
 use Castor\EventDispatcher;
+use Castor\ExpressionLanguage;
+use Castor\Fingerprint\FingerprintHelper;
 use Castor\FunctionFinder;
 use Castor\GlobalHelper;
 use Castor\ListenerDescriptor;
-use Castor\Monolog\Processor\ProcessProcessor;
 use Castor\PlatformUtil;
 use Castor\SectionOutput;
 use Castor\Stub\StubsGenerator;
 use Castor\TaskDescriptor;
 use Castor\VerbosityLevel;
+use Castor\WaitForHelper;
 use JoliCode\PhpOsHelper\OsHelper;
 use Monolog\Logger;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command;
@@ -28,13 +31,13 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 use Symfony\Component\VarDumper\Cloner\AbstractCloner;
+use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpExceptionInterface;
-
-use function Castor\log;
-use function Castor\request;
-use function Castor\run;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /** @internal */
 class Application extends SymfonyApplication
@@ -42,53 +45,88 @@ class Application extends SymfonyApplication
     public const NAME = 'castor';
     public const VERSION = 'v0.10.0';
 
+    // "Current" objects availables at some point of the lifecycle
+    private InputInterface $input;
+    private SectionOutput $sectionOutput;
+    private SymfonyStyle $symfonyStyle;
+    private Command $command;
+
     public function __construct(
         private readonly string $rootDir,
-        private readonly ContextRegistry $contextRegistry = new ContextRegistry(),
-        private readonly StubsGenerator $stubsGenerator = new StubsGenerator(),
-        private readonly FunctionFinder $functionFinder = new FunctionFinder(),
-        private readonly EventDispatcher $eventDispatcher = new EventDispatcher(),
+        public readonly FunctionFinder $functionFinder,
+        public readonly ContextRegistry $contextRegistry,
+        public readonly EventDispatcher $eventDispatcher,
+        public readonly ExpressionLanguage $expressionLanguage,
+        public readonly StubsGenerator $stubsGenerator,
+        public readonly Logger $logger,
+        public readonly Filesystem $fs,
+        public HttpClientInterface $httpClient,
+        public CacheItemPoolInterface&CacheInterface $cache,
+        public WaitForHelper $waitForHelper,
+        public FingerprintHelper $fingerprintHelper,
     ) {
-        if (!class_exists(\RepackedApplication::class)) {
-            $this->add(new RepackCommand());
-        }
-
         $this->setCatchErrors(true);
 
         AbstractCloner::$defaultCasters[self::class] = ['Symfony\Component\VarDumper\Caster\StubCaster', 'cutInternals'];
         AbstractCloner::$defaultCasters[AfterApplicationInitializationEvent::class] = ['Symfony\Component\VarDumper\Caster\StubCaster', 'cutInternals'];
 
+        if (!class_exists(\RepackedApplication::class)) {
+            $this->add(new RepackCommand());
+        }
+
         parent::__construct(static::NAME, static::VERSION);
+
+        GlobalHelper::setApplication($this);
+    }
+
+    public function getInput(): InputInterface
+    {
+        return $this->input ?? throw new \LogicException('Input not available yet.');
+    }
+
+    public function getSectionOutput(): SectionOutput
+    {
+        return $this->sectionOutput ?? throw new \LogicException('Section output not available yet.');
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->getSectionOutput()->getConsoleOutput();
+    }
+
+    public function getSymfonyStyle(): SymfonyStyle
+    {
+        return $this->symfonyStyle ?? throw new \LogicException('SymfonyStyle not available yet.');
+    }
+
+    public function getCommand(): Command
+    {
+        return $this->command ?? throw new \LogicException('Command not available yet.');
     }
 
     // We do all the logic as late as possible to ensure the exception handler
     // is registered
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        $sectionOutput = new SectionOutput($output);
-
-        GlobalHelper::setApplication($this);
-        GlobalHelper::setEventDispatcher($this->eventDispatcher);
-        GlobalHelper::setInput($input);
-        GlobalHelper::setSectionOutput($sectionOutput);
-        GlobalHelper::setLogger(new Logger(
-            'castor',
-            [
-                new ConsoleHandler($sectionOutput->getConsoleOutput()),
-            ],
-            [
-                new ProcessProcessor(),
-            ]
-        ));
-        GlobalHelper::setContextRegistry($this->contextRegistry);
-        GlobalHelper::setupDefaultCache();
+        $this->input = $input;
+        $this->sectionOutput = new SectionOutput($output);
+        $this->symfonyStyle = new SymfonyStyle($input, $output);
+        $this->logger->pushHandler(new ConsoleHandler($output));
 
         $tasks = $this->initializeApplication($input);
 
-        GlobalHelper::setInitialContext($this->createContext($input, $output));
+        // Must be done after the initializeApplication() call, to ensure all
+        // contexts have been created; but before the adding of task, because we
+        // may want to seek in the context to know if the command is enabled
+        $this->contextRegistry->setCurrentContext($this->createContext($input, $output));
 
         foreach ($tasks as $task) {
-            $this->add(new TaskCommand($task->taskAttribute, $task->function));
+            $this->add(new TaskCommand(
+                $task->taskAttribute,
+                $task->function,
+                $this->eventDispatcher,
+                $this->expressionLanguage,
+            ));
         }
 
         return parent::doRun($input, $output);
@@ -96,7 +134,7 @@ class Application extends SymfonyApplication
 
     protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output): int
     {
-        GlobalHelper::setCommand($command);
+        $this->command = $command;
 
         if ('_complete' !== $command->getName() && !class_exists(\RepackedApplication::class)) {
             $this->stubsGenerator->generateStubsIfNeeded($this->rootDir . '/.castor.stub.php');
@@ -122,7 +160,7 @@ class Application extends SymfonyApplication
             if ($function instanceof TaskDescriptor) {
                 $tasks[] = $function;
             } elseif ($function instanceof ContextDescriptor) {
-                $this->contextRegistry->add($function);
+                $this->contextRegistry->addDescriptor($function);
             } elseif ($function instanceof ListenerDescriptor && null !== $function->reflectionFunction->getClosure()) {
                 $this->eventDispatcher->addListener(
                     $function->asListener->event,
@@ -137,7 +175,7 @@ class Application extends SymfonyApplication
         $contextNames = $this->contextRegistry->getNames();
 
         if ($contextNames) {
-            $defaultContext = PlatformUtil::getEnv('CASTOR_CONTEXT') ?: $this->contextRegistry->getDefault();
+            $defaultContext = PlatformUtil::getEnv('CASTOR_CONTEXT') ?: $this->contextRegistry->getDefaultName();
 
             $this->getDefinition()->addOption(new InputOption(
                 'context',
@@ -182,10 +220,10 @@ class Application extends SymfonyApplication
 
     private function displayUpdateWarningIfNeeded(SymfonyStyle $symfonyStyle): void
     {
-        $latestVersion = GlobalHelper::getCache()->get('latest-version', function (ItemInterface $item): array {
+        $latestVersion = $this->cache->get('latest-version', function (ItemInterface $item): array {
             $item->expiresAfter(3600 * 60 * 24);
 
-            $response = request('GET', 'https://api.github.com/repos/jolicode/castor/releases/latest', [
+            $response = $this->httpClient->request('GET', 'https://api.github.com/repos/jolicode/castor/releases/latest', [
                 'timeout' => 1,
             ]);
 
@@ -197,7 +235,7 @@ class Application extends SymfonyApplication
         });
 
         if (!$latestVersion) {
-            log('Failed to fetch latest Castor version from GitHub.');
+            $this->logger->info('Failed to fetch latest Castor version from GitHub.');
 
             return;
         }
@@ -217,7 +255,7 @@ class Application extends SymfonyApplication
             };
 
             if (!$assets) {
-                log('Failed to detect the correct release url adapted to your system.');
+                $this->logger->info('Failed to detect the correct release url adapted to your system.');
 
                 return;
             }
@@ -225,7 +263,7 @@ class Application extends SymfonyApplication
             $latestReleaseUrl = reset($assets)['browser_download_url'] ?? null;
 
             if (!$latestReleaseUrl) {
-                log('Failed to fetch latest phar url.');
+                $this->logger->info('Failed to fetch latest phar url.');
 
                 return;
             }
@@ -242,7 +280,9 @@ class Application extends SymfonyApplication
             return;
         }
 
-        $globalComposerPath = trim(run('composer global config home --quiet', quiet: true, allowFailure: true)->getOutput());
+        $process = new Process(['composer', 'global', 'config', 'home', '--quiet']);
+        $process->run();
+        $globalComposerPath = trim($process->getOutput());
 
         if ($globalComposerPath && str_contains(__FILE__, $globalComposerPath)) {
             $symfonyStyle->block('Run the following command to update Castor: <comment>composer global update jolicode/castor</comment>', escape: false);

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -2,8 +2,21 @@
 
 namespace Castor\Console;
 
+use Castor\ContextRegistry;
+use Castor\EventDispatcher;
+use Castor\ExpressionLanguage;
+use Castor\Fingerprint\FingerprintHelper;
+use Castor\FunctionFinder;
+use Castor\Monolog\Processor\ProcessProcessor;
 use Castor\PathHelper;
+use Castor\PlatformUtil;
+use Castor\Stub\StubsGenerator;
+use Castor\WaitForHelper;
+use Monolog\Logger;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Console\Application as SymfonyApplication;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpClient\HttpClient;
 
 /** @internal */
 class ApplicationFactory
@@ -16,11 +29,34 @@ class ApplicationFactory
             return new CastorFileNotFoundApplication($e);
         }
 
+        $class = Application::class;
         if (class_exists(\RepackedApplication::class)) {
-            // @phpstan-ignore-next-line
-            return new \RepackedApplication($rootDir);
+            $class = \RepackedApplication::class;
         }
 
-        return new Application($rootDir);
+        $contextRegistry = new ContextRegistry();
+        $httpClient = HttpClient::create([
+            'headers' => [
+                'User-Agent' => 'Castor/' . Application::VERSION,
+            ],
+        ]);
+        $cache = new FilesystemAdapter(directory: PlatformUtil::getCacheDirectory());
+        $logger = new Logger('castor', [], [new ProcessProcessor()]);
+
+        // @phpstan-ignore-next-line
+        return new $class(
+            $rootDir,
+            new FunctionFinder(),
+            $contextRegistry,
+            new EventDispatcher(logger: $logger),
+            new ExpressionLanguage($contextRegistry),
+            new StubsGenerator($logger),
+            $logger,
+            new Filesystem(),
+            $httpClient,
+            $cache,
+            new WaitForHelper($httpClient, $logger),
+            new FingerprintHelper($cache),
+        );
     }
 }

--- a/src/EventDispatcher.php
+++ b/src/EventDispatcher.php
@@ -2,6 +2,8 @@
 
 namespace Castor;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyEventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -10,12 +12,13 @@ class EventDispatcher implements EventDispatcherInterface
 {
     public function __construct(
         private EventDispatcherInterface $eventDispatcher = new SymfonyEventDispatcher(),
+        private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
     public function dispatch(object $event, string $eventName = null): object
     {
-        log("Dispatching event {$eventName}", 'debug', [
+        $this->logger->debug("Dispatching event {$eventName}", [
             'event' => $event,
         ]);
 
@@ -24,7 +27,7 @@ class EventDispatcher implements EventDispatcherInterface
 
     public function addListener(string $eventName, callable $listener, int $priority = 0): void
     {
-        log("Adding listener for event {$eventName}", 'debug', [
+        $this->logger->debug("Adding listener for event {$eventName}", [
             'listener' => $listener,
             'priority' => $priority,
         ]);
@@ -34,7 +37,7 @@ class EventDispatcher implements EventDispatcherInterface
 
     public function removeListener(string $eventName, callable $listener): void
     {
-        log("Removing listener for event {$eventName}", 'debug', [
+        $this->logger->debug("Removing listener for event {$eventName}", [
             'listener' => $listener,
         ]);
 

--- a/src/ExpressionLanguage.php
+++ b/src/ExpressionLanguage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Castor;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage as SymfonyExpressionLanguage;
+
+class ExpressionLanguage extends SymfonyExpressionLanguage
+{
+    public function __construct(
+        private readonly ContextRegistry $contextRegistry,
+    ) {
+        parent::__construct();
+
+        $this->addFunction(new ExpressionFunction(
+            'var',
+            fn () => throw new \LogicException('This function can only be used in expressions.'),
+            fn ($vars, ...$args) => $this->contextRegistry->getVariable(...$args),
+        ));
+    }
+}

--- a/src/GlobalHelper.php
+++ b/src/GlobalHelper.php
@@ -3,36 +3,19 @@
 namespace Castor;
 
 use Castor\Console\Application;
-use Castor\GlobalHelper as CastorGlobalHelper;
 use Monolog\Logger;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\ExpressionLanguage\ExpressionFunction;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class GlobalHelper
 {
     private static Application $application;
-    private static InputInterface $input;
-    private static SectionOutput $sectionOutput;
-    private static SymfonyStyle $symfonyStyle;
-    private static Logger $logger;
-    private static ContextRegistry $contextRegistry;
-    private static Command $command;
-    private static Context $initialContext;
-    private static Filesystem $fs;
-    private static HttpClientInterface $httpClient;
-    private static CacheItemPoolInterface&CacheInterface $cache;
-    private static ExpressionLanguage $expressionLanguage;
-    private static EventDispatcher $eventDispatcher;
 
     public static function setApplication(Application $application): void
     {
@@ -44,167 +27,68 @@ class GlobalHelper
         return self::$application ?? throw new \LogicException('Application not available yet.');
     }
 
-    public static function setInput(InputInterface $input): void
-    {
-        self::$input = $input;
-    }
-
-    public static function getInput(): InputInterface
-    {
-        return self::$input ?? throw new \LogicException('Input not available yet.');
-    }
-
-    public static function getOutput(): OutputInterface
-    {
-        return self::getSectionOutput()->getConsoleOutput();
-    }
-
-    public static function setSectionOutput(SectionOutput $output): void
-    {
-        self::$sectionOutput = $output;
-    }
-
-    public static function getSectionOutput(): SectionOutput
-    {
-        return self::$sectionOutput ?? throw new \LogicException('Section output not available yet.');
-    }
-
-    public static function getSymfonyStyle(): SymfonyStyle
-    {
-        return self::$symfonyStyle ??= new SymfonyStyle(self::getInput(), self::getOutput());
-    }
-
-    public static function setLogger(Logger $logger): void
-    {
-        self::$logger = $logger;
-    }
-
-    public static function getLogger(): Logger
-    {
-        return self::$logger ?? throw new \LogicException('Logger not available yet.');
-    }
-
-    public static function setContextRegistry(ContextRegistry $contextRegistry): void
-    {
-        self::$contextRegistry = $contextRegistry;
-    }
-
     public static function getContextRegistry(): ContextRegistry
     {
-        return self::$contextRegistry ?? throw new \LogicException('ContextRegistry not available yet.');
-    }
-
-    public static function setCommand(Command $command): void
-    {
-        self::$command = $command;
-    }
-
-    public static function setInitialContext(Context $initialContext): void
-    {
-        self::$initialContext = $initialContext;
-    }
-
-    public static function getInitialContext(): Context
-    {
-        // We always need a default context, for example when using run() in a context builder
-        return self::$initialContext ?? new Context();
-    }
-
-    public static function getContext(string $name = null): Context
-    {
-        if (null === $name) {
-            return self::$initialContext ?? new Context();
-        }
-
-        return self::getContextRegistry()->get($name);
-    }
-
-    /**
-     * @template TKey of key-of<ContextData>
-     * @template TDefault
-     *
-     * @param TKey|string $key
-     * @param TDefault    $default
-     *
-     * @phpstan-return ($key is TKey ? ContextData[TKey] : TDefault)
-     */
-    public static function getVariable(string $key, mixed $default = null): mixed
-    {
-        $initialContext = self::getInitialContext();
-
-        if (!isset($initialContext[$key])) {
-            return $default;
-        }
-
-        return $initialContext[$key];
-    }
-
-    public static function getCommand(): Command
-    {
-        return self::$command ?? throw new \LogicException('Command not available yet.');
-    }
-
-    public static function getFilesystem(): Filesystem
-    {
-        return self::$fs ??= new Filesystem();
-    }
-
-    public static function setHttpClient(HttpClientInterface $httpClient): void
-    {
-        self::$httpClient = $httpClient;
-    }
-
-    public static function getHttpClient(): HttpClientInterface
-    {
-        return self::$httpClient ??= HttpClient::create([
-            'headers' => [
-                'User-Agent' => 'Castor/' . Application::VERSION,
-            ],
-        ]);
-    }
-
-    public static function setCache(CacheItemPoolInterface&CacheInterface $cache): void
-    {
-        self::$cache = $cache;
-    }
-
-    public static function getCache(): CacheItemPoolInterface&CacheInterface
-    {
-        return self::$cache ?? throw new \LogicException('Cache not available yet.');
-    }
-
-    public static function setupDefaultCache(): void
-    {
-        if (!isset(self::$cache)) {
-            $directory = PlatformUtil::getCacheDirectory();
-
-            self::setCache(new FilesystemAdapter(directory: $directory));
-        }
-    }
-
-    public static function getExpressionLanguage(): ExpressionLanguage
-    {
-        if (isset(self::$expressionLanguage)) {
-            return self::$expressionLanguage;
-        }
-
-        self::$expressionLanguage = new ExpressionLanguage();
-        self::$expressionLanguage->addFunction(new ExpressionFunction(
-            'var',
-            fn () => throw new \LogicException('This function can only be used in expressions.'),
-            fn ($vars, ...$args) => CastorGlobalHelper::getVariable(...$args),
-        ));
-
-        return self::$expressionLanguage;
+        return self::getApplication()->contextRegistry;
     }
 
     public static function getEventDispatcher(): EventDispatcher
     {
-        return self::$eventDispatcher;
+        return self::getApplication()->eventDispatcher;
     }
 
-    public static function setEventDispatcher(EventDispatcher $eventDispatcher): void
+    public static function getFilesystem(): Filesystem
     {
-        self::$eventDispatcher = $eventDispatcher;
+        return self::getApplication()->fs;
+    }
+
+    public static function getHttpClient(): HttpClientInterface
+    {
+        return self::getApplication()->httpClient;
+    }
+
+    public static function getCache(): CacheItemPoolInterface&CacheInterface
+    {
+        return self::getApplication()->cache;
+    }
+
+    public static function getLogger(): Logger
+    {
+        return self::getApplication()->logger;
+    }
+
+    public static function getInput(): InputInterface
+    {
+        return self::getApplication()->getInput();
+    }
+
+    public static function getSectionOutput(): SectionOutput
+    {
+        return self::getApplication()->getSectionOutput();
+    }
+
+    public static function getOutput(): OutputInterface
+    {
+        return self::getApplication()->getOutput();
+    }
+
+    public static function getSymfonyStyle(): SymfonyStyle
+    {
+        return self::getApplication()->getSymfonyStyle();
+    }
+
+    public static function getCommand(): Command
+    {
+        return self::getApplication()->getCommand();
+    }
+
+    public static function getContext(string $name = null): Context
+    {
+        return self::getContextRegistry()->get($name);
+    }
+
+    public static function getVariable(string $key, mixed $default = null): mixed
+    {
+        return self::getContextRegistry()->getVariable($key, $default);
     }
 }

--- a/src/Stub/StubsGenerator.php
+++ b/src/Stub/StubsGenerator.php
@@ -6,17 +6,22 @@ use Castor\Console\Application;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Finder\Finder;
-
-use function Castor\log;
 
 /** @internal */
 final class StubsGenerator
 {
+    public function __construct(
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
     public function generateStubsIfNeeded(string $dest): void
     {
         if ($this->shouldGenerate($dest)) {
-            log('Generating stubs...', 'debug');
+            $this->logger->debug('Generating stubs...');
             $this->generateStubs($dest);
         }
     }
@@ -24,7 +29,7 @@ final class StubsGenerator
     public function generateStubs(string $dest): void
     {
         if (!is_writable(\dirname($dest))) {
-            log("Could not generate stubs as the destination \"{$dest}\" is not writeable.", 'warning');
+            $this->logger->warning("Could not generate stubs as the destination \"{$dest}\" is not writeable.");
 
             return;
         }

--- a/tests/Examples/ContextContextDoNotExistTest.php.err.txt
+++ b/tests/Examples/ContextContextDoNotExistTest.php.err.txt
@@ -1,5 +1,5 @@
 
-In ContextRegistry.php line 62:
+In ContextRegistry.php line 68:
                                     
   Context "no_no_exist" not found.  
                                     

--- a/tests/Examples/ParallelExceptionTest.php.err.txt
+++ b/tests/Examples/ParallelExceptionTest.php.err.txt
@@ -15,7 +15,7 @@ In parallel.php line 71:
 parallel:exception
 
 
-In functions.php line 94:
+In functions.php line 93:
                                                    
   One or more exceptions were thrown in parallel.  
                                                    

--- a/tests/Stub/StubsGeneratorTest.php
+++ b/tests/Stub/StubsGeneratorTest.php
@@ -2,7 +2,6 @@
 
 namespace Castor\Tests\Stub;
 
-use Castor\GlobalHelper;
 use Castor\Stub\StubsGenerator;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
@@ -18,9 +17,7 @@ class StubsGeneratorTest extends TestCase
         $fs = new Filesystem();
         $fs->remove($file);
 
-        GlobalHelper::setLogger(new Logger('name'));
-
-        $generator = new StubsGenerator();
+        $generator = new StubsGenerator(new Logger('name'));
         $generator->generateStubs($file);
 
         $process = new Process([\PHP_BINARY, '-l', $file]);


### PR DESCRIPTION
Before this patch, the was many duplicated parts. There was some logic in the
`GlobalHelper` class, and a bit everywhere else in the application, like in the
`Application`, or the `ContextRegistry`. More over, there was too much static
call from class living in `src/` to some castor's functions or `GlobalHelper`.

This patch clean this. Now there are DI everywhere, no more static call in our
domain!

Since the application is the heart of castor, this class hold everything!
Everything rely on DI and should stay like this.

The `GlobalHelper` is now a simple proxy to the application, with some convenient
methods. And it should stay like this also.

