### PR TITLE
Revise the usage of the terms `command` and `task` for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `wait_for_http_response()` function for a more generic response check
 * Add `wait_for_docker_container()` function to wait for a docker container to be ready
 * [BC Break] Remove `callable $responseChecker` parameter from `wait_for_http_status()`
+* Revise the usage of the terms `command` and `task` for consistency through code and docs.
 
 ## 0.11.1 (2024-01-11)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,10 @@ supported PHP versions and the lowest PHP version with lowest dependencies versi
 
 So it could be green on your local php version but fail on CI.
 
-### Testing helpers
+### Testing functions
 
-When your changes are related to helpers, run the `bin/generate-tests.php` 
-to generate helpers tests to reflect your changes.
+When your changes are related to Castor's provided functions, run the `bin/generate-tests.php` 
+to generate tests that would reflect your changes.
 
 ## Coding Standards
 
@@ -96,12 +96,14 @@ tools/phpstan/vendor/bin/phpstan fix --config=phpstan.neon
 ## Update the Documentation
 
 When introducing non-internal code that user will be able to rely on in their
-own project, like new helpers for example, make sure to document its usage.
+own project, like new Castor functions for example, make sure to document its usage.
 
 ## Update the Changelog
 
 Add a new entry in [CHANGELOG.md](CHANGELOG.md) summarizing your changes.
-Multiple points for a single PR is fine. Prefix with `[BC Break]` entries that 
+Multiple points for a single PR is fine. 
+
+Prefix with `[BC Break]` entries that 
 are related to backward compatibility breaking changes.
 
 ## Keeping your fork up-to-date

--- a/README.md
+++ b/README.md
@@ -5,23 +5,22 @@
 
 <p align="center">
     <i>Castor is a <strong><abbr title="Developer eXperience">DX</abbr> oriented task
-    runner</strong> and <strong>command launcher</strong> built with PHP.</i>
+    runner</strong> built in PHP featuring a range of functions for common task processing.</i>
 </p>
 
-It can be seen as a replacement of Makefile, Fabric, Invoke, Shell scripts...
+It can be viewed as an alternative to Makefile, Fabric, Invoke, Shell scripts,
+etc., but it leverages PHP's scripting capabilities and its extensive library ecosystem.
 
-It comes with many helpers to make your life easier:
+It comes with many features to make your life easier:
 
 * Seamless parsing of **arguments and options**, simplifying input handling
