### PR TITLE
chore: introduce FunctionConfigurationException to streamline error reporting

### DIFF
--- a/src/Console/Command/TaskCommand.php
+++ b/src/Console/Command/TaskCommand.php
@@ -10,6 +10,7 @@ use Castor\Console\Application;
 use Castor\Event\AfterExecuteTaskEvent;
 use Castor\Event\BeforeExecuteTaskEvent;
 use Castor\EventDispatcher;
+use Castor\Exception\FunctionConfigurationException;
 use Castor\ExpressionLanguage;
 use Castor\SluggerHelper;
 use Symfony\Component\Console\Command\Command;
@@ -130,7 +131,7 @@ class TaskCommand extends Command implements SignalableCommandInterface
                     );
                 }
             } catch (LogicException $e) {
-                throw new \LogicException(sprintf('The argument "%s" for task "%s" cannot be configured: "%s".', $parameter->getName(), $this->getName(), $e->getMessage()));
+                throw new FunctionConfigurationException(sprintf('The argument "%s" cannot be configured: "%s".', $parameter->getName(), $e->getMessage()), $this->function, $e);
             }
         }
     }

--- a/src/Console/Command/TaskCommand.php
+++ b/src/Console/Command/TaskCommand.php
@@ -108,6 +108,10 @@ class TaskCommand extends Command implements SignalableCommandInterface
                         $taskArgumentAttribute->suggestedValues,
                     );
                 } elseif ($taskArgumentAttribute instanceof AsOption) {
+                    if ('verbose' === $name) {
+                        throw new FunctionConfigurationException('You cannot re-define a "verbose" option. But you can use "output()->isVerbose()" in your code instead.', $this->function);
+                    }
+
                     $mode = $taskArgumentAttribute->mode;
                     $defaultValue = $parameter->isOptional() ? $parameter->getDefaultValue() : null;
 

--- a/src/Context.php
+++ b/src/Context.php
@@ -250,11 +250,11 @@ class Context implements \ArrayAccess
 
     public function offsetSet(mixed $offset, mixed $value): void
     {
-        throw new \LogicException('Context is immutable');
+        throw new \LogicException('Context is immutable.');
     }
 
     public function offsetUnset(mixed $offset): void
     {
-        throw new \LogicException('Context is immutable');
+        throw new \LogicException('Context is immutable.');
     }
 }

--- a/src/ContextRegistry.php
+++ b/src/ContextRegistry.php
@@ -19,7 +19,7 @@ class ContextRegistry
         if (\array_key_exists($name, $this->descriptors)) {
             $alreadyDefined = $this->descriptors[$name]->function;
 
-            throw new FunctionConfigurationException(sprintf('You cannot defined two contexts with the same name "%s". There is one already defined in "%s:%d".', $name, PathHelper::makeRelative((string) $alreadyDefined->getFileName()), $alreadyDefined->getStartLine()), $descriptor->function);
+            throw new FunctionConfigurationException(sprintf('You cannot define two contexts with the same name "%s". There is one already defined in "%s:%d".', $name, PathHelper::makeRelative((string) $alreadyDefined->getFileName()), $alreadyDefined->getStartLine()), $descriptor->function);
         }
 
         $this->descriptors[$name] = $descriptor;

--- a/src/ContextRegistry.php
+++ b/src/ContextRegistry.php
@@ -2,6 +2,8 @@
 
 namespace Castor;
 
