### PR TITLE
feat(timeout): Remove the default timeout of 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add a `yaml_dump()` function to dump any PHP value to a YAML string
 * Add a `yaml_parse()` function to parse a YAML string to a PHP value
+* Remove the default timeout of 60 seconds from the Context
 
 ## 0.13.1 (2024-02-27)
 

--- a/doc/getting-started/run.md
+++ b/doc/getting-started/run.md
@@ -188,7 +188,8 @@ function cs(): int
 
 ## Timeout
 
-By default, Castor will use a 60 seconds timeout on all your `run()` calls.
+By default, Castor allow your `run()` calls to go indefinitly.
+
 If you want to tweak that you need to set the `timeout` argument.
 
 ```php
@@ -203,20 +204,7 @@ function foo(): void
 }
 ```
 
-This process will have a 2 minutes timeout. If you want to disable that feature,
-you need to set the timeout to `0`.
-
-```php
-use Castor\Attribute\AsTask;
-
-use function Castor\run;
-
-#[AsTask()]
-function foo(): void
-{
-    run('echo "bar"', timeout: 0);
-}
-```
+This process will have a 2 minutes timeout.
 
 > [!TIP]
 > Related example: [wait_for.php](https://github.com/jolicode/castor/blob/main/examples/wait_for.php)

--- a/src/Context.php
+++ b/src/Context.php
@@ -17,7 +17,7 @@ class Context implements \ArrayAccess
         ?string $currentDirectory = null,
         public readonly bool $tty = false,
         public readonly bool $pty = true,
-        public readonly float|null $timeout = 60,
+        public readonly float|null $timeout = null,
         public readonly bool $quiet = false,
         public readonly bool $allowFailure = false,
         public readonly bool $notify = false,


### PR DESCRIPTION
I see myself having to customise my context too often.

There is no point in having a command timeout on a build tool.

Makefile does not have timeout for example. I think NULL is a better default value.