### PR TITLE
Fix section output to work on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released yet
 
 * Ignore some low level env vars in runnable command showed in logs
+* Fix section output to work on Windows
 
 ## 0.12.1 (2024-02-06)
 

--- a/src/SectionOutput.php
+++ b/src/SectionOutput.php
@@ -25,7 +25,7 @@ class SectionOutput
         $this->mainOutput = null;
         $this->sections = new \SplObjectStorage();
 
-        if ($output instanceof ConsoleOutput && posix_isatty(\STDOUT) && 'true' === getenv('CASTOR_USE_SECTION')) {
+        if ($output instanceof ConsoleOutput && 'true' === getenv('CASTOR_USE_SECTION') && stream_isatty(\STDOUT)) {
             $this->mainOutput = $output;
             $this->consoleOutput = $output->section();
         }


### PR DESCRIPTION
- `posix_isatty()` does not work on Windows, but [`stream_isatty()`](https://www.php.net/manual/en/function.stream-isatty.php) seems to work on Windows
- first check if we want to use section before calling this function 