### PR TITLE
Fix dotenv doc

### DIFF
--- a/doc/going-further/interacting-with-castor/dot-env.md
+++ b/doc/going-further/interacting-with-castor/dot-env.md
@@ -3,6 +3,7 @@
 ## The `load_dot_env()` function
 
 You can load a `.env` file with the `load_dot_env()` function. This will:
+
 - load the `.env` file
 - populate the env variables for the current process
 - return the env variables as key/value array.


### PR DESCRIPTION
It misses list rendering in https://castor.jolicode.com/going-further/interacting-with-castor/dot-env/

![image](https://github.com/jolicode/castor/assets/2021641/d291857b-c3cd-432e-9d6f-8f891006fc6e)
