### PR TITLE
Add command to build standalone binary

### DIFF
--- a/.github/actions/phar/action.yaml
+++ b/.github/actions/phar/action.yaml
@@ -18,19 +18,19 @@ runs:
       shell: bash
       working-directory: tools/phar
 
-    - name: Compile phar Linux
+    - name: Build Castor phar for Linux
       run: bin/castor castor:phar:linux
       shell: bash
 
-    - name: Compile phar Darwin
+    - name: Build Castor phar for Darwin
       run: bin/castor castor:phar:darwin
       shell: bash
 
-    - name: Compile phar Windows
+    - name: Build Castor phar for Windows
       run: bin/castor castor:phar:windows
       shell: bash
 
-    - name: Ensure PHAR is OK
+    - name: Ensure phar is OK
       run: build/castor.linux-amd64.phar --version
       shell: bash
       working-directory: tools/phar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,33 @@ jobs:
           REQUIRE_DEV: true
 
   phpunit:
-    name: "PHPUnit on ${{ matrix.php }} ${{ matrix.phar && '(with phar)' || '' }}"
+    name: "PHPUnit on ${{ matrix.php }} | Castor from ${{ matrix.castor.method }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php: [ "8.1", "8.2", "8.3" ]
-        phar: [ false ]
         include:
           - php: "8.1"
-            phar: true
+            castor:
+              bin: 'bin/castor'
+              method: 'bin/castor'
+          - php: "8.1"
+            castor:
+              bin: 'tools/phar/build/castor.linux-amd64.phar'
+              method: 'phar'
+          - php: "8.1"
+            castor:
+              bin: 'castor'
+              method: 'binary'
+          - php: "8.2"
+            castor:
+              bin: 'bin/castor'
+              method: 'bin/castor'
+          - php: "8.3"
+            castor:
+              bin: 'bin/castor'
+              method: 'bin/castor'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,10 +79,25 @@ jobs:
         run: composer install --prefer-dist --no-progress --optimize-autoloader --classmap-authoritative
         working-directory: tools/phar
 
-      - name: Compile phar Linux
+      - name: Build Castor phar for Linux
         run: bin/castor castor:phar:linux
         shell: bash
-        if: matrix.phar
+        if: matrix.castor.method == 'phar' || matrix.castor.method == 'binary'
+
+      - name: Restore PHP static building artifacts cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /home/runner/.cache/castor/castor-php-static-compiler
+          # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          key: dynamic-key-${{ github.run_id }}
+          restore-keys: |
+            php-static-building-artifacts-cache-
+
+      - name: Compile Custom Built PHP along Castor phar for Linux
+        run: bin/castor compile tools/phar/build/castor.linux-amd64.phar --php-extensions=mbstring,phar,posix,tokenizer,pcntl
+        shell: bash
+        if: matrix.castor.method == 'binary'
 
       - name: Link box
         run: sudo ln -s $GITHUB_WORKSPACE/tools/phar/vendor/bin/box /usr/local/bin/box
@@ -76,10 +108,23 @@ jobs:
       - name: Run tests
         run: vendor/bin/simple-phpunit
         env:
-          CASTOR_BIN: ${{ github.workspace }}/${{ matrix.phar && 'tools/phar/build/castor.linux-amd64.phar' || 'bin/castor'}}
+          CASTOR_BIN: ${{ github.workspace }}/${{ matrix.castor.bin }}
+
+      # Workaround because hashFiles() can only include files inside the GITHUB_WORKSPACE
+      - name: Generate PHP static building artifacts cache key
+        run: echo "php_build_artifact_cache_key=$(find /home/runner/.cache/castor/castor-php-static-compiler -type f -exec md5sum {} + | sort -k 2 | md5sum | awk '{print $1}')" >> $GITHUB_ENV
+
+      - name: Save PHP static building artifacts cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /home/runner/.cache/castor/castor-php-static-compiler
+          key: php-static-building-artifacts-cache-${{ env.php_build_artifact_cache_key }}
+        # Cache outputs from the "binary" job specifically, as it generates an additional PHP build not produced by other jobs
+        if: matrix.castor.method == 'binary'
 
   phar:
-    name: Ensure PHAR is OK
+    name: Ensure phar is OK
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Set the process title according to the current application name and task name
 * Ignore some low level env vars in runnable command showed in logs
 * Fix section output to work on Windows
+* Add a `compile` command that puts together a customizable PHP binary with a repacked castor app into one executable file
 
 ## 0.12.1 (2024-02-06)
 

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -63,6 +63,7 @@ $taskFilterList = [
     'log:with-context',
     'parallel:sleep',
     'repack',
+    'compile',
     'run:ls',
     'run:run-parallel',
 ];

