### PR TITLE
Change `$this` to `self` in generate-tests.php for method `assertStringEqualsFile` in TaskTestCase

### DIFF
--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -167,9 +167,9 @@ class {{ class_name }} extends TaskTestCase
         $process = $this->runTask([{{ args }}]{{ cwd }});
 
         $this->assertSame({{ exitCode }}, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/src/Attribute/AsCommandArgument.php
+++ b/src/Attribute/AsCommandArgument.php
@@ -5,7 +5,7 @@ namespace Castor\Attribute;
 abstract class AsCommandArgument
 {
     public function __construct(
-        public readonly string|null $name = null,
+        public readonly ?string $name = null,
     ) {
     }
 }

--- a/src/Attribute/AsOption.php
+++ b/src/Attribute/AsOption.php
@@ -12,7 +12,7 @@ class AsOption extends AsCommandArgument
     public function __construct(
         ?string $name = null,
         public readonly string|array|null $shortcut = null,
-        public readonly int|null $mode = null,
+        public readonly ?int $mode = null,
         public readonly string $description = '',
         public readonly array $suggestedValues = [],
     ) {

--- a/src/Attribute/AsTask.php
+++ b/src/Attribute/AsTask.php
@@ -11,7 +11,7 @@ class AsTask
      */
     public function __construct(
         public string $name = '',
-        public string|null $namespace = null,
+        public ?string $namespace = null,
         public string $description = '',
         public array $aliases = [],
         public array $onSignals = [],

--- a/src/Context.php
+++ b/src/Context.php
@@ -17,7 +17,7 @@ class Context implements \ArrayAccess
         ?string $currentDirectory = null,
         public readonly bool $tty = false,
         public readonly bool $pty = true,
-        public readonly float|null $timeout = null,
+        public readonly ?float $timeout = null,
         public readonly bool $quiet = false,
         public readonly bool $allowFailure = false,
         public readonly bool $notify = false,
@@ -132,7 +132,7 @@ class Context implements \ArrayAccess
         );
     }
 
-    public function withTimeout(float|null $timeout): self
+    public function withTimeout(?float $timeout): self
     {
         return new self(
             $this->data,

--- a/src/SectionOutput.php
+++ b/src/SectionOutput.php
@@ -14,7 +14,7 @@ class SectionOutput
 
     private OutputInterface|ConsoleSectionOutput $consoleOutput;
 
-    private ConsoleOutput|null $mainOutput;
+    private ?ConsoleOutput $mainOutput;
 
     /** @var \SplObjectStorage<Process, SectionDetails> */
     private \SplObjectStorage $sections;

--- a/tests/Examples/Generated/ArgsAnotherArgsTest.php
+++ b/tests/Examples/Generated/ArgsAnotherArgsTest.php
@@ -12,9 +12,9 @@ class ArgsAnotherArgsTest extends TaskTestCase
         $process = $this->runTask(['args:another-args', 'FIXME(required)', '--test2', 1]);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ArgsArgsTest.php
+++ b/tests/Examples/Generated/ArgsArgsTest.php
@@ -12,9 +12,9 @@ class ArgsArgsTest extends TaskTestCase
         $process = $this->runTask(['args:args', 'FIXME(word)', '--option', 'default value', '--dry-run']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/BarBarTest.php
+++ b/tests/Examples/Generated/BarBarTest.php
@@ -12,9 +12,9 @@ class BarBarTest extends TaskTestCase
         $process = $this->runTask(['bar:bar']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/CacheComplexTest.php
+++ b/tests/Examples/Generated/CacheComplexTest.php
@@ -12,9 +12,9 @@ class CacheComplexTest extends TaskTestCase
         $process = $this->runTask(['cache:complex']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/CacheSimpleTest.php
+++ b/tests/Examples/Generated/CacheSimpleTest.php
@@ -12,9 +12,9 @@ class CacheSimpleTest extends TaskTestCase
         $process = $this->runTask(['cache:simple']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ContextContextDoNotExistTest.php
+++ b/tests/Examples/Generated/ContextContextDoNotExistTest.php
@@ -12,9 +12,9 @@ class ContextContextDoNotExistTest extends TaskTestCase
         $process = $this->runTask(['context:context', '--context', 'no_no_exist']);
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ContextContextDynamicTest.php
+++ b/tests/Examples/Generated/ContextContextDynamicTest.php
@@ -12,9 +12,9 @@ class ContextContextDynamicTest extends TaskTestCase
         $process = $this->runTask(['context:context', '--context', 'dynamic']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ContextContextInfoForcedTest.php
+++ b/tests/Examples/Generated/ContextContextInfoForcedTest.php
@@ -12,9 +12,9 @@ class ContextContextInfoForcedTest extends TaskTestCase
         $process = $this->runTask(['context:context-info-forced']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ContextContextMyDefaultTest.php
+++ b/tests/Examples/Generated/ContextContextMyDefaultTest.php
@@ -12,9 +12,9 @@ class ContextContextMyDefaultTest extends TaskTestCase
         $process = $this->runTask(['context:context', '--context', 'my_default', '-v']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ContextContextPathTest.php
+++ b/tests/Examples/Generated/ContextContextPathTest.php
@@ -12,9 +12,9 @@ class ContextContextPathTest extends TaskTestCase
         $process = $this->runTask(['context:context', '--context', 'path']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ContextContextProductionTest.php
+++ b/tests/Examples/Generated/ContextContextProductionTest.php
@@ -12,9 +12,9 @@ class ContextContextProductionTest extends TaskTestCase
         $process = $this->runTask(['context:context', '--context', 'production']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ContextContextRunTest.php
+++ b/tests/Examples/Generated/ContextContextRunTest.php
@@ -12,9 +12,9 @@ class ContextContextRunTest extends TaskTestCase
         $process = $this->runTask(['context:context', '--context', 'run']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ContextContextTest.php
+++ b/tests/Examples/Generated/ContextContextTest.php
@@ -12,9 +12,9 @@ class ContextContextTest extends TaskTestCase
         $process = $this->runTask(['context:context']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ContextContextWithTest.php
+++ b/tests/Examples/Generated/ContextContextWithTest.php
@@ -12,9 +12,9 @@ class ContextContextWithTest extends TaskTestCase
         $process = $this->runTask(['context:context-with']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/EnabledInProduction.php
+++ b/tests/Examples/Generated/EnabledInProduction.php
@@ -12,9 +12,9 @@ class EnabledInProduction extends TaskTestCase
         $process = $this->runTask(['enabled:hello', '--context', 'production']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/EnvEnvTest.php
+++ b/tests/Examples/Generated/EnvEnvTest.php
@@ -12,9 +12,9 @@ class EnvEnvTest extends TaskTestCase
         $process = $this->runTask(['env:env']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/EventListenerMyTaskTest.php
+++ b/tests/Examples/Generated/EventListenerMyTaskTest.php
@@ -12,9 +12,9 @@ class EventListenerMyTaskTest extends TaskTestCase
         $process = $this->runTask(['event-listener:my-task']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/FailureAllowFailureTest.php
+++ b/tests/Examples/Generated/FailureAllowFailureTest.php
@@ -12,9 +12,9 @@ class FailureAllowFailureTest extends TaskTestCase
         $process = $this->runTask(['failure:allow-failure']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/FailureFailureTest.php
+++ b/tests/Examples/Generated/FailureFailureTest.php
@@ -12,9 +12,9 @@ class FailureFailureTest extends TaskTestCase
         $process = $this->runTask(['failure:failure']);
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/FilesystemFilesystemTest.php
+++ b/tests/Examples/Generated/FilesystemFilesystemTest.php
@@ -12,9 +12,9 @@ class FilesystemFilesystemTest extends TaskTestCase
         $process = $this->runTask(['filesystem:filesystem']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/FilesystemFindTest.php
+++ b/tests/Examples/Generated/FilesystemFindTest.php
@@ -12,9 +12,9 @@ class FilesystemFindTest extends TaskTestCase
         $process = $this->runTask(['filesystem:find']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/FooBarTest.php
+++ b/tests/Examples/Generated/FooBarTest.php
@@ -12,9 +12,9 @@ class FooBarTest extends TaskTestCase
         $process = $this->runTask(['foo:bar']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/FooFooTest.php
+++ b/tests/Examples/Generated/FooFooTest.php
@@ -12,9 +12,9 @@ class FooFooTest extends TaskTestCase
         $process = $this->runTask(['foo:foo']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/HelloTest.php
+++ b/tests/Examples/Generated/HelloTest.php
@@ -12,9 +12,9 @@ class HelloTest extends TaskTestCase
         $process = $this->runTask(['hello']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/HttpRequestTest.php
+++ b/tests/Examples/Generated/HttpRequestTest.php
@@ -12,9 +12,9 @@ class HttpRequestTest extends TaskTestCase
         $process = $this->runTask(['http-request']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ListTest.php
+++ b/tests/Examples/Generated/ListTest.php
@@ -12,9 +12,9 @@ class ListTest extends TaskTestCase
         $process = $this->runTask(['list', '--raw', '--format', 'txt', '--short']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/NewProjectInitTest.php
+++ b/tests/Examples/Generated/NewProjectInitTest.php
@@ -12,9 +12,9 @@ class NewProjectInitTest extends TaskTestCase
         $process = $this->runTask(['init'], '/tmp');
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/NewProjectTest.php
+++ b/tests/Examples/Generated/NewProjectTest.php
@@ -12,9 +12,9 @@ class NewProjectTest extends TaskTestCase
         $process = $this->runTask([], '/tmp');
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/NoConfigCompletionTest.php
+++ b/tests/Examples/Generated/NoConfigCompletionTest.php
@@ -12,9 +12,9 @@ class NoConfigCompletionTest extends TaskTestCase
         $process = $this->runTask(['completion', 'bash'], '/tmp');
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/NoConfigUnknownTest.php
+++ b/tests/Examples/Generated/NoConfigUnknownTest.php
@@ -12,9 +12,9 @@ class NoConfigUnknownTest extends TaskTestCase
         $process = $this->runTask(['unknown:task'], '/tmp');
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/NoConfigUnknownWithArgsTest.php
+++ b/tests/Examples/Generated/NoConfigUnknownWithArgsTest.php
@@ -12,9 +12,9 @@ class NoConfigUnknownWithArgsTest extends TaskTestCase
         $process = $this->runTask(['unknown:task', 'toto', '--foo', 1], '/tmp');
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/NoNamespaceTest.php
+++ b/tests/Examples/Generated/NoNamespaceTest.php
@@ -12,9 +12,9 @@ class NoNamespaceTest extends TaskTestCase
         $process = $this->runTask(['no-namespace']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/NotRenameRenamedTest.php
+++ b/tests/Examples/Generated/NotRenameRenamedTest.php
@@ -12,9 +12,9 @@ class NotRenameRenamedTest extends TaskTestCase
         $process = $this->runTask(['not-rename:renamed']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/NotifyNotifyOnFinishTest.php
+++ b/tests/Examples/Generated/NotifyNotifyOnFinishTest.php
@@ -12,9 +12,9 @@ class NotifyNotifyOnFinishTest extends TaskTestCase
         $process = $this->runTask(['notify:notify-on-finish']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/NotifySendNotifyTest.php
+++ b/tests/Examples/Generated/NotifySendNotifyTest.php
@@ -12,9 +12,9 @@ class NotifySendNotifyTest extends TaskTestCase
         $process = $this->runTask(['notify:send-notify']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/OutputOutputTest.php
+++ b/tests/Examples/Generated/OutputOutputTest.php
@@ -12,9 +12,9 @@ class OutputOutputTest extends TaskTestCase
         $process = $this->runTask(['output:output']);
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ParallelExceptionTest.php
+++ b/tests/Examples/Generated/ParallelExceptionTest.php
@@ -12,9 +12,9 @@ class ParallelExceptionTest extends TaskTestCase
         $process = $this->runTask(['parallel:exception']);
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ParallelSleepTest.php
+++ b/tests/Examples/Generated/ParallelSleepTest.php
@@ -12,9 +12,9 @@ class ParallelSleepTest extends TaskTestCase
         $process = $this->runTask(['parallel:sleep', '--sleep5', '0', '--sleep7', '0', '--sleep10', '0']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/QuietQuietTest.php
+++ b/tests/Examples/Generated/QuietQuietTest.php
@@ -12,9 +12,9 @@ class QuietQuietTest extends TaskTestCase
         $process = $this->runTask(['quiet:quiet']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/RunTestFileTest.php
+++ b/tests/Examples/Generated/RunTestFileTest.php
@@ -12,9 +12,9 @@ class RunTestFileTest extends TaskTestCase
         $process = $this->runTask(['run:test-file']);
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/RunVariablesTest.php
+++ b/tests/Examples/Generated/RunVariablesTest.php
@@ -12,9 +12,9 @@ class RunVariablesTest extends TaskTestCase
         $process = $this->runTask(['run:variables']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/RunWhoamiTest.php
+++ b/tests/Examples/Generated/RunWhoamiTest.php
@@ -12,9 +12,9 @@ class RunWhoamiTest extends TaskTestCase
         $process = $this->runTask(['run:whoami']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/RunWithProcessHelperTest.php
+++ b/tests/Examples/Generated/RunWithProcessHelperTest.php
@@ -12,9 +12,9 @@ class RunWithProcessHelperTest extends TaskTestCase
         $process = $this->runTask(['run:with-process-helper']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ShellBashTest.php
+++ b/tests/Examples/Generated/ShellBashTest.php
@@ -12,9 +12,9 @@ class ShellBashTest extends TaskTestCase
         $process = $this->runTask(['shell:bash']);
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/ShellShTest.php
+++ b/tests/Examples/Generated/ShellShTest.php
@@ -12,9 +12,9 @@ class ShellShTest extends TaskTestCase
         $process = $this->runTask(['shell:sh']);
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/SignalSigusr2Test.php
+++ b/tests/Examples/Generated/SignalSigusr2Test.php
@@ -12,9 +12,9 @@ class SignalSigusr2Test extends TaskTestCase
         $process = $this->runTask(['signal:sigusr2']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/SymfonyGreetTest.php
+++ b/tests/Examples/Generated/SymfonyGreetTest.php
@@ -12,9 +12,9 @@ class SymfonyGreetTest extends TaskTestCase
         $process = $this->runTask(['symfony:greet', 'FIXME(who)', '--french', 'FIXME', '--punctuation', '!']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/SymfonyHelloTest.php
+++ b/tests/Examples/Generated/SymfonyHelloTest.php
@@ -12,9 +12,9 @@ class SymfonyHelloTest extends TaskTestCase
         $process = $this->runTask(['symfony:hello']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/VersionGuardMinVersionCheckFailTest.php
+++ b/tests/Examples/Generated/VersionGuardMinVersionCheckFailTest.php
@@ -12,9 +12,9 @@ class VersionGuardMinVersionCheckFailTest extends TaskTestCase
         $process = $this->runTask(['version-guard:min-version-check-fail']);
 
         $this->assertSame(1, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/VersionGuardMinVersionCheckTest.php
+++ b/tests/Examples/Generated/VersionGuardMinVersionCheckTest.php
@@ -12,9 +12,9 @@ class VersionGuardMinVersionCheckTest extends TaskTestCase
         $process = $this->runTask(['version-guard:min-version-check']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/WaitForCustomWaitForTaskTest.php
+++ b/tests/Examples/Generated/WaitForCustomWaitForTaskTest.php
@@ -12,9 +12,9 @@ class WaitForCustomWaitForTaskTest extends TaskTestCase
         $process = $this->runTask(['wait-for:custom-wait-for-task', '--thing', 'foobar']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/WaitForWaitForDockerContainerTaskTest.php
+++ b/tests/Examples/Generated/WaitForWaitForDockerContainerTaskTest.php
@@ -12,9 +12,9 @@ class WaitForWaitForDockerContainerTaskTest extends TaskTestCase
         $process = $this->runTask(['wait-for:wait-for-docker-container-task']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/WaitForWaitForPortTaskTest.php
+++ b/tests/Examples/Generated/WaitForWaitForPortTaskTest.php
@@ -12,9 +12,9 @@ class WaitForWaitForPortTaskTest extends TaskTestCase
         $process = $this->runTask(['wait-for:wait-for-port-task']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/WaitForWaitForUrlTaskTest.php
+++ b/tests/Examples/Generated/WaitForWaitForUrlTaskTest.php
@@ -12,9 +12,9 @@ class WaitForWaitForUrlTaskTest extends TaskTestCase
         $process = $this->runTask(['wait-for:wait-for-url-task']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/WaitForWaitForUrlWithSpecificResponseContentAndStatusTest.php
+++ b/tests/Examples/Generated/WaitForWaitForUrlWithSpecificResponseContentAndStatusTest.php
@@ -12,9 +12,9 @@ class WaitForWaitForUrlWithSpecificResponseContentAndStatusTest extends TaskTest
         $process = $this->runTask(['wait-for:wait-for-url-with-specific-response-content-and-status']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/WaitForWaitForUrlWithStatusCodeOnlyTest.php
+++ b/tests/Examples/Generated/WaitForWaitForUrlWithStatusCodeOnlyTest.php
@@ -12,9 +12,9 @@ class WaitForWaitForUrlWithStatusCodeOnlyTest extends TaskTestCase
         $process = $this->runTask(['wait-for:wait-for-url-with-status-code-only']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/YamlDumpTest.php
+++ b/tests/Examples/Generated/YamlDumpTest.php
@@ -12,9 +12,9 @@ class YamlDumpTest extends TaskTestCase
         $process = $this->runTask(['yaml:dump']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }

--- a/tests/Examples/Generated/YamlParseTest.php
+++ b/tests/Examples/Generated/YamlParseTest.php
@@ -12,9 +12,9 @@ class YamlParseTest extends TaskTestCase
         $process = $this->runTask(['yaml:parse']);
 
         $this->assertSame(0, $process->getExitCode());
-        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        self::assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
         if (file_exists(__FILE__ . '.err.txt')) {
-            $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+            self::assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
         } else {
             $this->assertSame('', $process->getErrorOutput());
         }


### PR DESCRIPTION
## Description

In the tests, `$this->assertStringEqualsFile` was replaced with `self::assertStringEqualsFile`. The change was necessary because the method `assertStringEqualsFile` is static. This ensures a more proper and standard use of static method invocation in PHP.