-* **Autocomplete** support for faster and error-free command entry
-* Effortless **process execution**, enabling seamless integration with external
-  tools
-* **Parallel processing** capabilities to maximize resource utilization
-* Intelligent **file watching** that automatically triggers actions on file
-  modifications
-* Customizable **notifications** to keep you informed and in control
-* Robust **logging** for capturing and analyzing essential information
-* A strong emphasis on exceptional **Developer Experience** (DX)
+* **Autocomplete** support for faster and error-free typing
+* A built-in list of useful functions:
+    * [`run()`](doc/03-run.md#the-run-function): Runs external processes, enabling seamless integration with external tools
+    * [`parallel()`](doc/going-further/parallel.md#the-parallel-function): Parallelizes process execution to maximize resource utilization
+    * [`watch()`](doc/going-further/watch.md): Watches files and automatically triggers actions on file modifications
+    * [`log()`](doc/going-further/log.md#the-log-function): Captures and analyzes essential information
+    * [And even more advanced functions](doc/06-reference.md)
 
 > [!NOTE]
 > Castor is still in early development, and the API is not stable yet. Even if
@@ -30,8 +29,11 @@ It comes with many helpers to make your life easier:
 
 ## Usage
 
-As an example, you could create a command that prints "Hello from castor" by creating
-a file `castor.php` with the following content:
+In Castor, tasks are set up as typical PHP functions marked with the `#[AsTask]` attribute in a `castor.php` file. 
+
+These tasks can run any PHP code but also make use of various [functions for standard operations](doc/06-reference.md) that come pre-packaged with Castor.
+
+For example:
 
 ```php
 <?php
@@ -48,14 +50,14 @@ function hello(): void
 }
 ```
 
-Then you can run the command with `castor greetings:hello`:
+Will expose a `greetings:hello` task that you can run with `castor greetings:hello`:
 
 ```bash
 $ castor greetings:hello
 Hello from castor
 ```
 
-Then, you can go wild and create more complex commands:
+Then, you can go wild and create more complex tasks:
 
 ```php
 #[AsTask(description: 'Clean the infrastructure (remove container, volume, networks)')]
@@ -116,8 +118,8 @@ Discover more by reading the docs:
 
 * [Installation and Autocomplete](doc/01-installation.md)
 * [Basic Usage](doc/02-basic-usage.md)
-* [Executing commands](doc/03-run.md)
-* [Command Arguments](doc/04-arguments.md)
+* [Executing Processes with `run()`](doc/03-run.md)
+* [Task Arguments](doc/04-arguments.md)
 * [Using the Context](doc/05-context.md)
 * [Castor reference](doc/06-reference.md)
 * [Going further with Castor](doc/going-further/index.md)

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -29,7 +29,7 @@ $application
 ;
 $applicationDescription = json_decode($o->fetch(), true);
 
-$commandFilterList = [
+$taskFilterList = [
     '_complete',
     'completion',
     'help',
@@ -66,19 +66,19 @@ $commandFilterList = [
     'fingerprint:task-with-a-fingerprint-and-force',
 ];
 $optionFilterList = array_flip(['help', 'quiet', 'verbose', 'version', 'ansi', 'no-ansi', 'no-interaction', 'context']);
-foreach ($applicationDescription['commands'] as $command) {
-    if (in_array($command['name'], $commandFilterList, true)) {
+foreach ($applicationDescription['commands'] as $task) {
+    if (in_array($task['name'], $taskFilterList, true)) {
         continue;
     }
 
-    echo "Generating test for {$command['name']}\n";
+    echo "Generating test for {$task['name']}\n";
 
     $args = [
-        $command['name'],
+        $task['name'],
     ];
 
-    $options = array_diff_key($command['definition']['options'], $optionFilterList);
-    foreach ($command['definition']['arguments'] as $argument) {
+    $options = array_diff_key($task['definition']['options'], $optionFilterList);
+    foreach ($task['definition']['arguments'] as $argument) {
         if (!$argument['is_required']) {
             continue;
         }
@@ -95,7 +95,7 @@ foreach ($applicationDescription['commands'] as $command) {
         $args[] = $option['default'] ?? 'FIXME';
     }
 
-    $class = u($command['name'])->camel()->title()->append('Test')->toString();
+    $class = u($task['name'])->camel()->title()->append('Test')->toString();
 
     add_test($args, $class);
 }
@@ -110,8 +110,8 @@ add_test(['context:context', '--context', 'dynamic'], 'ContextContextDynamicTest
 add_test(['enabled:hello', '--context', 'production'], 'EnabledInProduction');
 add_test([], 'NewProjectTest', '/tmp');
 add_test(['init'], 'NewProjectInitTest', '/tmp');
-add_test(['unknown:command'], 'NoConfigUnknownTest', '/tmp');
-add_test(['unknown:command', 'toto', '--foo', 1], 'NoConfigUnknownWithArgsTest', '/tmp');
+add_test(['unknown:task'], 'NoConfigUnknownTest', '/tmp');
+add_test(['unknown:task', 'toto', '--foo', 1], 'NoConfigUnknownWithArgsTest', '/tmp');
 add_test(['completion', 'bash'], 'NoConfigCompletionTest', '/tmp');
 
 function add_test(array $args, string $class, string $cwd = null)

--- a/doc/01-installation.md
+++ b/doc/01-installation.md
@@ -147,8 +147,8 @@ jobs:
 
 ## Autocomplete
 
-If you use bash, you can enable autocomplete for castor by executing the
-following commands:
+If you use bash, you can enable autocomplete for castor by running the
+following task:
 
 ```
 castor completion | sudo tee /etc/bash_completion.d/castor

--- a/doc/02-basic-usage.md
+++ b/doc/02-basic-usage.md
@@ -1,11 +1,11 @@
 # Basic usage
 
-Castor use a convention to find commands. It will look for the
+Castor use a convention to find tasks. It will look for the
 first `castor.php` file in the current directory or in parents directory.
 
 In this file, all functions with the `Castor\Attribute\AsTask` attribute will be
-transformed as commands. The name of the function will be the name of the
-command and the namespace will be the namespace of the command.
+transformed as tasks. The name of the function will be the task's name
+and the namespace will be the task's namespace.
 
 For example, if you have the following file:
 
@@ -33,27 +33,27 @@ function bar(): void
 }
 ```
 
-You will have two commands: `hello:castor` and `foo:bar`. If there is no
-namespace then the command will have no namespace.
+You will have two tasks: `hello:castor` and `foo:bar`. If there is no
+namespace then the task will have no namespace.
 
 From now on, we will omit the leading `<?php` in all doc examples.
 
 > [!TIP]
 > Related example: [foo.php](https://github.com/jolicode/castor/blob/main/examples/foo.php)
 
-## Splitting commands in multiple files
+## Splitting tasks in multiple files
 
 ### Using a directory
 
 Castor will also look for `castor` directory in the same directory of
 the `castor.php` file and load all the PHP files from it.
 
-You could then have an empty `castor.php` file and split your commands in
+You could then have an empty `castor.php` file and split your tasks in
 multiple files, like `castor/hello.php` and `castor/foo.php`.
 
 ### The `import()` function
 
-You can also use the `import()` function to import commands from another file.
+You can also use the `import()` function to import tasks from another file.
 This function takes a file path, or a directory as an argument.
 
 When using a directory as an argument, Castor will load all the PHP files in it:
@@ -66,10 +66,10 @@ import(__DIR__ . '/my-app/castor');
 ```
 
 > [!WARNING]
-> You cannot dynamically import commands. The `import()` function must be called
+> You cannot dynamically import tasks. The `import()` function must be called
 > at the top level of the file.
 
-## Overriding command name, namespace or description
+## Overriding task name, namespace or description
 
 The `Castor\Attribute\AsTask` attribute takes three optional
 arguments: `name`, `namespace` and `description` to override the default values:

--- a/doc/03-run.md
+++ b/doc/03-run.md
@@ -1,9 +1,8 @@
-# Executing commands
+# Executing Processes
 
 ## The `run()` function
 
-Castor provides a `Castor\run()` function to run commands. It allows to run a
-process:
+Castor provides a `run()` function to execute external processes.
 
 ```php
 use Castor\Attribute\AsTask;
@@ -15,18 +14,18 @@ function foo(): void
 {
     run('echo "bar"');
     run(['echo', 'bar']);
-}
+}AsTaskArgument
 ```
 
-You can pass a string or an array of string for this command. When passing a
+You can pass a string or an array of string for this function. When passing a
 string, arguments will not be escaped - use it carefully.
 
 ## Process object
 
 Under the hood, Castor uses the
 [`Symfony\Component\Process\Process`](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Process/Process.php)
-object to run the command. The `run()` function will return this object. So
-you can use the API of this class to interact with the process:
+object to execute the process. The `run()` function will return this object. So
+you can use the API of this class to interact with the underlying process:
 
 ```php
 use Castor\Attribute\AsTask;
@@ -46,7 +45,7 @@ function foo(): void
 
 ## Failure
 
-By default, Castor will throw an exception if the command fails. You can disable
+By default, Castor will throw an exception if the process fails. You can disable
 that by setting the `allowFailure` option to `true`:
 
 ```php
@@ -66,7 +65,7 @@ function foo(): void
 
 ## Working directory
 
-By default, Castor will run the command in the same directory as
+By default, Castor will execute the process in the same directory as
 the `castor.php` file. You can change that by setting the `path` argument. It
 can be either a relative or an absolute path:
 
@@ -78,8 +77,8 @@ use function Castor\run;
 #[AsTask]
 function foo(): void
 {
-    run('pwd', path: '../'); // run the command in the parent directory of the castor.php file
-    run('pwd', path: '/tmp'); // run the command in the /tmp directory
+    run('pwd', path: '../'); // run the process in the parent directory of the castor.php file
+    run('pwd', path: '/tmp'); // run the process in the /tmp directory
 }
 ```
 
@@ -110,7 +109,7 @@ function foo(): void
 ## Processing the output
 
 By default, Castor will forward the stdout and stderr to the current terminal.
-If you do not want to print the output of the command you can set the `quiet`
+If you do not want to print the process output you can set the `quiet`
 option to `true`:
 
 ```php
@@ -125,8 +124,8 @@ function foo(): void
 }
 ```
 
-You can also fetch the output of the command by using the API of
-the `Symfony\Component\Process\Process` object:
+You can also fetch the process output by using the 
+returned `Symfony\Component\Process\Process` object:
 
 ```php
 use Castor\Attribute\AsTask;
@@ -146,7 +145,7 @@ function foo(): void
 
 ### The `capture()` function
 
-Castor provides a `capture()` function that will run the command quietly,
+Castor provides a `capture()` function that will run the process quietly,
 trims the output, then returns it:
 
 ```php
@@ -204,7 +203,7 @@ function foo(): void
 }
 ```
 
-This command will have a 2 minutes timeout. If you want to disable that feature,
+This process will have a 2 minutes timeout. If you want to disable that feature,
 you need to set the timeout to `0`.
 
 ```php
@@ -224,7 +223,7 @@ function foo(): void
 
 ## PTY & TTY
 
-By default, Castor will use a pseudo terminal (PTY) to run the command,
+By default, Castor will use a pseudo terminal (PTY) to run the underlying process,
 which allows to have nice output in most cases.
 For some commands you may want to disable the PTY and use a TTY instead. You can
 do that by setting the `tty` option to `true`:
@@ -247,7 +246,7 @@ function foo(): void
 
 You can also disable the pty by setting the `pty` option to `false`. If `pty`
 and `tty` are both set to `false`, the standard input will not be forwarded to
-the command:
+the process:
 
 ```php
 use Castor\Attribute\AsTask;

--- a/doc/04-arguments.md
+++ b/doc/04-arguments.md
@@ -1,7 +1,7 @@
-# Command arguments
+# Task arguments
 
-When creating a function that will be used as a command, all the parameters of
-the function will be used as arguments or options of the command:
+When creating a function that will be used as a task, all the parameters of
+the function will be used as arguments or options:
 
 ```php
 use Castor\Attribute\AsTask;
@@ -9,7 +9,7 @@ use Castor\Attribute\AsTask;
 use function Castor\run;
 
 #[AsTask]
-function command(
+function task(
     string $firstArg,
     string $secondArg
 ) {
@@ -20,7 +20,7 @@ function command(
 Which can be called like that:
 
 ```bash
-$ castor command foo bar
+$ castor task foo bar
 foo bar
 ```
 
@@ -34,7 +34,7 @@ use Castor\Attribute\AsTask;
 use function Castor\run;
 
 #[AsTask]
-function command(
+function task(
     string $firstArg,
     string $default = 'default'
 ) {
@@ -43,9 +43,9 @@ function command(
 ```
 
 ```bash
-$ castor command foo
+$ castor task foo
 foo default
-$ castor command --default=bar foo
+$ castor task --default=bar foo
 foo bar
 ```
 

--- a/doc/05-context.md
+++ b/doc/05-context.md
@@ -1,11 +1,11 @@
 # Context
 
-For every command that Castor run, it uses a `Context` object. This object
+For every task that Castor run, it uses a `Context` object. This object
 contains the default values for the `run` or `watch` function (directory,
 environment variables, pty, tty, etc...).
 
 It also contains custom values that can be set by the user and reused in
-commands.
+tasks.
 
 The context is immutable, which means that every time you change a value, a new
 context is created.
@@ -90,7 +90,7 @@ function foo(): void
 }
 ```
 
-By default the `foo` command will not print anything as the `FOO` environment
+By default the `foo` task will not print anything as the `FOO` environment
 variable is not set. If you want to use your new context you can use
 the `--context` option:
 
@@ -110,7 +110,7 @@ BAR
 
 ## Setting a default context
 
-You may want to set a default context for all your commands. You can do that by
+You may want to set a default context for all your tasks. You can do that by
 setting the `default` argument to `true` in the `AsContext` attribute:
 
 ```php