--- a/doc/going-further/compile.md
+++ b/doc/going-further/compile.md
@@ -1,0 +1,57 @@
+# Compiling your application into a standalone binary
+
+[Packing your Castor application as a phar](repack.md) can be a good way to easily
+share and use it in various environments.
+
+However, you need to ensure that PHP is installed and configured correctly in all
+the environments where you want to use your Castor app. 
+This can be a hassle, especially if you don't have control over the environments.
+
+To make things simpler, Castor's `compile` command can help by creating a
+customizable PHP binary with a phar, making one executable file that can be used in any setting. 
+
+Just pass your repacked Castor app phar as an argument of this command.
+
+## Pre-requisites
+
+Follow the [`repack` documentation](repack.md) to produce a phar of your
+Castor app.
+
+## Running the Compile Command
+
+To compile your Castor application, navigate to your project directory and run:
+
+```bash
+vendor/bin/castor compile my-custom-castor-app.phar
+```
+
+> [!WARNING]
+> Compiling is not supported yet on Windows.
+
+### Options
+
+Make sure to take a look at the command description to see all the available options:
+```bash
+vendor/bin/castor compile --help
+```
+
+### Behavior
+
+The `compile` command performs several steps:
+
+1. Downloads or uses an existing [Static PHP CLI tool](https://github.com/crazywhalecc/static-php-cli) to compile PHP and the phar into a binary.
+2. If required, it automatically installs dependencies and compiles PHP with the specified extensions.
+3. Combines the compiled PHP and your phar file into a single executable.
+
+## Post-Compilation
+
+Once the compilation is finished, your Castor application is transformed into a standalone binary named `castor` by default (you can use the `--output` option to change it). 
+
+This binary is now ready to be distributed and run in environments that do not have PHP installed. 
+
+You can simply run it like any other executable:
+
+```bash
+./castor
+```
+

--- a/doc/going-further/index.md
+++ b/doc/going-further/index.md
@@ -25,6 +25,7 @@
 
 * [Listening to events](events.md)
 * [Repacking your application in a new phar](repack.md)
+* [Compiling your application in a standalone binary](compile.md)
 
 ## Examples
 

--- a/doc/going-further/repack.md
+++ b/doc/going-further/repack.md
@@ -3,6 +3,8 @@
 You have created a Castor application, with many tasks, and you want to
 distribute it as a single phar file? Castor can help you with that.
 
+## Pre-requisites
+
 In your project, install Castor as a dependency:
 
 ```bash
@@ -17,6 +19,8 @@ You'll also need to ensure the phar creation is allowed by your PHP
 configuration. See the [PHP
 documentation](https://www.php.net/manual/en/phar.configuration.php#ini.phar.readonly) to disabled
 `phar.readonly`.
+
+## Running the Repack Command
 
 Then, run the repack command to create the new phar:
 
@@ -34,3 +38,9 @@ vendor/bin/castor repack --help
 > Castor will automatically import all files in the current directly.
 > So ensure to have the less files possible in the directory where you run the
 > repack task to avoid including useless files in the phar.
+
+## Going further
+
+Packaging your Castor app as a phar simplifies distribution but requires PHP setup on target systems. 
+
+[Castor's `compile` command](compile.md) streamlines this by embedding the phar in a PHP binary, creating a standalone executable for diverse environments.

--- a/examples/failure.php
+++ b/examples/failure.php
@@ -9,7 +9,7 @@ use function Castor\run;
 #[AsTask(description: 'A failing task not authorized to fail')]
 function failure(): void
 {
-    run('i_do_not_exist', path: '/tmp');
+    run('i_do_not_exist', path: '/tmp', pty: false);
 }
 
 #[AsTask(description: 'A failing task authorized to fail')]

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -2,6 +2,7 @@
 
 namespace Castor\Console;
 
+use Castor\Console\Command\CompileCommand;
 use Castor\Console\Command\DebugCommand;
 use Castor\Console\Command\RepackCommand;
 use Castor\ContextRegistry;
@@ -45,6 +46,7 @@ class ApplicationFactory
         $cacheDir = PlatformUtil::getCacheDirectory();
         $cache = new FilesystemAdapter(directory: $cacheDir);
         $logger = new Logger('castor', [], [new ProcessProcessor()]);
+        $fs = new Filesystem();
 
         /** @var SymfonyApplication */
         // @phpstan-ignore-next-line
@@ -56,7 +58,7 @@ class ApplicationFactory
             new ExpressionLanguage($contextRegistry),
             new StubsGenerator($logger),
             $logger,
-            new Filesystem(),
+            $fs,
             $httpClient,
             $cache,
             new WaitForHelper($httpClient, $logger),
@@ -67,6 +69,7 @@ class ApplicationFactory
 
         if (!class_exists(\RepackedApplication::class)) {
             $application->add(new RepackCommand());
+            $application->add(new CompileCommand($httpClient, $fs));
         }
 
         return $application;

--- a/src/Console/Command/CompileCommand.php
+++ b/src/Console/Command/CompileCommand.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Castor\Console\Command;
+
+use Castor\PathHelper;
+use Castor\PlatformUtil;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @internal
+ */
+class CompileCommand extends Command
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly Filesystem $fs
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('compile')
+            ->addArgument('phar-path', InputArgument::REQUIRED, 'Path to phar to compile along PHP')
+            ->addOption('output', null, InputOption::VALUE_REQUIRED, 'Compiled standalone binary output filepath', PathHelper::getRoot() . '/castor')
+            ->addOption('os', null, InputOption::VALUE_REQUIRED, 'Target OS for PHP compilation', 'linux', ['linux', 'macos'])
+            ->addOption('arch', null, InputOption::VALUE_REQUIRED, 'Target architecture for PHP compilation', 'x86_64', ['x86_64', 'aarch64'])
+            ->addOption('php-version', null, InputOption::VALUE_REQUIRED, 'PHP version in major.minor format', '8.3')
+            ->addOption('php-extensions', null, InputOption::VALUE_REQUIRED, 'PHP extensions required, in a comma-separated format. Defaults are the minimum required to run a basic "Hello World" task in Castor.', 'mbstring,phar,posix,tokenizer')
+            ->addOption('php-rebuild', null, InputOption::VALUE_NONE, 'Ignore cache and force PHP build compilation.')
+            ->setHidden(true)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $os = $input->getOption('os');
+        if (!\in_array($os, ['linux', 'macos'])) {
+            throw new \InvalidArgumentException('Currently supported target OS are one of "linux" or "macos"');
+        }
+
+        $arch = $input->getOption('arch');
+        if (!\in_array($arch, ['x86_64', 'aarch64'])) {
+            throw new \InvalidArgumentException('Target architecture must be one of "x86_64" or "aarch64"');
+        }
+
+        $io = new SymfonyStyle($input, $output);
+        $io->section('Compiling PHP and your Castor app phar into a standalone binary');
+
+        $phpBuildCacheKey = $this->generatePHPBuildCacheKey($input);
+
+        $spcBinaryPath = PlatformUtil::getCacheDirectory() . '/castor-php-static-compiler/' . $phpBuildCacheKey . '/spc';
+        $spcBinaryDir = \dirname($spcBinaryPath);
+
+        $this->setupSPC(
+            $spcBinaryDir,
+            $spcBinaryPath,
+            $io,
+            $os,
+            $arch,
+            $output
+        );
+
+        if (!$this->fs->exists($spcBinaryDir . '/buildroot/bin/micro.sfx') || $input->getOption('php-rebuild')) {
+            $this->installPHPBuildTools($spcBinaryPath, $spcBinaryDir, $io);
+
+            $phpExtensions = $input->getOption('php-extensions');
+
+            $this->downloadPHPSourceDeps(
+                $spcBinaryPath,
+                $phpExtensions,
+                $input->getOption('php-version'),
+                $spcBinaryDir,
+                $io
+            );
+
+            $this->buildPHP(
+                $spcBinaryPath,
+                $phpExtensions,
+                $arch,
+                $spcBinaryDir,
+                $io
+            );
+        }
+
+        $this->mergePHPandPHARIntoSingleExecutable(
+            $spcBinaryPath,
+            $input->getArgument('phar-path'),
+            $input->getOption('output'),
+            $spcBinaryDir,
+            $io
+        );
+
+        return Command::SUCCESS;
+    }
+
+    private function downloadSPC(string $spcSourceUrl, string $spcBinaryDestination, SymfonyStyle $io): void
+    {
+        $response = $this->httpClient->request('GET', $spcSourceUrl);
+        $contentLength = $response->getHeaders()['content-length'][0] ?? 0;
+
+        $outputStream = fopen($spcBinaryDestination, 'w');
+        $progressBar = $io->createProgressBar((int) $contentLength);
+
+        if (false === $outputStream) {
+            throw new \RuntimeException(sprintf('Failed to open file "%s" for writing.', $spcBinaryDestination));
+        }
+
+        foreach ($this->httpClient->stream($response) as $chunk) {
+            fwrite($outputStream, $chunk->getContent());
+            $progressBar->advance(\strlen($chunk->getContent()));
+        }
+
+        fclose($outputStream);
+        chmod($spcBinaryDestination, 0o755);
+
+        $progressBar->finish();
+    }
+
+    private function installPHPBuildTools(string $spcBinaryPath, string $spcBinaryDir, SymfonyStyle $io): void
+    {
+        $installSPCDepsProcess = new Process(
+            command: [$spcBinaryPath, 'doctor', '--auto-fix'],
+            cwd: $spcBinaryDir,
+            timeout: null,
+        );
+        $io->text('Running command: ' . $installSPCDepsProcess->getCommandLine());
+        $installSPCDepsProcess->mustRun(fn ($type, $buffer) => print $buffer);
+    }
+
+    private function downloadPHPSourceDeps(string $spcBinaryPath, mixed $phpExtensions, mixed $phpVersion, string $spcBinaryDir, SymfonyStyle $io): void
+    {
+        $downloadProcess = new Process(
+            command: [
+                $spcBinaryPath, 'download',
+                '--for-extensions=' . $phpExtensions,
+                '--with-php=' . $phpVersion,
+            ],
+            cwd: $spcBinaryDir,
+            timeout: null,
+        );
+        $io->text('Running command: ' . $downloadProcess->getCommandLine());
+        $downloadProcess->mustRun(fn ($type, $buffer) => print $buffer);
+    }
+
+    private function buildPHP(string $spcBinaryPath, mixed $phpExtensions, mixed $arch, string $spcBinaryDir, SymfonyStyle $io): void
+    {
+        $buildProcess = new Process(
+            command: [
+                $spcBinaryPath, 'build', $phpExtensions,
+                '--build-micro',
+                '--with-micro-fake-cli',
+                '--arch=' . $arch,
+            ],
+            cwd: $spcBinaryDir,
+            timeout: null,
+        );
+        $io->text('Running command: ' . $buildProcess->getCommandLine());
+        $buildProcess->mustRun(fn ($type, $buffer) => print $buffer);
+    }
+
+    private function mergePHPandPHARIntoSingleExecutable(string $spcBinaryPath, string $pharFilePath, string $appBinaryFilePath, string $spcBinaryDir, SymfonyStyle $io): void
+    {
+        if (!$this->fs->isAbsolutePath($pharFilePath)) {
+            $pharFilePath = PathHelper::getRoot() . '/' . $pharFilePath;
+        }
+
+        $mergePHPandPHARProcess = new Process(
+            [
+                $spcBinaryPath,
+                'micro:combine', $pharFilePath,
+                '--output=' . $appBinaryFilePath,
+            ],
+            cwd: $spcBinaryDir,
+            timeout: null,
+        );
+
+        $io->text('Running command: ' . $mergePHPandPHARProcess->getCommandLine());
+        $mergePHPandPHARProcess->mustRun(fn ($type, $buffer) => print $buffer);
+    }
+
+    private function setupSPC(string $spcBinaryDir, string $spcBinaryPath, SymfonyStyle $io, mixed $os, mixed $arch, OutputInterface $output): void
+    {
+        $this->fs->mkdir($spcBinaryDir, 0o755);
+
+        if ($this->fs->exists($spcBinaryPath)) {
+            $io->text(sprintf('Using the static-php-cli (spc) tool from "%s"', $spcBinaryPath));
+        } else {
+            $spcSourceUrl = sprintf('https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-%s-%s', $os, $arch);
+            $io->text(sprintf('Downloading the static-php-cli (spc) tool from "%s" to "%s"', $spcSourceUrl, $spcBinaryPath));
+            $this->downloadSPC($spcSourceUrl, $spcBinaryPath, $io);
+            $io->newLine(2);
+        }
+    }
+
+    private function generatePHPBuildCacheKey(InputInterface $input): string
+    {
+        $keyComponents = [];
+
+        foreach (['os', 'arch', 'php-version'] as $phpBuildOption) {
+            $keyComponents[$phpBuildOption] = $input->getOption($phpBuildOption);
+        }
+
+        $phpExtensions = explode(',', $input->getOption('php-extensions'));
+        sort($phpExtensions);
+
+        $keyComponents['php-extensions'] = $phpExtensions;
+
+        $keyComponents['compile-command'] = hash_file('md5', __FILE__);
+
+        return md5(serialize($keyComponents));
+    }
+}

--- a/src/Console/Command/RepackCommand.php
+++ b/src/Console/Command/RepackCommand.php
@@ -22,7 +22,7 @@ class RepackCommand extends Command
             ->setName('repack')
             ->addOption('app-name', null, InputOption::VALUE_REQUIRED, 'The name of the phar application', 'my-app')
             ->addOption('app-version', null, InputOption::VALUE_REQUIRED, 'The version of the phar application', '1.0.0')
-            ->addOption('os', null, InputOption::VALUE_REQUIRED, 'The targeted OS', 'linux', ['linux', 'macos', 'windows'])
+            ->addOption('os', null, InputOption::VALUE_REQUIRED, 'The targeted OS', 'linux', ['linux', 'darwin', 'windows'])
             ->setHidden(true)
         ;
     }
@@ -34,8 +34,8 @@ class RepackCommand extends Command
         }
 
         $os = $input->getOption('os');
-        if (!\in_array($os, ['linux', 'macos', 'windows'])) {
-            throw new \RuntimeException('The os option must be one of linux, macos or windows.');
+        if (!\in_array($os, ['linux', 'darwin', 'windows'])) {
+            throw new \InvalidArgumentException('The os option must be one of linux, darwin or windows.');
         }
 
         $finder = new ExecutableFinder();
@@ -89,7 +89,7 @@ class RepackCommand extends Command
                 ),
             ];
         }
-        // add all files from the FunctionFinder, this is usefull if the file
+        // add all files from the FunctionFinder, this is useful if the file
         // are in a hidden directory, because it's not included by default by
         // box
         $boxConfig['files'] = [
@@ -106,7 +106,7 @@ class RepackCommand extends Command
         $process = new Process([$box, 'compile', '--config=.box.json']);
 
         try {
-            $process->mustRun(fn ($type, $buffer) => print ($buffer));
+            $process->mustRun(fn ($type, $buffer) => print $buffer);
         } finally {
             unlink('.box.json');
             unlink('.main.php');

--- a/tests/CompileCommandTest.php
+++ b/tests/CompileCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Castor\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class CompileCommandTest extends TestCase
+{
+    /**
+     * @group test
+     */
+    public function test()
+    {
+        $castorAppDirPath = RepackCommandTest::setupRepackedCastorApp('castor-test-compile');
+
+        (new Process(
+            [
+                'vendor/jolicode/castor/bin/castor',
+                'repack',
+                '--os', 'linux',
+            ],
+            cwd: $castorAppDirPath)
+        )->mustRun();
+
+        $binary = $castorAppDirPath . '/castor';
+
+        (new Process(
+            [
+                'vendor/jolicode/castor/bin/castor',
+                'compile', $castorAppDirPath . '/my-app.linux.phar',
+                '--os', 'linux',
+                '--output', $binary,
+                '--php-extensions', 'mbstring,phar,posix,tokenizer',
+                '-vvv',
+            ],
+            cwd: $castorAppDirPath,
+            timeout: 5 * 60)
+        )->mustRun();
+
+        $this->assertFileExists($binary);
+
+        (new Process([$binary], cwd: $castorAppDirPath))->mustRun();
+
+        $p = (new Process([$binary, 'hello'], cwd: $castorAppDirPath))->mustRun();
+        $this->assertSame('hello', $p->getOutput());
+
+        // Twice, because we want to be sure the phar is not corrupted after a
+        // run
+        $p = (new Process([$binary, 'hello'], cwd: $castorAppDirPath))->mustRun();
+        $this->assertSame('hello', $p->getOutput());
+    }
+}

--- a/tests/Examples/Generated/FailureFailureTest.php.err.txt
+++ b/tests/Examples/Generated/FailureFailureTest.php.err.txt
@@ -1,3 +1,4 @@
+sh: 1: i_do_not_exist: not found
 
 In failure.php line 12:
                                         

--- a/tests/Examples/Generated/FailureFailureTest.php.output.txt
+++ b/tests/Examples/Generated/FailureFailureTest.php.output.txt
@@ -1,1 +1,0 @@
-sh: 1: i_do_not_exist: not found

--- a/tests/TaskTestCase.php
+++ b/tests/TaskTestCase.php
@@ -17,13 +17,14 @@ abstract class TaskTestCase extends TestCase
     {
         $coverage = $this->getTestResultObject()?->getCodeCoverage();
 
-        $bin = $_SERVER['CASTOR_BIN'] ?? __DIR__ . '/../bin/castor';
+        $castorBin = $_SERVER['CASTOR_BIN'] ?? __DIR__ . '/../bin/castor';
+
         $extraEnv = [
             'ENDPOINT' => $_SERVER['ENDPOINT'],
         ];
 
         if ($coverage) {
-            $bin = __DIR__ . '/bin/castor';
+            $castorBin = __DIR__ . '/bin/castor';
             $testName = debug_backtrace()[1]['class'] . '::' . debug_backtrace()[1]['function'];
             $outputFilename = stream_get_meta_data(tmpfile())['uri'];
             $extraEnv = [
@@ -33,7 +34,7 @@ abstract class TaskTestCase extends TestCase
         }
 
         $process = new Process(
-            [\PHP_BINARY, $bin, '--no-ansi', ...$args],
+            [$castorBin, '--no-ansi', ...$args],
             cwd: $cwd ?? __DIR__ . '/..',
             env: [
                 'COLUMNS' => 120,

--- a/tools/php-cs-fixer/composer.lock
+++ b/tools/php-cs-fixer/composer.lock
@@ -1047,16 +1047,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
                 "shasum": ""
             },
             "require": {
@@ -1070,9 +1070,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -1109,7 +1106,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -1125,20 +1122,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "875e90aeea2777b6f135677f618529449334a612"
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
-                "reference": "875e90aeea2777b6f135677f618529449334a612",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/32a9da87d7b3245e09ac426c83d334ae9f06f80f",
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f",
                 "shasum": ""
             },
             "require": {
@@ -1149,9 +1146,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -1190,7 +1184,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -1206,20 +1200,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/bc45c394692b948b4d383a08d7753968bed9a83d",
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d",
                 "shasum": ""
             },
             "require": {
@@ -1230,9 +1224,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -1274,7 +1265,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -1290,20 +1281,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "42292d99c55abe617799667f454222c54c60e229"
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
-                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
                 "shasum": ""
             },
             "require": {
@@ -1317,9 +1308,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -1357,7 +1345,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -1373,20 +1361,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-28T09:04:16+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
                 "shasum": ""
             },
             "require": {
@@ -1394,9 +1382,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -1440,7 +1425,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -1456,20 +1441,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b"
+                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/7581cd600fa9fd681b797d00b02f068e2f13263b",
-                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/c565ad1e63f30e7477fc40738343c62b40bc672d",
+                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d",
                 "shasum": ""
             },
             "require": {
@@ -1477,9 +1462,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -1519,7 +1501,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -1535,7 +1517,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/process",


### PR DESCRIPTION
Fixes #257 

I've added a `compile` command, similar to `repack`. Because compiling statically also means repacking the app, I've reused the `repack` command options into `compile` and set it to automatically run at the start of the compilation process.

All the files needed to build the final binary are stored in `/tmp/castor-php-static-compiler` folder and cached in the CI with a cache key based on `src/Console/Command/CompileCommand.php` and `tests/CompileCommandTest.php`.

Since this process includes downloading and building PHP source, it's no surprise that the test suite runs 3 minutes slower when cache is not warm. Fortunately, it will happen only when `src/Console/Command/CompileCommand.php` or `tests/CompileCommandTest.php` is modified and thus have a very minimal impact overall.

Here's the `compile -h` output for reference:
```
Usage:
  compile [options]

Options:
      --app-name=APP-NAME              The name of the phar application [default: "my-app"]
      --app-version=APP-VERSION        The version of the phar application [default: "1.0.0"]
      --os=OS                          The targeted OS [default: "linux"]
      --arch=ARCH                      Target architecture for PHP compilation [default: "x86_64"]
      --php-version=PHP-VERSION        PHP version in major.minor format [default: "8.2"]
      --php-extensions=PHP-EXTENSIONS  PHP extensions required, in a comma-separated format. Defaults are the minimum required to run a basic "Hello World" task in Castor. [default: "mbstring,phar,posix,tokenizer"]
      --php-rebuild                    Force PHP build compilation.
  -h, --help                           Display help for the given command. When no command is given display help for the list command
  -q, --quiet                          Do not output any message
  -V, --version                        Display this application version
      --ansi|--no-ansi                 Force (or disable --no-ansi) ANSI output
  -n, --no-interaction                 Do not ask any interactive question
  -v|vv|vvv, --verbose                 Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
  ```

Here's a cold `php  vendor/bin/castor compile` run output example:

<details> 

```

Executing the repack command to build your Castor app as a PHAR archive.
------------------------------------------------------------------------


    ____
   / __ )____  _  __
  / __  / __ \| |/_/
 / /_/ / /_/ />  <
