### PR TITLE
feat(event): add an event when registering a task, allowing also to disable this registration

### DIFF
--- a/examples/event-listener.php
+++ b/examples/event-listener.php
@@ -4,10 +4,12 @@ namespace event_listener;
 
 use Castor\Attribute\AsListener;
 use Castor\Attribute\AsTask;
+use Castor\Console\Command\TaskCommand;
 use Castor\Event\AfterExecuteTaskEvent;
 use Castor\Event\BeforeExecuteTaskEvent;
 use Castor\Event\ProcessStartEvent;
 use Castor\Event\ProcessTerminateEvent;
+use Castor\Event\RegisterTaskEvent;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 
@@ -17,6 +19,12 @@ use function Castor\task;
 
 #[AsTask(description: 'An dummy task with event listeners attached')]
 function my_task(): void
+{
+    run('echo "Hello from task!"');
+}
+
+#[AsTask(description: 'I should not be seen')]
+function a_command_that_should_not_exist(): void
 {
     run('echo "Hello from task!"');
 }
@@ -86,4 +94,16 @@ function process_start_event(ProcessStartEvent $event): void
     }
 
     io()->writeln('Hello after process start!');
+}
+
+#[AsListener(event: RegisterTaskEvent::class)]
+function process_register_task(RegisterTaskEvent $event): void
+{
+    if ($event->task instanceof TaskCommand) {
+        $function = $event->task->function;
+
+        if ('event_listener\\a_command_that_should_not_exist' === $function->getName()) {
+            $event->register = false;
+        }
+    }
 }

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -2,9 +2,6 @@
 
 namespace Castor\Console;
 
-use Castor\Console\Command\CompileCommand;
-use Castor\Console\Command\DebugCommand;
-use Castor\Console\Command\RepackCommand;
 use Castor\ContextRegistry;
 use Castor\EventDispatcher;
 use Castor\ExpressionLanguage;
@@ -74,15 +71,10 @@ class ApplicationFactory
             $cache,
             new WaitForHelper($httpClient, $logger),
             new FingerprintHelper($cache),
+            $cacheDir,
         );
 
         $application->setDispatcher($eventDispatcher);
-        $application->add(new DebugCommand($rootDir, $cacheDir, $contextRegistry));
-
-        if (!class_exists(\RepackedApplication::class)) {
-            $application->add(new RepackCommand());
-            $application->add(new CompileCommand($httpClient, $fs));
-        }
 
         return $application;
     }

--- a/src/Console/Command/TaskCommand.php
+++ b/src/Console/Command/TaskCommand.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/** @internal */
 class TaskCommand extends Command implements SignalableCommandInterface
 {
     /**

--- a/src/Event/RegisterTaskEvent.php
+++ b/src/Event/RegisterTaskEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Castor\Event;
+
+use Symfony\Component\Console\Command\Command;
+
+class RegisterTaskEvent
+{
+    public function __construct(
+        public readonly Command $task,
+        public bool $register = true,
+    ) {
+    }
+}


### PR DESCRIPTION
Did not write the doc yet, just want the feedback on the feature first

So mainly this add an event before a task is registered allowing a listener to this event to disable the task.

This will allow in the future docker extension to disable and add behavior on a task (overwrite it with custom behavior ?) based on custom attribute by example without having to change anything in our core.

I moved the "fixed" command so they can also be listened