### PR TITLE
Delay AfterApplicationInitializationEvent dispatch after the context setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Edited the duration of update check from `60 days` to `24 hours`
 * Revise the usage of the terms `command` and `task` for consistency through code and docs.
 * [BC Break] Remove `callable $responseChecker` parameter from `wait_for_http_status()`
+* [BC Break] The event `AfterApplicationInitializationEvent` second arguments is now a
+  `TaskDescriptorCollection`, and the event is emitted after the context configuration
 
 ## 0.11.1 (2024-01-11)
 

--- a/src/Event/AfterApplicationInitializationEvent.php
+++ b/src/Event/AfterApplicationInitializationEvent.php
@@ -3,14 +3,13 @@
 namespace Castor\Event;
 
 use Castor\Console\Application;
-use Castor\TaskDescriptor;
+use Castor\TaskDescriptorCollection;
 
 class AfterApplicationInitializationEvent
 {
     public function __construct(
         public readonly Application $application,
-        /** @var array<TaskDescriptor> $tasks */
-        public array &$tasks,
+        public TaskDescriptorCollection $taskDescriptorCollection,
     ) {
     }
 }

--- a/src/TaskDescriptorCollection.php
+++ b/src/TaskDescriptorCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Castor;
+
+class TaskDescriptorCollection
+{
+    /**
+     * @param TaskDescriptor[]        $taskDescriptors
+     * @param SymfonyTaskDescriptor[] $symfonyTaskDescriptors
+     */
+    public function __construct(
+        public readonly array $taskDescriptors,
+        public readonly array $symfonyTaskDescriptors,
+    ) {
+    }
+}


### PR DESCRIPTION
This PR allows such things:

```php
#[\Attribute(\Attribute::TARGET_FUNCTION)]
class AsDeployTask extends AsTask
{
}

#[AsListener(AfterApplicationInitializationEvent::class)]
function scope_tasks(AfterApplicationInitializationEvent $e)
{
    $deployTask = [];
    $regularTasks = [];
    foreach ($e->taskDescriptorCollection->taskDescriptors as $taskDescriptor) {
        if ($taskDescriptor->taskAttribute instanceof AsDeployTask) {
            $deployTask[] = $taskDescriptor;
        } else {
            $regularTasks[] = $taskDescriptor;
        }
    }

    $deploy = variable('deploy', false);
    $e->taskDescriptorCollection = new TaskDescriptorCollection(
        $deploy ? $deployTask : $regularTasks,
        $deploy ? [] : $e->taskDescriptorCollection->symfonyTaskDescriptors,
    );
}
```