/_____/\____/_/|_|


Box version 4.6.1@048e634 2023-12-21 12:09:11 UTC

 // Loading the configuration file ".box.json".                                 

🔨  Building the PHAR "/home/psegatori/www/castor-app-as-binary/my-app.linux.phar"

? Removing the existing PHAR "/home/psegatori/www/castor-app-as-binary/my-app.linux.phar"
? Checking Composer compatibility
    > Supported version detected
? Registering compactors
  + KevinGH\Box\Compactor\Php
? Adding main file: /home/psegatori/www/castor-app-as-binary/.main.php
? Skip requirements checker
? Adding binary files
    > 1 file(s)
? Auto-discover files? Yes
? Exclude dev files? Yes
? Adding files
    > 1409 file(s)
? Generating new stub
  - Using shebang line: #!/usr/bin/env php
  - Using banner:
    > Generated by Humbug Box 4.6.1@048e634.
    > 
    > @link https://github.com/humbug/box
? Dumping the Composer autoloader
? Removing the Composer dump artefacts
? Compressing with the algorithm "GZ"
    > Warning: the extension "zlib" will now be required to execute the PHAR
? Setting file permissions to 0755
* Done.

💡  1 recommendation found:
    - The "base-path" setting can be omitted since is set to its default value
⚠️  1 warning found:
    - The "annotations" setting has been set but is ignored since no PHP compactor has been configured

 // PHAR: 1418 files (2.66MB)                                                   
 // You can inspect the generated PHAR with the "info" command.                 

 // Memory usage: 23.62MB (peak: 29.82MB), time: <1sec                          

