### PR TITLE
Repack - Add local box.json support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Deprecate `Context::withPath()` in favor of `Context::withCurrentDirectory()`
 * Deprecate `path` argument in `capture()`, `exit_code()`, `run()`, `with()` in favor of `currentDirectory`
+* Add a way to merge an application `box.json` config file used by `castor:repack`command
 
 ## 0.14.0 (2024-03-08)
 

--- a/doc/going-further/extending-castor/repack.md
+++ b/doc/going-further/extending-castor/repack.md
@@ -39,6 +39,11 @@ vendor/bin/castor repack --help
 > So ensure to have the less files possible in the directory where you run the
 > repack task to avoid including useless files in the phar.
 
+> [!NOTE]
+> If a `box.json` file exists in your application directory, 
+> it will be merged with the config file used by Castor.  
+> None of this keys `base-path`, `main`, `alias` or `output` keys can be defined in your application box config.
+
 ## Going further
 
 Packaging your Castor app as a phar simplifies distribution but requires PHP

--- a/src/Console/Command/RepackCommand.php
+++ b/src/Console/Command/RepackCommand.php
@@ -101,6 +101,24 @@ class RepackCommand extends Command
             ...$boxConfig['files'] ?? [],
         ];
 
+        if (file_exists($appBoxConfigFile = PathHelper::getRoot() . '/box.json')) {
+            $appBoxConfig = json_decode((string) file_get_contents($appBoxConfigFile), true, 512, \JSON_THROW_ON_ERROR);
+
+            if (
+                \array_key_exists('base-path', $appBoxConfig)
+                || \array_key_exists('main', $appBoxConfig)
+                || \array_key_exists('alias', $appBoxConfig)
+                || \array_key_exists('output', $appBoxConfig)
+            ) {
+                throw new \RuntimeException('Application box config could not contains one of this keys: base-path, main, alias or output.');
+            }
+
+            $boxConfig = array_merge_recursive(
+                $boxConfig,
+                $appBoxConfig,
+            );
+        }
+
         file_put_contents('.box.json', json_encode($boxConfig, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
         file_put_contents('.main.php', $main);
 


### PR DESCRIPTION
Issue #305 - Add support for local box.json config file.

For example:

```json
{
    "files": [
        "vendor/twig/twig/src/TwigTest.php"
    ]
}
```