### PR TITLE
Unset terminal emulation for consistent output in tests

### DIFF
--- a/tests/TaskTestCase.php
+++ b/tests/TaskTestCase.php
@@ -29,6 +29,7 @@ abstract class TaskTestCase extends TestCase
             cwd: $cwd ?? __DIR__ . '/..',
             env: [
                 'COLUMNS' => 120,
+                'TERM' => 'dumb',
                 ...$extraEnv,
             ],
         );


### PR DESCRIPTION
To avoid printing colors and other special formatting (like bold or underline) in command outputs that would break the equality check when comparing with provided file text output in tests

Without: 

```
14) Castor\Tests\Examples\OutputOutputTest::test
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '\n
-This is a title\n
-===============\n
+This is a title\n
+===============\n
 \n
  This is the command "output:output"\n
 \n
- // With IO, you can ask questions ...                                                                                  \n
+ // With IO, you can ask questions ...                                                                                  \n
 \n
- Tell me something:\n
+ Tell me something:\n
  > '

21) Castor\Tests\Examples\WaitForWaitForUrlWithContentCheckerTaskTest::test
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Waiting for URL "https://example.com" to return HTTP status "200"... OK\n
+'Waiting for URL "https://example.com" to return HTTP status "200"... OK\n
 \n
 '
```

Couldn't run the tests properly on my local without this.