### PR TITLE
feat: add an `open` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Remove the default timeout of 60 seconds from the Context
 * Add `bool` return type to `fingerprint()` function to indicate if the callable was run
 * Add a `recursive` parameter to the `withData()` method of `Context` to allow recursive merging for nested arrays
+* Add an `open()` function to open a file or URL in the default application
 
 ## 0.13.1 (2024-02-27)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ And run the tool to make your code compliant with
 castor's static analysis checks:
 
 ```shell
-tools/phpstan/vendor/bin/phpstan fix --config=phpstan.neon
+tools/phpstan/vendor/bin/phpstan --configuration=phpstan.neon
 ```
 
 ## Update the Documentation

--- a/doc/going-further/helpers/open.md
+++ b/doc/going-further/helpers/open.md
@@ -1,0 +1,16 @@
+# Open URLs and files
+
+Castor provides an `open()` function that will open one or more
+URLs or files in the user's default application.
+
+```php
+use Castor\Attribute\AsTask;
+
+use function Castor\open;
+
+#[AsTask()]
+function open()
+{
+    open('https://castor.jolicode.com');
+}
+```

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -27,6 +27,7 @@ Castor provides the following built-in functions:
 - [`log`](going-further/interacting-with-castor/log.md#the-log-function)
 - [`logger`](going-further/interacting-with-castor/log.md#the-logger-function)
 - [`notify`](going-further/helpers/notify.md#the-notify-function)
+- [`open`](going-further/helpers/open.md)
 - [`output`](going-further/helpers/console-and-io.md#the-output-function)
 - [`parallel`](going-further/helpers/parallel.md#the-parallel-function)
 - [`request`](going-further/helpers/http-request.md#the-request-function)

--- a/examples/open.php
+++ b/examples/open.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace open;
+
+use Castor\Attribute\AsTask;
+
+use function Castor\open;
+
+#[AsTask(description: 'Open Castor documentation in the default browser')]
+function documentation(): void
+{
+    open('https://castor.jolicode.com');
+}
+
+#[AsTask(description: 'Open an URL and a file in the default applications')]
+function multiple(): void
+{
+    open('https://castor.jolicode.com', 'examples/open.php');
+}

--- a/src/Exception/ExecutableNotFoundException.php
+++ b/src/Exception/ExecutableNotFoundException.php
@@ -7,6 +7,6 @@ class ExecutableNotFoundException extends \RuntimeException
     public function __construct(
         readonly string $executableName,
     ) {
-        parent::__construct("Executable {$executableName} not found. Please install it to use this feature.");
+        parent::__construct(sprintf('Executable "%s" not found. Please install it to use this feature.', $executableName));
     }
 }

--- a/tests/Examples/Generated/FilesystemFindTest.php.output.txt
+++ b/tests/Examples/Generated/FilesystemFindTest.php.output.txt
@@ -1,1 +1,1 @@
-Number of PHP files: 28
+Number of PHP files: 29

--- a/tests/Examples/Generated/ListTest.php.output.txt
+++ b/tests/Examples/Generated/ListTest.php.output.txt
@@ -44,6 +44,8 @@ log:with-context                                                  Logs an "error
 not-rename:renamed                                                Task that was renamed
 notify:notify-on-finish                                           Sends a notification when the task finishes
 notify:send-notify                                                Sends a notification
+open:documentation                                                Open Castor documentation in the default browser
+open:multiple                                                     Open an URL and a file in the default applications
 output:output                                                     Plays with Symfony Style
 parallel:exception                                                Sleep and throw an exception
 parallel:sleep                                                    Sleeps for 5, 7, and 10 seconds in parallel


### PR DESCRIPTION
An `open` task has [recently been added](https://github.com/jolicode/docker-starter/pull/282/files#diff-b824f66b797834738d78126819926ed443d87080a25c369853ed32c1b757cb54R59) to Docker Starter. However, it works only on macOS as the Linux command is `xdg-open`. Having it here allows using the right command according to the operating system thanks to the OSHelper. WDYT?