### PR TITLE
[Tests] Fix comparison when some messages are too long

### DIFF
--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -142,7 +142,7 @@ function add_test(array $args, string $class, ?string $cwd = null)
         [\PHP_BINARY,  __DIR__ . '/castor', '--no-ansi', ...$args],
         cwd: $cwd ? str_replace('{{ base }}', __DIR__ . '/..', $cwd) : __DIR__ . '/..',
         env: [
-            'COLUMNS' => 120,
+            'COLUMNS' => 1000,
             'ENDPOINT' => $_SERVER['ENDPOINT'],
         ],
         timeout: null,

--- a/tests/Examples/Generated/AutocompleteInvalidTest.php.err.txt
+++ b/tests/Examples/Generated/AutocompleteInvalidTest.php.err.txt
@@ -1,8 +1,7 @@
-
 In TaskCommand.php line 238:
-                                                                                            
-  Function "autocomplete_argument()" is not properly configured:                            
-  The value provided in the "autocomplete" option on parameter "argument" is not callable.  
-  Defined in "castor.php" line 8.                                                           
-                                                                                            
+
+  Function "autocomplete_argument()" is not properly configured:
+  The value provided in the "autocomplete" option on parameter "argument" is not callable.
+  Defined in "castor.php" line 8.
+
 

--- a/tests/Examples/Generated/ContextContextDoNotExistTest.php.err.txt
+++ b/tests/Examples/Generated/ContextContextDoNotExistTest.php.err.txt
@@ -1,6 +1,5 @@
-
 In ContextRegistry.php line XXXX:
-                                    
-  Context "no_no_exist" not found.  
-                                    
+
+  Context "no_no_exist" not found.
+
 

--- a/tests/Examples/Generated/ContextGeneratorArg2Test.php.err.txt
+++ b/tests/Examples/Generated/ContextGeneratorArg2Test.php.err.txt
@@ -1,8 +1,7 @@
-
 In FunctionFinder.php line 223:
-                                                        
-  Function "gen()" is not properly configured:          
-  The context generator "foo" must not have arguments.  
-  Defined in "castor.php" line 7.                       
-                                                        
+
+  Function "gen()" is not properly configured:
+  The context generator "foo" must not have arguments.
+  Defined in "castor.php" line 7.
+
 

--- a/tests/Examples/Generated/ContextGeneratorArgTest.php.err.txt
+++ b/tests/Examples/Generated/ContextGeneratorArgTest.php.err.txt
@@ -1,8 +1,7 @@
-
 In FunctionFinder.php line 214:
-                                                   
-  Function "gen()" is not properly configured:     
-  The contexts generator must not have arguments.  
-  Defined in "castor.php" line 7.                  
-                                                   
+
+  Function "gen()" is not properly configured:
+  The contexts generator must not have arguments.
+  Defined in "castor.php" line 7.
+
 

--- a/tests/Examples/Generated/ContextGeneratorNotCallableTest.php.err.txt
+++ b/tests/Examples/Generated/ContextGeneratorNotCallableTest.php.err.txt
@@ -1,8 +1,7 @@
-
 In FunctionFinder.php line 219:
-                                                
-  Function "gen()" is not properly configured:  
-  The context generator "foo" is not callable.  
-  Defined in "castor.php" line 6.               
-                                                
+
+  Function "gen()" is not properly configured:
+  The context generator "foo" is not callable.
+  Defined in "castor.php" line 6.
+
 

--- a/tests/Examples/Generated/FailureFailureTest.php.err.txt
+++ b/tests/Examples/Generated/FailureFailureTest.php.err.txt
@@ -1,9 +1,9 @@
 sh: 1: i_do_not_exist: not found
 
 In failure.php line 12:
-                                        
-  The command "i_do_not_exist" failed.  
-                                        
+
+  The command "i_do_not_exist" failed.
+
 
 failure:failure
 

