### PR TITLE
fix(wait_for): Fix `wait_for_http_status` helper throw exception on first response check

### DIFF
--- a/src/WaitForHelper.php
+++ b/src/WaitForHelper.php
@@ -160,12 +160,8 @@ class WaitForHelper
         $this->waitForHttpResponse(
             io: $io,
             url: $url,
-            responseChecker: function (ResponseInterface $response) use ($url, $status) {
-                if ($response->getStatusCode() !== $status) {
-                    throw new ExitedBeforeTimeoutException(sprintf('Response from URL "%s" contained status code "%s". Expected "%s"', $url, $response->getStatusCode(), $status));
-                }
-
-                return true;
+            responseChecker: function (ResponseInterface $response) use ($status) {
+                return $response->getStatusCode() === $status;
             },
             timeout: $timeout,
             quiet: $quiet,
@@ -199,7 +195,12 @@ class WaitForHelper
                         // We return null to break the loop, there is no need to
                         // wait for a timeout, nothing will change at this
                         // point
-                        return $responseChecker($response) ? true : null;
+                        $responseFromChecker = $responseChecker($response);
+                        if (null === $responseFromChecker) {
+                            return null;
+                        }
+
+                        return $responseFromChecker;
                     }
 
                     return true;


### PR DESCRIPTION
Hey

An error occurs after a modification has been made to the verification of HTTP code and responses.

This throws an exception on the first check, so it doesn't wait until a service is up and running and crashes on the first check.

