### PR TITLE
feat: Use PropertyAccess Component syntax for nested variables access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /my-app.*
 /var/
 /vendor/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add a `yaml_dump()` function to dump any PHP value to a YAML string
 * Add a `yaml_parse()` function to parse a YAML string to a PHP value
 * Remove the default timeout of 60 seconds from the Context
+* Add possibility to use [Property Access Component](https://symfony.com/doc/current/components/property_access.html) syntax for getting variable from context.
 
 ## 0.13.1 (2024-02-27)
 

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "symfony/http-client": "^6.4.3",
         "symfony/monolog-bridge": "^6.4.3",
         "symfony/process": "^6.4.3",
+        "symfony/property-access": "^6.4",
         "symfony/string": "^6.4.3",
         "symfony/translation-contracts": "^3.4.1",
         "symfony/var-dumper": "^6.4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16e5f7934a962f8c5ad979ca1c6cc176",
+    "content-hash": "a08187a40ca9c74303089d9e6d917d6b",
     "packages": [
         {
             "name": "jolicode/jolinotif",
@@ -2343,6 +2343,166 @@
             "time": "2024-01-23T14:51:35+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v6.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "c0664db266024013e31446dd690b6bfcf218ad93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/c0664db266024013e31446dd690b6bfcf218ad93",
+                "reference": "c0664db266024013e31446dd690b6bfcf218ad93",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/property-info": "^5.4|^6.0|^7.0"
+            },
+            "require-dev": {
+                "symfony/cache": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property-path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v6.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-16T13:31:43+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v6.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "e96d740ab5ac39aa530c8eaa0720ea8169118e26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/e96d740ab5ac39aa530c8eaa0720ea8169118e26",
+                "reference": "e96d740ab5ac39aa530c8eaa0720ea8169118e26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/string": "^5.4|^6.0|^7.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/serializer": "<6.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "phpstan/phpdoc-parser": "^1.0",
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v6.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-23T14:51:35+00:00"
+        },
+        {
             "name": "symfony/service-contracts",
             "version": "v3.4.1",
             "source": {
@@ -3448,5 +3608,5 @@
     "platform-overrides": {
         "php": "8.1.19"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/doc/getting-started/context.md
+++ b/doc/getting-started/context.md
@@ -53,13 +53,15 @@ function foo(): void
 {
     $foobar = variable('foobar', 'default value');
 
-    // Same as:
     $context = context();
-    try {
-        $foobar = $context['foobar'];
-    } catch (\OutOfBoundsException) {
-        $foobar = 'default value;
-    }
+    // Same as:
+    $foobar = $context['foobar'] ?? 'default value';
+    
+    // Getting nested values
+    $foobar = variable('[foo][bar][baz]', 'default value');
+    
+    // Same as:
+    $foobar = $context['foo']['bar']['baz'] ?? 'default value';
 }
 ```
 

--- a/examples/context.php
+++ b/examples/context.php
@@ -21,6 +21,9 @@ function defaultContext(): Context
         'name' => 'my_default',
         'production' => false,
         'foo' => 'bar',
+        'nested' => [
+            'key' => 'nested_value',
+        ],
     ]);
 }
 
@@ -83,6 +86,7 @@ function contextInfo(): void
     echo 'Production? ' . (variable('production', false) ? 'yes' : 'no') . "\n";
     echo "verbosity: {$context->verbosityLevel->value}\n";
     echo 'context: ' . variable('foo', 'N/A') . "\n";
+    echo 'nested key: ' . variable('[nested][key]', 'N/A') . "\n";
 }
 
 /**

--- a/src/Attribute/AsCommandArgument.php
+++ b/src/Attribute/AsCommandArgument.php
@@ -5,7 +5,7 @@ namespace Castor\Attribute;
 abstract class AsCommandArgument
 {
     public function __construct(
-        public readonly string|null $name = null,
+        public readonly ?string $name = null,
     ) {
     }
 }

--- a/src/Attribute/AsOption.php
+++ b/src/Attribute/AsOption.php
@@ -12,7 +12,7 @@ class AsOption extends AsCommandArgument
     public function __construct(
         ?string $name = null,
         public readonly string|array|null $shortcut = null,
-        public readonly int|null $mode = null,
+        public readonly ?int $mode = null,
         public readonly string $description = '',
         public readonly array $suggestedValues = [],
     ) {

--- a/src/Attribute/AsTask.php
+++ b/src/Attribute/AsTask.php
@@ -11,7 +11,7 @@ class AsTask
      */
     public function __construct(
         public string $name = '',
-        public string|null $namespace = null,
+        public ?string $namespace = null,
         public string $description = '',
         public array $aliases = [],
         public array $onSignals = [],

--- a/src/Context.php
+++ b/src/Context.php
@@ -17,7 +17,7 @@ class Context implements \ArrayAccess
         ?string $currentDirectory = null,
         public readonly bool $tty = false,
         public readonly bool $pty = true,
-        public readonly float|null $timeout = null,
+        public readonly ?float $timeout = null,
         public readonly bool $quiet = false,
         public readonly bool $allowFailure = false,
         public readonly bool $notify = false,
@@ -132,7 +132,7 @@ class Context implements \ArrayAccess
         );
     }
 
-    public function withTimeout(float|null $timeout): self
+    public function withTimeout(?float $timeout): self
     {
         return new self(
             $this->data,

--- a/src/ContextRegistry.php
+++ b/src/ContextRegistry.php
@@ -2,6 +2,8 @@
 
 namespace Castor;
 
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
 /** @internal */
 class ContextRegistry
 {
@@ -113,11 +115,11 @@ class ContextRegistry
     {
         $context = $this->getCurrentContext();
 
-        if (!isset($context[$key])) {
-            return $default;
+        if (str_starts_with($key, '[')) {
+            return PropertyAccess::createPropertyAccessor()->getValue($context, $key) ?? $default;
         }
 
-        return $context[$key];
+        return $context[$key] ?? $default;
     }
 
     /**

--- a/src/SectionOutput.php
+++ b/src/SectionOutput.php
@@ -14,7 +14,7 @@ class SectionOutput
 
     private OutputInterface|ConsoleSectionOutput $consoleOutput;
 
-    private ConsoleOutput|null $mainOutput;
+    private ?ConsoleOutput $mainOutput;
 
     /** @var \SplObjectStorage<Process, SectionDetails> */
     private \SplObjectStorage $sections;

--- a/tests/Examples/Generated/ContextContextDynamicTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextDynamicTest.php.output.txt
@@ -2,3 +2,4 @@ context name: dynamic
 Production? no
 verbosity: 1
 context: baz
+nested key: N/A

--- a/tests/Examples/Generated/ContextContextMyDefaultTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextMyDefaultTest.php.output.txt
@@ -2,3 +2,4 @@ context name: my_default
 Production? no
 verbosity: 2
 context: bar
+nested key: nested_value

--- a/tests/Examples/Generated/ContextContextPathTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextPathTest.php.output.txt
@@ -2,3 +2,4 @@ context name: path
 Production? yes
 verbosity: 1
 context: bar
+nested key: N/A

--- a/tests/Examples/Generated/ContextContextProductionTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextProductionTest.php.output.txt
@@ -2,3 +2,4 @@ context name: production
 Production? yes
 verbosity: 1
 context: bar
+nested key: nested_value

--- a/tests/Examples/Generated/ContextContextRunTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextRunTest.php.output.txt
@@ -2,3 +2,4 @@ context name: run
 Production? no
 verbosity: 1
 context: no defined
+nested key: N/A

--- a/tests/Examples/Generated/ContextContextTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextTest.php.output.txt
@@ -2,3 +2,4 @@ context name: my_default
 Production? no
 verbosity: 1
 context: bar
+nested key: nested_value

--- a/tests/Examples/Generated/ContextContextWithTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextWithTest.php.output.txt
@@ -2,4 +2,5 @@ context name: dynamic
 Production? no
 verbosity: -1
 context: bar
+nested key: N/A
 bar

--- a/tools/php-cs-fixer/composer.lock
+++ b/tools/php-cs-fixer/composer.lock
@@ -226,16 +226,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.49.0",
+            "version": "v3.51.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "8742f7aa6f72a399688b65e4f58992c2d4681fc2"
+                "reference": "127fa74f010da99053e3f5b62672615b72dd6efd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/8742f7aa6f72a399688b65e4f58992c2d4681fc2",
-                "reference": "8742f7aa6f72a399688b65e4f58992c2d4681fc2",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/127fa74f010da99053e3f5b62672615b72dd6efd",
+                "reference": "127fa74f010da99053e3f5b62672615b72dd6efd",
                 "shasum": ""
             },
             "require": {
@@ -245,7 +245,7 @@
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
-                "sebastian/diff": "^4.0 || ^5.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
                 "symfony/console": "^5.4 || ^6.0 || ^7.0",
                 "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
                 "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
@@ -266,7 +266,8 @@
                 "php-cs-fixer/accessible-object": "^1.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.4",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.4",
-                "phpunit/phpunit": "^9.6 || ^10.5.5",
+                "phpunit/phpunit": "^9.6 || ^10.5.5 || ^11.0.2",
+                "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
                 "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
             },
             "suggest": {
@@ -305,7 +306,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.49.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.51.0"
             },
             "funding": [
                 {
@@ -313,7 +314,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-02T00:41:40+00:00"
+            "time": "2024-02-28T19:50:06+00:00"
         },
         {
             "name": "psr/container",
@@ -1819,5 +1820,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
### Description
This pull request introduces a feature enhancement that allows the use of the [Property Access Component](https://symfony.com/doc/current/components/property_access.html) syntax for accessing nested variables within the context.

### Changes Made
- Added the capability to utilize Property Access Component syntax for retrieving variables from the context.
- Modified the `.gitignore` file to exclude the `.idea/` directory.
- Improved the example usage by replacing try/catch with the null coalescing operator for enhanced readability.
- Upgraded the `friendsofphp/php-cs-fixer` dependency to version 3.51.0 to align the local and CI environments.

### Example of Usage
```php
// Context
new Context([
    'nested' => [
        'key' => 'nested_value',
    ],
]);

// Getting nested values
$foobar = variable('[foo][bar][baz]', 'default value');

// Same as:
$foobar = $context['foo']['bar']['baz'] ?? 'default value';
```

### Warning
Not sure about the usage of the `str_starts_with('[')` condition for detecting when use PropertyAccess.

```php
if (str_starts_with($key, '[')) {
    return PropertyAccess::createPropertyAccessor()->getValue($context, $key) ?? $default;
}
```