--- a/tests/Examples/Generated/ListTest.php.output.txt
+++ b/tests/Examples/Generated/ListTest.php.output.txt
@@ -63,7 +63,7 @@ signal:sigusr2                                                    Captures SIGUS
 ssh:download                                                      Downloads a file from the remote server
 ssh:ls                                                            Lists content of /var/www directory on the remote server
 ssh:upload                                                        Uploads a file to the remote server
-symfony:greet                                                     
+symfony:greet
 symfony:hello                                                     Says hello from a symfony application
 version-guard:min-version-check                                   Check if the minimum castor version requirement is met
 version-guard:min-version-check-fail                              Check if the minimum castor version requirement is met (fail)

--- a/tests/Examples/Generated/NewProjectInitTest.php.output.txt
+++ b/tests/Examples/Generated/NewProjectInitTest.php.output.txt
@@ -1,5 +1,4 @@
-
- [WARNING] Could not find root "castor.php" file.                                                                       
+ [WARNING] Could not find root "castor.php" file.
 
  Do you want to create a new project? (yes/no) [no]:
- > 
+ >

--- a/tests/Examples/Generated/NewProjectTest.php.output.txt
+++ b/tests/Examples/Generated/NewProjectTest.php.output.txt
@@ -1,5 +1,4 @@
-
- [WARNING] Could not find root "castor.php" file.                                                                       
+ [WARNING] Could not find root "castor.php" file.
 
  Do you want to create a new project? (yes/no) [no]:
- > 
+ >

--- a/tests/Examples/Generated/NoConfigUnknownTest.php.output.txt
+++ b/tests/Examples/Generated/NoConfigUnknownTest.php.output.txt
@@ -1,3 +1,2 @@
-
- [ERROR] Could not find root "castor.php" file. Did you run castor in the right directory?                              
+ [ERROR] Could not find root "castor.php" file. Did you run castor in the right directory?
 

--- a/tests/Examples/Generated/NoConfigUnknownWithArgsTest.php.output.txt
+++ b/tests/Examples/Generated/NoConfigUnknownWithArgsTest.php.output.txt
@@ -1,3 +1,2 @@
-
- [ERROR] Could not find root "castor.php" file. Did you run castor in the right directory?                              
+ [ERROR] Could not find root "castor.php" file. Did you run castor in the right directory?
 

--- a/tests/Examples/Generated/NoDefaultContextTest.php.err.txt
+++ b/tests/Examples/Generated/NoDefaultContextTest.php.err.txt
@@ -1,6 +1,5 @@
-
 In ContextRegistry.php line XXXX:
-                                                                                           
-  Since there are multiple contexts "one", "two", you must set a "default: true" context.  
-                                                                                           
+
+  Since there are multiple contexts "one", "two", you must set a "default: true" context.
+
 

--- a/tests/Examples/Generated/OutputOutputTest.php.err.txt
+++ b/tests/Examples/Generated/OutputOutputTest.php.err.txt
@@ -1,7 +1,6 @@
 
-            
-  Aborted.  
-            
+  Aborted.
+
 
 output:output
 

--- a/tests/Examples/Generated/OutputOutputTest.php.output.txt
+++ b/tests/Examples/Generated/OutputOutputTest.php.output.txt
@@ -1,10 +1,9 @@
-
 This is a title
 ===============
 
  This is the task "output:output"
 
- // With IO, you can ask questions ...                                                                                  
+ // With IO, you can ask questions ...
 
  Tell me something:
- > 
+ >

--- a/tests/Examples/Generated/ParallelExceptionTest.php.err.txt
+++ b/tests/Examples/Generated/ParallelExceptionTest.php.err.txt
@@ -1,24 +1,23 @@
-
 In parallel.php line 74:
-                        
-  This is an exception  
-                        
+
+  This is an exception
+
 
 parallel:exception
 
 
 In parallel.php line 72:
-                                
-  The command "exit 1" failed.  
-                                
+
+  The command "exit 1" failed.
+
 
 parallel:exception
 
 
 In functions.php line XXXX:
-                                                   
-  One or more exceptions were thrown in parallel.  
-                                                   
+
+  One or more exceptions were thrown in parallel.
+
 
 parallel:exception
 

