### PR TITLE
Add `http_download` and `http_upload` functions

### DIFF
--- a/examples/http.php
+++ b/examples/http.php
@@ -1,15 +1,35 @@
 <?php
 
+namespace http;
+
 use Castor\Attribute\AsTask;
 
-use function Castor\request;
+use function Castor\http_download;
+use function Castor\http_request;
+use function Castor\http_upload;
 
 #[AsTask(description: 'Make HTTP request')]
-function httpRequest(): void
+function request(): void
 {
     $url = $_SERVER['ENDPOINT'] ?? 'https://example.com';
 
-    $response = request('GET', $url);
+    $response = http_request('GET', $url);
 
     echo $response->getContent();
+}
+
+#[AsTask(description: 'Download a file through HTTP')]
+function download(): void
+{
+    http_download('https://github.blog/wp-content/uploads/2023/09/Productivity-LightMode-1.png?resize=1200%2C630');
+    http_download('http://releases.ubuntu.com/18.04.2/ubuntu-18.04.2-desktop-amd64.iso');
+}
+
+#[AsTask(description: 'Upload a file through HTTP')]
+function upload(): void
+{
+    file_put_contents($filepath = sys_get_temp_dir() . '/castor_http_upload_test.txt', 'Hello World');
+    $request = http_upload('https://httpbin.org/post', $filepath);
+
+    echo $request->getContent();
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -14,6 +14,7 @@ use Castor\ExpressionLanguage;
 use Castor\Fingerprint\FingerprintHelper;
 use Castor\FunctionFinder;
 use Castor\GlobalHelper;
+use Castor\HttpHelper;
 use Castor\ListenerDescriptor;
 use Castor\PlatformUtil;
 use Castor\SectionOutput;
@@ -67,6 +68,7 @@ class Application extends SymfonyApplication
         public HttpClientInterface $httpClient,
         public CacheItemPoolInterface&CacheInterface $cache,
         public WaitForHelper $waitForHelper,
+        public HttpHelper $httpHelper,
         public FingerprintHelper $fingerprintHelper,
     ) {
         $handler = ErrorHandler::register();

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -10,6 +10,7 @@ use Castor\EventDispatcher;
 use Castor\ExpressionLanguage;
 use Castor\Fingerprint\FingerprintHelper;
 use Castor\FunctionFinder;
+use Castor\HttpHelper;
 use Castor\Monolog\Processor\ProcessProcessor;
 use Castor\PathHelper;
 use Castor\PlatformUtil;
@@ -63,6 +64,7 @@ class ApplicationFactory
             $httpClient,
             $cache,
             new WaitForHelper($httpClient, $logger),
+            new HttpHelper($httpClient, $fs, $logger),
             new FingerprintHelper($cache),
         );
 

--- a/src/GlobalHelper.php
+++ b/src/GlobalHelper.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\Cache\CacheInterface;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class GlobalHelper
 {
@@ -42,9 +41,9 @@ class GlobalHelper
         return self::getApplication()->fs;
     }
 
-    public static function getHttpClient(): HttpClientInterface
+    public static function getHttpHelper(): HttpHelper
     {
-        return self::getApplication()->httpClient;
+        return self::getApplication()->httpHelper;
     }
 
     public static function getCache(): CacheItemPoolInterface&CacheInterface

