### PR TITLE
Ignore argc & argv env vars in log runnable commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released yet
 
+* Ignore some low level env vars in runnable command showed in logs
+
 ## 0.12.1 (2024-02-06)
 
 * Fix issue with symfony console (color doesn't work in tmux or screen)

--- a/src/Monolog/Processor/ProcessProcessor.php
+++ b/src/Monolog/Processor/ProcessProcessor.php
@@ -32,6 +32,9 @@ class ProcessProcessor implements ProcessorInterface
         $runnable = $process->getCommandLine();
 
         foreach ($process->getEnv() as $key => $value) {
+            if ('argv' === $key || 'argc' === $key) {
+                continue;
+            }
             $runnable = sprintf('%s=%s %s ', $key, escapeshellarg($value), $runnable);
         }
 

--- a/tests/Monolog/Processor/ProcessProcessorTest.php
+++ b/tests/Monolog/Processor/ProcessProcessorTest.php
@@ -12,7 +12,11 @@ class ProcessProcessorTest extends TestCase
 {
     public function test(): void
     {
-        $process = new Process(['ls', '-alh'], '/tmp', ['foo' => 'b\'"`\ar']);
+        $process = new Process(['ls', '-alh'], '/tmp', [
+            'foo' => 'b\'"`\ar',
+            'argc' => 3,
+            'argv' => ['/home/foo/.local/bin//castor', 'builder', '-vvv'],
+        ]);
         $log = new LogRecord(
             datetime: new \DateTimeImmutable(),
             channel: 'test',
@@ -25,7 +29,11 @@ class ProcessProcessorTest extends TestCase
         $this->assertEquals(
             [
                 'cwd' => '/tmp',
-                'env' => ['foo' => 'b\'"`\ar'],
+                'env' => [
+                    'foo' => 'b\'"`\ar',
+                    'argc' => 3,
+                    'argv' => ['/home/foo/.local/bin//castor', 'builder', '-vvv'],
+                ],
                 'runnable' => <<<'TXT'
                     foo='b'\''"`\ar' 'ls' '-alh'
                     TXT,


### PR DESCRIPTION
I don't know yet why it happens now, but I get a failure on a task that worked before. `argv` is an array, so that broke `escapeshellarg`. I guess we should not pass `argc` and `argv` manually so let's remove it from the runnable command in logs.