### PR TITLE
fix: Import of task when remote import used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Import and load task from remote import automatically
 * Fix multiple remote imports of the same package with default version
 * Add `context()` function in expression language to enable a task
+* Fix import of local tasks when using remote import
 
 
 ## 0.15.0 (2024-04-03)

--- a/src/Import/Importer.php
+++ b/src/Import/Importer.php
@@ -68,6 +68,8 @@ class Importer
             $files = Finder::create()
                 ->files()
                 ->name('*.php')
+                ->notPath('/vendor\/composer/')
+                ->notName('autoload.php')
                 ->in($path)
             ;
 


### PR DESCRIPTION
**Description:**
This pull request resolves an issue related to task imports when utilizing remote imports. The issue occurs during subsequent runs of Castor, where files within the `vendor/composer` directory and the `vendor/autoload.php` file are erroneously included, causing failures.

**Changes:**
- Added exclusions for files within the `vendor/composer` directory.
- Added exclusion for the `autoload.php` file.

This adjustment ensures that these files are not considered during task imports, thus rectifying the problem encountered during subsequent Castor runs.

Screen of issue :
![image](https://github.com/jolicode/castor/assets/72203064/29dc54c9-da2a-479c-9790-41b1be965286)
