### PR TITLE
feat: Add possibility to recursive merge data in Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add a `yaml_parse()` function to parse a YAML string to a PHP value
 * Remove the default timeout of 60 seconds from the Context
 * Add `bool` return type to `fingerprint()` function to indicate if the callable was run
+* Add a `recursive` parameter to the `withData()` method of `Context` to allow recursive merging for nested arrays
 
 ## 0.13.1 (2024-02-27)
 

--- a/examples/context.php
+++ b/examples/context.php
@@ -21,6 +21,16 @@ function defaultContext(): Context
         'name' => 'my_default',
         'production' => false,
         'foo' => 'bar',
+        'nested' => [
+            'merge' => [
+                'key' => [
+                    'value' => 'should keep this',
+                    'replaced' => 'should be replaced',
+                ],
+                'another' => 'should keep',
+            ],
+            'another' => 'should keep',
+        ],
     ]);
 }
 
@@ -28,10 +38,21 @@ function defaultContext(): Context
 function productionContext(): Context
 {
     return defaultContext()
-        ->withData([
-            'name' => 'production',
-            'production' => true,
-        ])
+        ->withData(
+            [
+                'name' => 'production',
+                'production' => true,
+                'nested' => [
+                    'merge' => [
+                        'key' => [
+                            'replaced' => 'replaced value',
+                            'new' => 'new value',
+                        ],
+                    ],
+                ],
+            ],
+            recursive: true
+        )
     ;
 }
 
@@ -83,6 +104,7 @@ function contextInfo(): void
     echo 'Production? ' . (variable('production', false) ? 'yes' : 'no') . "\n";
     echo "verbosity: {$context->verbosityLevel->value}\n";
     echo 'context: ' . variable('foo', 'N/A') . "\n";
+    echo 'nested merge recursive: ' . json_encode(variable('nested', []), \JSON_THROW_ON_ERROR) . "\n";
 }
 
 /**

--- a/tests/Examples/Generated/ContextContextDynamicTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextDynamicTest.php.output.txt
@@ -2,3 +2,4 @@ context name: dynamic
 Production? no
 verbosity: 1
 context: baz
+nested merge recursive: []

--- a/tests/Examples/Generated/ContextContextMyDefaultTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextMyDefaultTest.php.output.txt
@@ -2,3 +2,4 @@ context name: my_default
 Production? no
 verbosity: 2
 context: bar
+nested merge recursive: {"merge":{"key":{"value":"should keep this","replaced":"should be replaced"},"another":"should keep"},"another":"should keep"}

--- a/tests/Examples/Generated/ContextContextPathTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextPathTest.php.output.txt
@@ -2,3 +2,4 @@ context name: path
 Production? yes
 verbosity: 1
 context: bar
+nested merge recursive: []

--- a/tests/Examples/Generated/ContextContextProductionTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextProductionTest.php.output.txt
@@ -2,3 +2,4 @@ context name: production
 Production? yes
 verbosity: 1
 context: bar
+nested merge recursive: {"merge":{"key":{"value":"should keep this","replaced":"replaced value","new":"new value"},"another":"should keep"},"another":"should keep"}

--- a/tests/Examples/Generated/ContextContextRunTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextRunTest.php.output.txt
@@ -2,3 +2,4 @@ context name: run
 Production? no
 verbosity: 1
 context: no defined
+nested merge recursive: []

--- a/tests/Examples/Generated/ContextContextTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextTest.php.output.txt
@@ -2,3 +2,4 @@ context name: my_default
 Production? no
 verbosity: 1
 context: bar
+nested merge recursive: {"merge":{"key":{"value":"should keep this","replaced":"should be replaced"},"another":"should keep"},"another":"should keep"}

--- a/tests/Examples/Generated/ContextContextWithTest.php.output.txt
+++ b/tests/Examples/Generated/ContextContextWithTest.php.output.txt
@@ -2,4 +2,5 @@ context name: dynamic
 Production? no
 verbosity: -1
 context: bar
+nested merge recursive: []
 bar


### PR DESCRIPTION
## Description

### Overview

This pull request addresses the need for improved array merging behavior, specifically focusing on preserving nested values while merging arrays.

### Examples

#### `defaultContext` Function

For example, the `defaultContext` function is updated to return a `Context` object with a nested array. The `nested` key contains an array with a `merge` key, which in turn contains another array.

This structure is designed to demonstrate the merging behavior of nested arrays. 

The `replaced` key is intended to be replaced, while the `value` key is expected to be preserved.

```php
#[AsContext(default: true, name: 'my_default')]
function defaultContext(): Context
{
    return new Context([
        'name' => 'my_default',
        'production' => false,
        'foo' => 'bar',
        'nested' => [
            'merge' => [
                'key' => [
                    'value' => 'should keep this',
                    'replaced' => 'should be replaced',
                ],
                'another' => 'should keep',
            ],
            'another' => 'should keep',
        ],
    ]);
}
```
---

#### `productionContext` Function

The `productionContext` function is based on the `defaultContext` function, with the intention of modifying the `Context` object to reflect a production environment.

In the case of the `nested` array, the `replaced` key is replaced with a new value, and a new key is added to the `key` array.

```php
#[AsContext(name: 'production')]
function productionContext(): Context
{
    return defaultContext()
        ->withData(
            [
                'name' => 'production',
                'production' => true,
                'nested' => [
                    'merge' => [
                        'key' => [
                            'replaced' => 'replaced value',
                            'new' => 'new value',
                        ],
                    ],
                ],
            ],
            recursive: true  // Enable recursive merging for nested arrays
        );
}
```

### Outcome

#### Actual

In the case of actual behavior, the `Context` object returned by the `productionContext` function is as follows (or now with `recursive` set to `false`):

```php
[
    'name' => 'production',
    'production' => true,
    'foo' => 'bar',
    'nested' => [
        'merge' => [
            'key' => [
                'replaced' => 'replaced value',
                'new' => 'new value',
            ],
        ],
    ],
]
```

#### New Behavior

With the updated behavior, the `Context` object returned by the `productionContext` function is as follows, and `recursive` set to `true`:

```php
[
    'name' => 'production',
    'production' => true,
    'foo' => 'bar',
    'nested' => [
        'merge' => [
            'key' => [
                'value' => 'should keep this',
                'replaced' => 'replaced value',
                'new' => 'new value',
            ],
            'another' => 'should keep',
        ],
        'another' => 'should keep',
    ],
]
```

### Recursive Merging

> [!NOTE]
> 
> Actually the `recursive` option is by default `true`.
> 
> Is this a good idea to change the default behavior? or better to set `false` by default and let the user decide to set it to `true`?