--- a/tests/Examples/Generated/RunVariablesTest.php.output.txt
+++ b/tests/Examples/Generated/RunVariablesTest.php.output.txt
@@ -1,4 +1,4 @@
 Output: ba'"`r
 
-Error output: 
+Error output:
 Exit code: 0

--- a/tests/Examples/Generated/ShellBashTest.php.err.txt
+++ b/tests/Examples/Generated/ShellBashTest.php.err.txt
@@ -1,8 +1,7 @@
-
 In Process.php line XXXX:
-                                                   
-  TTY mode requires /dev/tty to be read/writable.  
-                                                   
+
+  TTY mode requires /dev/tty to be read/writable.
+
 
 shell:bash
 

--- a/tests/Examples/Generated/ShellShTest.php.err.txt
+++ b/tests/Examples/Generated/ShellShTest.php.err.txt
@@ -1,8 +1,7 @@
-
 In Process.php line XXXX:
-                                                   
-  TTY mode requires /dev/tty to be read/writable.  
-                                                   
+
+  TTY mode requires /dev/tty to be read/writable.
+
 
 shell:sh
 

--- a/tests/Examples/Generated/TwoDefaultContextTest.php.err.txt
+++ b/tests/Examples/Generated/TwoDefaultContextTest.php.err.txt
@@ -1,8 +1,7 @@
-
 In ContextRegistry.php line XXXX:
-                                                                                                                
-  Function "two()" is not properly configured:                                                                  
-  You cannot define two contexts with the same name "default". There is one already defined in "castor.php:7".  
-  Defined in "castor.php" line 13.                                                                              
-                                                                                                                
+
+  Function "two()" is not properly configured:
+  You cannot define two contexts with the same name "default". There is one already defined in "castor.php:7".
+  Defined in "castor.php" line 13.
+
 

--- a/tests/Examples/Generated/VersionGuardMinVersionCheckFailTest.php.err.txt
+++ b/tests/Examples/Generated/VersionGuardMinVersionCheckFailTest.php.err.txt
@@ -1,8 +1,7 @@
-
 In version-guard.php line 18:
-                                                                                                                  
-  This project requires Castor in version v999.0.0 or greater, you are using vX.Y.Z. Please consider upgrading.  
-                                                                                                                  
+
+  This project requires Castor in version v999.0.0 or greater, you are using vX.Y.Z. Please consider upgrading.
+
 
 version-guard:min-version-check-fail
 

--- a/tests/Helper/OutputCleaner.php
+++ b/tests/Helper/OutputCleaner.php
@@ -16,6 +16,10 @@ final class OutputCleaner
         $string = preg_replace('{you are using v\d+.\d+.\d+.}m', 'you are using vX.Y.Z.', $string);
         $string = preg_replace('{you are using v\d+.\d+.\d+.}m', 'you are using vX.Y.Z.', $string);
 
+        // Avoid spacing issues
+        $string = ltrim($string, "\n"); // Trim output start to avoid empty lines
+        $string = preg_replace('/ +$/m', '', $string); // Remove trailing space
+
         return str_replace(\dirname(__DIR__, 2), '...', $string);
     }
 }

--- a/tests/TaskTestCase.php
+++ b/tests/TaskTestCase.php
@@ -38,7 +38,7 @@ abstract class TaskTestCase extends TestCase
             [$castorBin, '--no-ansi', ...$args],
             cwd: $cwd ? str_replace('{{ base }}', __DIR__ . '/..', $cwd) : __DIR__ . '/..',
             env: [
-                'COLUMNS' => 120,
+                'COLUMNS' => 1000,
                 ...$extraEnv,
             ],
         );


### PR DESCRIPTION
Because we manipulate the output (like removing some path specific to the user running the tests), it can happen that the message is no longer padded correctly. For example, if a path is too long, the message containing will be splitted in two line by Symfony. And because the padding is dependent on the initial message, some user can have a diff on the output.

To avoid that, let's:
- drastically increase the output "width" to 1000 chars
- remove the trailing spaces at each lines