Compiling PHP and your Castor app PHAR archive into a standalone binary
-----------------------------------------------------------------------

 Using the static-php-cli (spc) tool from "/tmp/castor-php-static-compiler/spc"
 Running command: '/tmp/castor-php-static-compiler/spc' 'doctor' '--auto-fix'
     _        _   _                 _           
 ___| |_ __ _| |_(_) ___      _ __ | |__  _ __  
/ __| __/ _` | __| |/ __|____| '_ \| '_ \| '_ \ 
\__ \ || (_| | |_| | (_|_____| |_) | | | | |_) |
|___/\__\__,_|\__|_|\___|    | .__/|_| |_| .__/   v2.1.0-beta.1
                             |_|         |_|    
Checking if current OS are supported ... Linux x86_64 ubuntu, supported
Checking if necessary tools are installed ... ok
Checking if musl-wrapper is installed ... ok
Checking if musl-cross-make is installed ... ok
Checking if necessary linux headers are installed ... ok
Doctor check complete !
 Running command: '/tmp/castor-php-static-compiler/spc' 'download' '--for-extensions=mbstring,phar,posix,tokenizer' '--with-php=8.2'
     _        _   _                 _           
 ___| |_ __ _| |_(_) ___      _ __ | |__  _ __  
/ __| __/ _` | __| |/ __|____| '_ \| '_ \| '_ \ 
\__ \ || (_| | |_| | (_|_____| |_) | | | | |_) |
|___/\__\__,_|\__|_|\___|    | .__/|_| |_| .__/   v2.1.0-beta.1
                             |_|         |_|    