--- a/doc/going-further/console-and-io.md
+++ b/doc/going-further/console-and-io.md
@@ -68,5 +68,5 @@ object.
 ## The `task()` function
 
 Castor provides the `task()` to access the current
-[`Command`](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Console/Command/Command.php)
+[`Symfony Command`](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Console/Command/Command.php)
 object that powers your current task.

--- a/doc/going-further/log.md
+++ b/doc/going-further/log.md
@@ -15,7 +15,7 @@ castor -vvv # display level "debug" and above
 ```
 
 When an error occurs, the error message is displayed and the program exits. If
-you need more information, you can re-run the command with the `-v` option.
+you need more information, you can re-run the task with the `-v` option.
 
 ## The `log()` function
 

--- a/doc/going-further/repack.md
+++ b/doc/going-further/repack.md
@@ -33,4 +33,4 @@ vendor/bin/castor repack --help
 > [!NOTE]
 > Castor will automatically import all files in the current directly.
 > So ensure to have the less files possible in the directory where you run the
-> repack command to avoid including useless files in the phar.
+> repack task to avoid including useless files in the phar.

--- a/doc/going-further/wait-for.md
+++ b/doc/going-further/wait-for.md
@@ -53,7 +53,7 @@ wait_for(
 
 > [!NOTE]
 > you can also return null if you want to abort the waiting process. The
-> helper will throw an exception if the callback returns null.
+> function will throw an exception if the callback returns null.
 
 ### The `wait_for_port()` function
 

--- a/examples/fingerprint.php
+++ b/examples/fingerprint.php
@@ -52,7 +52,7 @@ function task_with_a_fingerprint_and_force(
             run('echo "Cool, no fingerprint! Executing..."');
         },
         fingerprint: my_fingerprint_check(),
-        force: $force // This option will force the command to run even if the fingerprint has not changed
+        force: $force // This option will force the task to run even if the fingerprint has not changed
     );
 
     run('echo "Cool! I finished!"');

--- a/examples/output.php
+++ b/examples/output.php
@@ -12,7 +12,7 @@ function output(): void
 {
     io()->title('This is a title');
 
-    io()->text(sprintf('This is the command "%s"', task()->getName()));
+    io()->text(sprintf('This is the task "%s"', task()->getName()));
 
     io()->comment('With IO, you can ask questions ...');
     $value = io()->ask('Tell me something');

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -174,7 +174,7 @@ class Application extends SymfonyApplication
         if (class_exists(\RepackedApplication::class)) {
             $functionsRootDir = \RepackedApplication::ROOT_DIR;
         }
-        // Find all potential commands / context
+
         $functions = $this->functionFinder->findFunctions($functionsRootDir);
         $tasks = [];
         foreach ($functions as $function) {

--- a/src/Console/Command/TaskCommand.php
+++ b/src/Console/Command/TaskCommand.php
@@ -36,12 +36,12 @@ class TaskCommand extends Command implements SignalableCommandInterface
         $this->setDescription($taskAttribute->description);
         $this->setAliases($taskAttribute->aliases);
 
-        $commandName = $taskAttribute->name;
+        $taskName = $taskAttribute->name;
         if ($taskAttribute->namespace) {
-            $commandName = $taskAttribute->namespace . ':' . $commandName;
+            $taskName = $taskAttribute->namespace . ':' . $taskName;
         }
 
-        parent::__construct($commandName);
+        parent::__construct($taskName);
     }
 
     /**
@@ -73,20 +73,20 @@ class TaskCommand extends Command implements SignalableCommandInterface
     protected function configure(): void
     {
         foreach ($this->function->getParameters() as $parameter) {
-            $commandArgumentAttribute = $parameter->getAttributes(AsCommandArgument::class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
+            $taskArgumentAttribute = $parameter->getAttributes(AsCommandArgument::class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
 
-            if ($commandArgumentAttribute) {
-                $commandArgumentAttribute = $commandArgumentAttribute->newInstance();
+            if ($taskArgumentAttribute) {
+                $taskArgumentAttribute = $taskArgumentAttribute->newInstance();
             } elseif ($parameter->isOptional()) {
-                $commandArgumentAttribute = new AsOption();
+                $taskArgumentAttribute = new AsOption();
             } else {
-                $commandArgumentAttribute = new AsArgument();
+                $taskArgumentAttribute = new AsArgument();
             }
 
-            $name = $this->setParameterName($parameter, $commandArgumentAttribute->name);
+            $name = $this->setParameterName($parameter, $taskArgumentAttribute->name);
 
             try {
-                if ($commandArgumentAttribute instanceof AsArgument) {
+                if ($taskArgumentAttribute instanceof AsArgument) {
                     if ($parameter->isOptional()) {
                         $mode = InputArgument::OPTIONAL;
                     } else {
@@ -99,12 +99,12 @@ class TaskCommand extends Command implements SignalableCommandInterface
                     $this->addArgument(
                         $name,
                         $mode,
-                        $commandArgumentAttribute->description,
+                        $taskArgumentAttribute->description,
                         $parameter->isOptional() ? $parameter->getDefaultValue() : null,
-                        $commandArgumentAttribute->suggestedValues,
+                        $taskArgumentAttribute->suggestedValues,
                     );
-                } elseif ($commandArgumentAttribute instanceof AsOption) {
-                    $mode = $commandArgumentAttribute->mode;
+                } elseif ($taskArgumentAttribute instanceof AsOption) {
+                    $mode = $taskArgumentAttribute->mode;
                     $defaultValue = $parameter->isOptional() ? $parameter->getDefaultValue() : null;
 
                     if (!$mode) {
@@ -119,15 +119,15 @@ class TaskCommand extends Command implements SignalableCommandInterface
 
                     $this->addOption(
                         $name,
-                        $commandArgumentAttribute->shortcut,
+                        $taskArgumentAttribute->shortcut,
                         $mode,
-                        $commandArgumentAttribute->description,
+                        $taskArgumentAttribute->description,
                         $defaultValue,
-                        $commandArgumentAttribute->suggestedValues,
+                        $taskArgumentAttribute->suggestedValues,
                     );
                 }
             } catch (LogicException $e) {
-                throw new \LogicException(sprintf('The argument "%s" for command "%s" cannot be configured: "%s".', $parameter->getName(), $this->getName(), $e->getMessage()));
+                throw new \LogicException(sprintf('The argument "%s" for task "%s" cannot be configured: "%s".', $parameter->getName(), $this->getName(), $e->getMessage()));
             }
         }
     }

--- a/src/Context.php
+++ b/src/Context.php
@@ -9,7 +9,7 @@ class Context implements \ArrayAccess
     /**
      * @phpstan-param ContextData $data The input parameter accepts an array or an Object
      *
-     * @param array<string, string|\Stringable|int> $environment A list of environment variables to add to the command
+     * @param array<string, string|\Stringable|int> $environment A list of environment variables to add to the task
      */
     public function __construct(
         public readonly array $data = [],

--- a/src/HasherHelper.php
+++ b/src/HasherHelper.php
@@ -119,13 +119,13 @@ class HasherHelper
 
     public function writeTaskName(): self
     {
-        $commandName = $this->application->getCommand()->getName() ?? 'n/a';
+        $taskName = $this->application->getCommand()->getName() ?? 'n/a';
 
         $this->logger->debug('Hashing task name "{name}".', [
-            'name' => $commandName,
+            'name' => $taskName,
         ]);
 
-        hash_update($this->hashContext, $commandName);
+        hash_update($this->hashContext, $taskName);
 
         return $this;
     }

--- a/tests/Examples/Generated/NoConfigUnknownTest.php
+++ b/tests/Examples/Generated/NoConfigUnknownTest.php
@@ -6,10 +6,10 @@ use Castor\Tests\TaskTestCase;
 
 class NoConfigUnknownTest extends TaskTestCase
 {
-    // unknown:command
+    // unknown:task
     public function test(): void
     {
-        $process = $this->runTask(['unknown:command'], '/tmp');
+        $process = $this->runTask(['unknown:task'], '/tmp');
 
         $this->assertSame(1, $process->getExitCode());
         $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());

--- a/tests/Examples/Generated/NoConfigUnknownWithArgsTest.php
+++ b/tests/Examples/Generated/NoConfigUnknownWithArgsTest.php
@@ -6,10 +6,10 @@ use Castor\Tests\TaskTestCase;
 
 class NoConfigUnknownWithArgsTest extends TaskTestCase
 {
-    // unknown:command
+    // unknown:task
     public function test(): void
     {
-        $process = $this->runTask(['unknown:command', 'toto', '--foo', 1], '/tmp');
+        $process = $this->runTask(['unknown:task', 'toto', '--foo', 1], '/tmp');
 
         $this->assertSame(1, $process->getExitCode());
         $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());

--- a/tests/Examples/Generated/OutputOutputTest.php.output.txt
+++ b/tests/Examples/Generated/OutputOutputTest.php.output.txt
@@ -2,7 +2,7 @@
 This is a title
 ===============
 
- This is the command "output:output"
+ This is the task "output:output"
 
  // With IO, you can ask questions ...                                                                                  
 


### PR DESCRIPTION
Fix issue https://github.com/jolicode/castor/issues/231

I went with the following approach:
- Castor is a **task** runner, providing built-in **helper** functions for common task logics. (Reasoning: `run()` is a helper the same way `with()` is, provided functions are not necessarily **commands**)
-  **Commands** are what the `run()` helper is running, processes are the result of running a command.
- ~~Avoid using **function** broader term when really it's about castor built-in **helpers**~~

I'm still unsure how to rename the internal `TaskCommand`, `RepackCommand` etc. Because they are in essence Symfony command but are displayed alongside other tasks when doing `bin/castor`.

**Todo**:
- [x] Settle on internal naming for "Command" class when using Symfony Command class ( `TaskCommand`, `RepackCommand`, etc.)
- [x] List the BC Breaks (there's none)
