### PR TITLE
fix: Allow `fingerprint` function to return execution status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add a `yaml_dump()` function to dump any PHP value to a YAML string
 * Add a `yaml_parse()` function to parse a YAML string to a PHP value
 * Remove the default timeout of 60 seconds from the Context
+* Add `bool` return type to `fingerprint()` function to indicate if the callable was run
 
 ## 0.13.1 (2024-02-27)
 

--- a/examples/fingerprint.php
+++ b/examples/fingerprint.php
@@ -47,13 +47,17 @@ function task_with_a_fingerprint_and_force(
 ): void {
     run('echo "Hello Task with Fingerprint!"');
 
-    fingerprint(
+    $hasRun = fingerprint(
         callback: function () {
             run('echo "Cool, no fingerprint! Executing..."');
         },
         fingerprint: my_fingerprint_check(),
         force: $force // This option will force the task to run even if the fingerprint has not changed
     );
+
+    if ($hasRun) {
+        run('echo "Fingerprint has been executed!"');
+    }
 
     run('echo "Cool! I finished!"');
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -885,16 +885,16 @@ function fingerprint_save(string $fingerprint): void
     GlobalHelper::getApplication()->fingerprintHelper->postProcessFingerprintForHash($fingerprint);
 }
 
-function fingerprint(callable $callback, string $fingerprint, bool $force = false): void
+function fingerprint(callable $callback, string $fingerprint, bool $force = false): bool
 {
-    if (!fingerprint_exists($fingerprint) || $force) {
-        try {
-            $callback();
-            fingerprint_save($fingerprint);
-        } catch (\Throwable $e) {
-            throw $e;
-        }
+    if ($force || !fingerprint_exists($fingerprint)) {
+        $callback();
+        fingerprint_save($fingerprint);
+
+        return true;
     }
+
+    return false;
 }
 
 /**

--- a/tests/Examples/Fingerprint/FingerprintTaskWithAFingerprintAndForceTest.php.output_runnable.txt
+++ b/tests/Examples/Fingerprint/FingerprintTaskWithAFingerprintAndForceTest.php.output_runnable.txt
@@ -1,3 +1,4 @@
 Hello Task with Fingerprint!
 Cool, no fingerprint! Executing...
+Fingerprint has been executed!
 Cool! I finished!


### PR DESCRIPTION
**Description:**

This change adds the feature of returning `true` if the callback was executed and `false` otherwise, allowing streamlined conditional execution.

**Usage:**

```php
$hasRun = fingerprint(fn () => echo "my fingerprinted task", fingerprint: $uniqueFingerprint, force: $forceExecution);
if ($hasRun === false) {
    doSomethingWhenHasNotRunned();
}
```

Enhances code readability for managing fingerprinted tasks.