[11:07:48] [INFO] Fetching source php-src [1/4]
[11:07:48] [NOTI] source [php-src] already downloaded: php-8.2.15.tar.gz
[11:07:48] [INFO] Fetching source micro [2/4]
[11:07:48] [NOTI] source [micro] already downloaded: micro
[11:07:48] [INFO] Fetching source pkg-config [3/4]
[11:07:48] [NOTI] source [pkg-config] already downloaded: pkg-config-0.29.2.tar.gz
[11:07:48] [INFO] Fetching source zlib [4/4]
[11:07:48] [NOTI] source [zlib] already downloaded: zlib-1.3.1.tar.gz
[11:07:48] [INFO] Download complete, used 0.013 s !
 Running command: '/tmp/castor-php-static-compiler/spc' 'build' 'mbstring,phar,posix,tokenizer' '--build-micro' '--arch=x86_64' '-r'
     _        _   _                 _           
 ___| |_ __ _| |_(_) ___      _ __ | |__  _ __  
/ __| __/ _` | __| |/ __|____| '_ \| '_ \| '_ \ 
\__ \ || (_| | |_| | (_|_____| |_) | | | | |_) |
|___/\__\__,_|\__|_|\___|    | .__/|_| |_| .__/   v2.1.0-beta.1
                             |_|         |_|    
[11:07:48] [INFO] [EXEC] echo | x86_64-linux-musl-gcc -E -x c - -march=corei7 2>/dev/null
[11:07:48] [INFO] [EXEC] echo | x86_64-linux-musl-gcc -E -x c - -mtune=core-avx2 2>/dev/null
[11:07:48] [INFO] Build OS:       Linux (x86_64)
[11:07:48] [INFO] Build SAPI:     micro
[11:07:48] [INFO] Extensions (5): mbstring, zlib, phar, posix, tokenizer
[11:07:48] [INFO] Libraries (1):  zlib
[11:07:48] [INFO] Strip Binaries: yes
[11:07:48] [INFO] Enable ZTS:     no
[11:07:48] [WARN] Some extensions will be enabled due to dependencies: zlib
[11:07:48] [INFO] Build will start after 2s ...
[11:07:50] [INFO] Building required library [pkg-config]
[11:07:50] [INFO] Entering dir: /tmp/castor-php-static-compiler/source/pkg-config
[11:07:50] [INFO] [EXEC] LDFLAGS=--static ./configure --disable-shared --enable-static --with-internal-glib --prefix=/tmp/castor-php-static-compiler/buildroot --without-sysroot --without-system-include-path --without-system-library-path --without-pc-path
[11:08:05] [INFO] [EXEC] make clean
[11:08:05] [INFO] [EXEC] make -j20
[11:08:09] [INFO] [EXEC] make install
[11:08:09] [INFO] lib [pkg-config] build success
[11:08:09] [INFO] Building required library [zlib]
[11:08:09] [INFO] Entering dir: /tmp/castor-php-static-compiler/source/zlib
[11:08:09] [INFO] [EXEC] ./configure --static --prefix=
[11:08:09] [INFO] [EXEC] make clean
[11:08:09] [INFO] [EXEC] make -j20
[11:08:10] [INFO] [EXEC] make install DESTDIR=/tmp/castor-php-static-compiler/buildroot
[11:08:10] [INFO] Patching library [zlib] pkgconfig
[11:08:10] [INFO] lib [zlib] build success
[11:08:10] [INFO] Entering dir: /tmp/castor-php-static-compiler/source/php-src
[11:08:10] [INFO] [EXEC] ./buildconf --force
[11:08:12] [INFO] Entering dir: /tmp/castor-php-static-compiler/source/php-src
[11:08:12] [INFO] mbstring is using --enable-mbstring --disable-mbregex
[11:08:12] [INFO] zlib is using --with-zlib --with-zlib-dir="/tmp/castor-php-static-compiler/buildroot"
[11:08:12] [INFO] phar is using --enable-phar 
[11:08:12] [INFO] posix is using --enable-posix 
[11:08:12] [INFO] tokenizer is using --enable-tokenizer 
[11:08:12] [INFO] [EXEC] LD_LIBRARY_PATH=/usr/local/musl/x86_64-linux-musl/lib ./configure --prefix= --with-valgrind=no --enable-shared=no --enable-static=yes --disable-all --disable-cgi --disable-phpdbg --disable-cli --disable-fpm --disable-embed --enable-micro=all-static --enable-mbstring --disable-mbregex --with-zlib --with-zlib-dir="/tmp/castor-php-static-compiler/buildroot" --enable-phar --enable-posix --enable-tokenizer CFLAGS='' CPPFLAGS='-I/tmp/castor-php-static-compiler/buildroot/include' LDFLAGS='-L/tmp/castor-php-static-compiler/buildroot/lib' LIBS='-ldl -lpthread' 
[11:08:25] [INFO] cleaning up
[11:08:25] [INFO] Entering dir: /tmp/castor-php-static-compiler/source/php-src
[11:08:25] [INFO] [EXEC] make clean
[11:08:25] [INFO] building micro
patching file ext/phar/phar.c
[11:08:25] [INFO] Entering dir: /tmp/castor-php-static-compiler/source/php-src
[11:08:25] [INFO] [EXEC] sed -i "s|//lib|/lib|g" Makefile
[11:08:25] [INFO] [EXEC] make -j20 EXTRA_CFLAGS='-g0 -Os -fno-ident -fPIE -Xcompiler -march=corei7 -Xcompiler -mtune=core-avx2' EXTRA_LIBS='/tmp/castor-php-static-compiler/buildroot/lib/libz.a  ' EXTRA_LDFLAGS_PROGRAM=' -all-static' micro
[11:09:00] [INFO] Entering dir: /tmp/castor-php-static-compiler/source/php-src/sapi/micro
[11:09:00] [INFO] [EXEC] strip --strip-all micro.sfx
[11:09:00] [INFO] Deploying micro file
[11:09:00] [INFO] [EXEC] cp '/tmp/castor-php-static-compiler/source/php-src/sapi/micro/micro.sfx' '/tmp/castor-php-static-compiler/buildroot/bin/'
patching file ext/phar/phar.c
[11:09:00] [INFO] [EXEC] /tmp/castor-php-static-compiler/source/hello.exe
[11:09:00] [INFO] Build complete, used 71.625 s !
[11:09:00] [INFO] phpmicro binary path: /tmp/castor-php-static-compiler/buildroot/bin/micro.sfx
[11:09:00] [INFO] License path: /tmp/castor-php-static-compiler/buildroot/license/
 Running command: '/tmp/castor-php-static-compiler/spc' 'micro:combine' '/home/psegatori/www/castor-app-as-binary/my-app.linux.phar' '--output=/home/psegatori/www/castor-app-as-binary/my-app'
     _        _   _                 _           
 ___| |_ __ _| |_(_) ___      _ __ | |__  _ __  
/ __| __/ _` | __| |/ __|____| '_ \| '_ \| '_ \ 
\__ \ || (_| | |_| | (_|_____| |_) | | | | |_) |
|___/\__\__,_|\__|_|\___|    | .__/|_| |_| .__/   v2.1.0-beta.1
                             |_|         |_|    
Combine success! Binary file: /home/psegatori/www/castor-app-as-binary/my-app
```

</details>

TODO:

- [x] Add tests for macos ?
- [x] Add docs