--- a/src/HttpHelper.php
+++ b/src/HttpHelper.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Castor;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+use function \log as log;
+
+/** @internal */
+class HttpHelper
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly Filesystem $filesystem,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function http_client(): HttpClientInterface
+    {
+        return $this->httpClient;
+    }
+
+    /**
+     * @param string|null $filePath Path to save the downloaded content. If null, the filename is determined from the URL or content disposition.
+     */
+    public function http_download(string $url, ?string $filePath = null, string $method = 'GET', array $options = [], bool $stream = true): ResponseInterface
+    {
+        $this->logger->info('Download starts for URL: "{url}"', ['url' => $url, 'method' => $method, 'stream' => $stream]);
+
+        $response = $this->httpClient->request($method, $url, $options);
+        $totalSize = $response->getHeaders()['content-length'][0] ?? 0;
+
+        if (null === $filePath) {
+            $disposition = $response->getHeaders(false)['content-disposition'][0] ?? null;
+            if (null !== $disposition && preg_match('/filename="([^"]+)"/', $disposition, $matches)) {
+                $filename = $matches[1];
+            } else {
+                // Fallback to parsing the URL for a file name
+                $path = parse_url($url, \PHP_URL_PATH);
+                $filename = basename($path);
+            }
+            $filePath = PathHelper::getRoot() . \DIRECTORY_SEPARATOR . $filename;
+            $this->logger->info('Determined the filename: "{filename}" for download.', ['filename' => $filename]);
+        }
+
+        if ($stream) {
+            $fileStream = fopen($filePath, 'w');
+            if (false === $fileStream) {
+                throw new \RuntimeException(sprintf('Cannot open file "%s" for writing.', $filePath));
+            }
+
+            $downloadedSize = 0;
+            $lastLogTime = time();
+            foreach ($this->httpClient->stream($response) as $chunk) {
+                fwrite($fileStream, $chunk->getContent());
+                $downloadedSize += \strlen($chunk->getContent());
+                if (time() - $lastLogTime >= 2) {
+                    $this->logger->info(
+                        sprintf('Download progress: %s/%s', $this->formatSize($downloadedSize), $this->formatSize($totalSize)),
+                        ['filePath' => $filePath]
+                    );
+                    $lastLogTime = time();
+                }
+            }
+
+            // To display the 100%
+            $this->logger->info(
+                sprintf('Download progress: %s/%s', $this->formatSize($downloadedSize), $this->formatSize($totalSize)),
+                ['filePath' => $filePath]
+            );
+
+            fclose($fileStream);
+            $this->logger->info('Finished downloading "{filePath}".', ['url' => $url, 'filePath' => $filePath, 'size' => $totalSize]);
+
+            return $response;
+        }
+
+        $content = $response->getContent();
+        file_put_contents($filePath, $content);
+        $this->logger->info('Finished downloading "{filePath}".', ['url' => $url, 'filePath' => $filePath, 'size' => \strlen($content)]);
+
+        return $response;
+    }
+
+    public function http_upload(string $url, string $filePath, string $method = 'POST', array $options = []): ResponseInterface
+    {
+        if (isset($options['body'])) {
+            throw new \InvalidArgumentException('Request body shouldn\'t be set as it will be filled with the file content');
+        }
+
+        if (!$this->filesystem->exists($filePath)) {
+            throw new \RuntimeException(sprintf('File "%s" does not exist.', $filePath));
+        }
+
+        // Determine file name from filePath if not provided in options
+        if (!isset($options['headers']['Content-Disposition'])) {
+            $filename = basename($filePath);
+            $options['headers']['Content-Disposition'] = 'attachment; filename="' . $filename . '"';
+        }
+
+        $fileStream = fopen($filePath, 'r');
+        if (false === $fileStream) {
+            throw new \RuntimeException(sprintf('Cannot open file "%s".', $filePath));
+        }
+
+        $options['body'] = $fileStream;
+
+        $response = $this->httpClient->request($method, $url, $options);
+
+        if ($response->getStatusCode() >= 400) {
+            throw new \RuntimeException(sprintf('Failed to upload file. Server responded with status code %s.', $response->getStatusCode()));
+        }
+
+        return $response;
+    }
+
+    public function http_request(string $method, string $url, array $options): ResponseInterface
+    {
+        return $this->httpClient->request($method, $url, $options);
+    }
+
+    private function formatSize(int $bytes, int $precision = 2): string
+    {
+        if ($bytes < 1024) {
+            return $bytes . ' B';
+        }
+
+        $units = ['KB', 'MB', 'GB', 'TB'];
+        $log = log($bytes, 1024);
+        $pow = floor($log);
+        $size = round($bytes / (1024 ** $pow), $precision);
+
+        return $size . ' ' . $units[$pow - 1];
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -720,14 +720,35 @@ function get_cache(): CacheItemPoolInterface&CacheInterface
  *
  * @see HttpClientInterface::OPTIONS_DEFAULTS
  */
-function request(string $method, string $url, array $options = []): ResponseInterface
+function http_request(string $method, string $url, array $options = []): ResponseInterface
 {
-    return http_client()->request($method, $url, $options);
+    return GlobalHelper::getHttpHelper()->http_request($method, $url, $options);
 }
 
 function http_client(): HttpClientInterface
 {
-    return GlobalHelper::getHttpClient();
+    return GlobalHelper::getHttpHelper()->http_client();
+}
+
+function http_download(string $url, ?string $filePath = null, string $method = 'GET', array $options = [], bool $stream = true): ResponseInterface
+{
+    return GlobalHelper::getHttpHelper()->http_download(
+        $url,
+        $filePath,
+        $method,
+        $options,
+        $stream
+    );
+}
+
+function http_upload(string $url, string $filePath, string $method = 'POST', array $options = []): ResponseInterface
+{
+    return GlobalHelper::getHttpHelper()->http_upload(
+        $url,
+        $filePath,
+        $method,
+        $options,
+    );
 }
 
 function import(string $path): void


### PR DESCRIPTION
:warning: This a Work In Progress :warning: 

I had some needs to move files around and implemented custom logics in my tasks. In hindsight I think they could be considered native castor functions.

This is the current verbose output:
![image](https://github.com/jolicode/castor/assets/1524501/eeb6cc28-af80-4008-8ad6-180e81de9528)


Things that need to be thought about:

- Should I allow an array of urls ? or array of ResponseInterface to do `http_download([http_request(), ...])` maybe ?
- If array of urls is supported, then it could have a `bool concurent` param
- Could a `callback $fileNamer` be useful to apply any logic needed to determinate the filename ? Examples of suffixing the date to the filename. Or could be useful to generate a dynamic filename given an array of urls ?
-  Should it use the same httpclient instance as every other helpers or have its own ?
- What should it returns ? The ResponseInterface and/or the File object ? The ResponseStreamInterface in case of streaming ?
- What should it logs ? What could be interesting in the context and what's redundant ?
- What about S3 download / upload for example ? Would it require a `s3_download` and `s3_upload`
- Is abstracting the filesystem through flysystem would be a good idea ? That would open the ability to stream every http file to whatever filesystem location, like s3, ftp, sftp etc. Useful for backup scripts. 

ToDo
- [ ] Tests
- [ ] Logging for `http_upload`