+use Castor\Exception\FunctionConfigurationException;
+
 /** @internal */
 class ContextRegistry
 {
@@ -15,14 +17,18 @@ class ContextRegistry
     {
         $name = $descriptor->contextAttribute->name;
         if (\array_key_exists($name, $this->descriptors)) {
-            throw new \RuntimeException(sprintf('You cannot defined two context with the same name "%s". There is one defined in "%s" and another in "%s".', $name, $this->describeFunction($this->descriptors[$name]->function), $this->describeFunction($descriptor->function)));
+            $alreadyDefined = $this->descriptors[$name]->function;
+
+            throw new FunctionConfigurationException(sprintf('You cannot defined two contexts with the same name "%s". There is one already defined in "%s:%d".', $name, PathHelper::makeRelative((string) $alreadyDefined->getFileName()), $alreadyDefined->getStartLine()), $descriptor->function);
         }
 
         $this->descriptors[$name] = $descriptor;
 
         if ($descriptor->contextAttribute->default) {
             if ($this->defaultName) {
-                throw new \RuntimeException(sprintf('You cannot set multiple "default: true" context. There is one defined in "%s" and another in "%s".', $this->defaultName, $this->describeFunction($descriptor->function)));
+                $alreadyDefined = $this->descriptors[$this->defaultName]->function;
+
+                throw new FunctionConfigurationException(sprintf('You cannot set multiple "default: true" context. There is one already defined in "%s:%d".', PathHelper::makeRelative((string) $alreadyDefined->getFileName()), $alreadyDefined->getStartLine()), $descriptor->function);
             }
             $this->defaultName = $name;
         }
@@ -73,7 +79,7 @@ class ContextRegistry
 
         $context = $this->descriptors[$name]->function->invoke();
         if (!$context instanceof Context) {
-            throw new \LogicException(sprintf('The context generator "%s", defined at "%s:%s" must return an instance of "%s", "%s" returned', $name, $this->descriptors[$name]->function->getFileName(), $this->descriptors[$name]->function->getStartLine(), Context::class, get_debug_type($context)));
+            throw new FunctionConfigurationException(sprintf('The context generator must return an instance of "%s", "%s" returned.', Context::class, get_debug_type($context)), $this->descriptors[$name]->function);
         }
 
         return $context;
@@ -129,18 +135,5 @@ class ContextRegistry
         sort($names);
 
         return $names;
-    }
-
-    private function describeFunction(\ReflectionFunction $function): string
-    {
-        $name = $function->getName();
-        $shortFilename = str_replace(PathHelper::getRoot() . '/', '', (string) $function->getFileName());
-        $location = sprintf('%s:%d', $shortFilename, $function->getStartLine());
-
-        if (str_contains($name, '{closure}')) {
-            return $location;
-        }
-
-        return sprintf('%s@%s', $name, $location);
     }
 }

--- a/src/Exception/FunctionConfigurationException.php
+++ b/src/Exception/FunctionConfigurationException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Castor\Exception;
+
+use Castor\PathHelper;
+
+class FunctionConfigurationException extends \InvalidArgumentException
+{
+    public function __construct(string $message, \ReflectionFunction|\ReflectionClass $function, ?\Throwable $e = null)
+    {
+        $message = sprintf(<<<'TXT'
+            Function "%s()" is not properly configured:
+            %s
+            Defined in "%s" line %d.
+            TXT,
+            $function->getName(),
+            $message,
+            PathHelper::makeRelative((string) $function->getFileName()),
+            $function->getStartLine(),
+        );
+
+        parent::__construct($message, previous: $e);
+    }
+}

--- a/src/HasherHelper.php
+++ b/src/HasherHelper.php
@@ -39,11 +39,11 @@ class HasherHelper
         }
 
         if (!is_file($path)) {
-            throw new \InvalidArgumentException(sprintf('The path "%s" is not a file', $path));
+            throw new \InvalidArgumentException(sprintf('The path "%s" is not a file.', $path));
         }
 
         if (!is_readable($path)) {
-            throw new \InvalidArgumentException(sprintf('The file "%s" is not readable', $path));
+            throw new \InvalidArgumentException(sprintf('The file "%s" is not readable.', $path));
         }
 
         $this->logger->debug('Hashing file "{path}" with strategy "{strategy}".', [
@@ -97,7 +97,7 @@ class HasherHelper
         $files = glob($pattern);
 
         if (false === $files) {
-            throw new \InvalidArgumentException(sprintf('The pattern "%s" is invalid', $pattern));
+            throw new \InvalidArgumentException(sprintf('The pattern "%s" is invalid.', $pattern));
         }
 
         foreach ($files as $file) {

--- a/src/PathHelper.php
+++ b/src/PathHelper.php
@@ -41,4 +41,13 @@ class PathHelper
 
         return $realpath;
     }
+
+    public static function makeRelative(string $path): string
+    {
+        if (!Path::isAbsolute($path)) {
+            throw new \RuntimeException(sprintf('Path "%s" is not absolute.', $path));
+        }
+
+        return Path::makeRelative($path, self::getRoot());
+    }
 }


### PR DESCRIPTION
before / after 

![image](https://github.com/jolicode/castor/assets/408368/989e111e-0dfe-4b7c-90fb-0de14d26b981)

--

or 
![image](https://github.com/jolicode/castor/assets/408368/66c1d9f4-13f4-4a0f-8085-8ca39667cad1)


---

I also add some explaination about the verbose option: 

![image](https://github.com/jolicode/castor/assets/408368/c1e9916e-0e42-4fa5-aac3-e43d962c5dc2)
