### PR TITLE
feat: Add support for Darwin ARM64 static

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -121,10 +121,41 @@ jobs:
           path: ./castor.darwin-amd64
           if-no-files-found: error
 
+  static-darwin-arm64:
+    needs: phars
+    name: Create MacOs arm64 static binary and upload
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/install
+
+      - uses: ./.github/actions/cache
+        with:
+          os: 'darwin'
+
+      - name: retrieve phar artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: tools/phar/build
+          merge-multiple: true
+
+      - uses: ./.github/actions/static
+        with:
+          os: 'darwin-arm64'
+
+      - name: Upload the MacOs arm64 static binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'castor.darwin-arm64'
+          path: ./castor.darwin-arm64
+          if-no-files-found: error
+
   release:
     name: Upload artifacts to the release
     if: github.event_name == 'release'
-    needs: [phars, static-linux-amd64, static-darwin-amd64]
+    needs: [phars, static-linux-amd64, static-darwin-amd64, static-darwin-arm64]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -140,6 +171,7 @@ jobs:
         run: |
           gh release upload ${{ github.ref_name }} ./build/castor.darwin-amd64
           gh release upload ${{ github.ref_name }} ./build/castor.darwin-amd64.phar
+          gh release upload ${{ github.ref_name }} ./build/castor.darwin-arm64
           gh release upload ${{ github.ref_name }} ./build/castor.darwin-arm64.phar
           gh release upload ${{ github.ref_name }} ./build/castor.linux-amd64
           gh release upload ${{ github.ref_name }} ./build/castor.linux-amd64.phar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Not released yet
 
-* Add support for running Castor on Linux ARM64
+* Distribute static binaries `castor.darwin-arm64` automatically with the
+  release
+* Add support for running Castor on Linux arm64 and distribute the binary
+  `castor.linux-arm64.phar` automatically with the release
 * Add a bash installer to ease installation
 * Add a option `ignoreValidationErrors` on `AsTask` attribute to ignore
   parameters & options validation errors

--- a/src/Console/Command/CompileCommand.php
+++ b/src/Console/Command/CompileCommand.php
@@ -58,12 +58,15 @@ class CompileCommand extends Command
         $spcBinaryPath = PlatformHelper::getCacheDirectory() . '/castor-php-static-compiler/' . $phpBuildCacheKey . '/spc';
         $spcBinaryDir = \dirname($spcBinaryPath);
 
+        $os = $input->getOption('os');
+        $arch = $input->getOption('arch');
+
         $this->setupSPC(
             $spcBinaryDir,
             $spcBinaryPath,
             $io,
-            $input->getOption('os'),
-            $input->getOption('arch'),
+            $os,
+            $arch,
         );
 
         if (!$this->fs->exists($spcBinaryDir . '/buildroot/bin/micro.sfx') || $input->getOption('php-rebuild')) {
@@ -82,7 +85,7 @@ class CompileCommand extends Command
             $this->buildPHP(
                 $spcBinaryPath,
                 $phpExtensions,
-                $input->getOption('arch'),
+                ('macos' === $os && 'aarch64' === $arch) ? 'arm64' : $arch,
                 $spcBinaryDir,
                 $io
             );


### PR DESCRIPTION
Because @ruudk mentioned the Darwin ARM64 compiled version (https://github.com/jolicode/castor/pull/353#issuecomment-2027095462) I had a quick look and saw almost everything was here to make it possible so continued to have a look.

This used to fail because of an issue in static-php-cli (https://github.com/crazywhalecc/static-php-cli/pull/391) so be sure to use the latest nightly.
Also, this will probably fail for now in the CI because of the XZ issue (but I managed to make it work locally by commenting out XZ download in SPC) but I prefer to open the PR so that I don't forget about this work :) 