### PR TITLE
Rework the way one can programatically add more context generatorl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Not released yet
 
+* Add a `compile` command that puts together a customizable PHP binary with a
+  repacked castor app into one executable file
 * Set the process title according to the current application name and task name
+* Compile watcher and phar for `ARM64` on macOS
+* Deprecates `add_context()` function, use  `AsContextGenerator` attribute
+  instead
 * Ignore some low level env vars in runnable command showed in logs
 * Fix section output to work on Windows
-* Add a `compile` command that puts together a customizable PHP binary with a repacked castor app into one executable file
-* Compile watcher and phar for `ARM64` on macOS
 
 ## 0.12.1 (2024-02-06)
 

--- a/doc/06-reference.md
+++ b/doc/06-reference.md
@@ -6,7 +6,6 @@ Here is a reference of all the functions and attributes provided by Castor.
 
 Castor provides the following built-in functions:
 
-- [`add_context`](going-further/advanced-context.md#the-add_context-function)
 - [`app`](going-further/console-and-io.md#the-app-function)
 - [`cache`](going-further/cache.md#the-cache-function)
 - [`capture`](03-run.md#the-capture-function)
@@ -52,6 +51,7 @@ Castor provides the following attributes to register tasks, listener, etc:
 
 - [`AsArgument`](04-arguments.md#overriding-the-argument-name-and-description)
 - [`AsContext`](05-context.md#creating-a-new-context)
+- [`AsContextGenerator`](06-advanded-context.md#the-ascontextgenerator-attribute)
 - [`AsListener`](going-further/events.md#registering-a-listener)
 - [`AsOption`](04-arguments.md#overriding-the-option-name-and-description)
 - [`AsSymfonyTask`](going-further/symfony-task.md)

--- a/doc/going-further/advanced-context.md
+++ b/doc/going-further/advanced-context.md
@@ -81,24 +81,25 @@ function foo(): void
 }
 ```
 
-## The `add_context()` function
+## The `AsContextGenerator()` attribute
 
 In some case, you may want to programmatically define contexts. You can use the
-`add_context()` to do so:
+`AsContextGenerator()` attribute:
 
 ```php
+use Castor\Attribute\AsContextGenerator;
 use Castor\Context;
 
-use function Castor\add_context;
-
-add_context('dynamic', fn () => new Context([
-    'name' => 'dynamic',
-    'production' => false,
-    'foo' => 'baz',
-]));
+/**
+ * @return iterable<string, \Closure(): Context>
+ */
+#[AsContextGenerator()]
+function context_generator(): iterable
+{
+    yield 'dynamic' => fn () => new Context([
+        'name' => 'dynamic',
+        'production' => false,
+        'foo' => 'baz',
+    ]);
+}
 ```
-
-> [!NOTE]
-> You should use the `add_context()` function at the top level of your Castor
-> files (not in a task function), in order to make these contexts available to
-> all tasks.

--- a/examples/context.php
+++ b/examples/context.php
@@ -3,10 +3,10 @@
 namespace context;
 
 use Castor\Attribute\AsContext;
+use Castor\Attribute\AsContextGenerator;
 use Castor\Attribute\AsTask;
 use Castor\Context;
 
-use function Castor\add_context;
 use function Castor\context;
 use function Castor\io;
 use function Castor\load_dot_env;
@@ -85,11 +85,18 @@ function contextInfo(): void
     echo 'context: ' . variable('foo', 'N/A') . "\n";
 }
 
-add_context('dynamic', fn () => new Context([
-    'name' => 'dynamic',
-    'production' => false,
-    'foo' => 'baz',
-]));
+/**
+ * @return iterable<string, \Closure(): Context>
+ */
+#[AsContextGenerator()]
+function context_generator(): iterable
+{
+    yield 'dynamic' => fn () => new Context([
+        'name' => 'dynamic',
+        'production' => false,
+        'foo' => 'baz',
+    ]);
+}
 
 #[AsTask(description: 'Displays information about the context')]
 function contextInfoForced(): void

--- a/src/Attribute/AsContextGenerator.php
+++ b/src/Attribute/AsContextGenerator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Castor\Attribute;
+
+#[\Attribute(\Attribute::TARGET_FUNCTION)]
+class AsContextGenerator
+{
+}

--- a/src/ContextGeneratorDescriptor.php
+++ b/src/ContextGeneratorDescriptor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Castor;
+
+use Castor\Attribute\AsContextGenerator;
+
+/** @internal */
+class ContextGeneratorDescriptor
+{
+    /**
+     * @param array<\Closure(): Context> $generators
+     */
+    public function __construct(
+        public readonly AsContextGenerator $contextAttribute,
+        public readonly \ReflectionFunction $function,
+        public readonly array $generators,
+    ) {
+    }
+}

--- a/src/ContextRegistry.php
+++ b/src/ContextRegistry.php
@@ -28,7 +28,10 @@ class ContextRegistry
         }
     }
 
-    public function addContext(string $name, \Closure $callable, bool $default = false): void
+    /**
+     * @param \Closure(): Context $callable
+     */
+    public function addContext(string $name, callable $callable, bool $default = false): void
     {
         $this->addDescriptor(new ContextDescriptor(
             new Attribute\AsContext(name: $name, default: $default),
@@ -68,7 +71,12 @@ class ContextRegistry
             throw new \RuntimeException(sprintf('Context "%s" not found.', $name));
         }
 
-        return $this->descriptors[$name]->function->invoke();
+        $context = $this->descriptors[$name]->function->invoke();
+        if (!$context instanceof Context) {
+            throw new \LogicException(sprintf('The context generator "%s", defined at "%s:%s" must return an instance of "%s", "%s" returned', $name, $this->descriptors[$name]->function->getFileName(), $this->descriptors[$name]->function->getStartLine(), Context::class, get_debug_type($context)));
+        }
+
+        return $context;
     }
 
     public function setCurrentContext(Context $context): void

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,6 +2,7 @@
 
 namespace Castor;
 
+use Castor\Attribute\AsContextGenerator;
 use Castor\Console\Application;
 use Castor\Exception\MinimumVersionRequirementNotMetException;
 use Castor\Exception\WaitFor\ExitedBeforeTimeoutException;
@@ -626,6 +627,8 @@ function io(): SymfonyStyle
 
 function add_context(string $name, \Closure $callable, bool $default = false): void
 {
+    trigger_deprecation('jolicode/castor', '0.13', 'The "%s()" function is deprecated, use "Castor\Attributes\%s()" instead.', __FUNCTION__, AsContextGenerator::class);
+
     GlobalHelper::getContextRegistry()->addContext($name, $callable, $default);
 }
 


### PR DESCRIPTION
expect `import()` and `guard()` no **direct** call to castor functions should be made during the initialization. everything should be lazy loaded.

cc @Korbeil 