### PR TITLE
chore(tests): make some tests less sensible to user environment

### DIFF
--- a/examples/failure.php
+++ b/examples/failure.php
@@ -9,11 +9,11 @@ use function Castor\run;
 #[AsTask(description: 'A failing task not authorized to fail')]
 function failure(): void
 {
-    run('i_do_not_exist', workingDirectory: '/tmp', pty: false);
+    run('bash -c i_do_not_exist', workingDirectory: '/tmp', pty: false);
 }
 
 #[AsTask(description: 'A failing task authorized to fail')]
 function allow_failure(): void
 {
-    run('i_do_not_exist', allowFailure: true, pty: false);
+    run('bash -c i_do_not_exist', allowFailure: true, pty: false);
 }

--- a/examples/ssh.php
+++ b/examples/ssh.php
@@ -27,7 +27,7 @@ function whoami(): void
 #[AsTask(description: 'Uploads a file to the remote server')]
 function upload(): void
 {
-    ssh_upload('/tmp/test.html', '/var/www/index.html', host: 'server-1.example.com', user: 'debian');
+    ssh_upload(__FILE__, '/var/www/index.html', host: 'server-1.example.com', user: 'debian');
 }
 
 #[AsTask(description: 'Downloads a file from the remote server')]

--- a/tests/Generated/FailureAllowFailureTest.php.err.txt
+++ b/tests/Generated/FailureAllowFailureTest.php.err.txt
@@ -1,1 +1,1 @@
-sh: 1: i_do_not_exist: not found
+bash: line 1: i_do_not_exist: command not found

--- a/tests/Generated/FailureFailureTest.php.err.txt
+++ b/tests/Generated/FailureFailureTest.php.err.txt
@@ -1,8 +1,8 @@
-sh: 1: i_do_not_exist: not found
+bash: line 1: i_do_not_exist: command not found
 
 In failure.php line 12:
 
-  The command "i_do_not_exist" failed.
+  The command "bash -c i_do_not_exist" failed.
 
 
 failure:failure

--- a/tests/Generated/SshUploadTest.php.err.txt
+++ b/tests/Generated/SshUploadTest.php.err.txt
@@ -2,7 +2,7 @@ ssh: Could not resolve hostname server-1.example.com: Name or service not known
 
 In SshRunner.php line XXXX:
 
-  The command "scp -r /tmp/test.html debian@server-1.example.com:/var/www/index.html" failed.
+  The command "scp -r .../examples/ssh.php debian@server-1.example.com:/var/www/index.html" failed.
 
 
 ssh:upload

--- a/tests/Slow/CompileCommandTest.php
+++ b/tests/Slow/CompileCommandTest.php
@@ -3,12 +3,20 @@
 namespace Castor\Tests\Slow;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 class CompileCommandTest extends TestCase
 {
     public function test()
     {
+        $finder = new ExecutableFinder();
+        $box = $finder->find('box');
+
+        if (null === $box) {
+            $this->markTestSkipped('box is not installed.');
+        }
+
         $castorAppDirPath = RepackCommandTest::setupRepackedCastorApp('castor-test-compile');
 
         (new Process(

--- a/tests/Slow/RepackCommandTest.php
+++ b/tests/Slow/RepackCommandTest.php
@@ -4,12 +4,20 @@ namespace Castor\Tests\Slow;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 class RepackCommandTest extends TestCase
 {
     public function test()
     {
+        $finder = new ExecutableFinder();
+        $box = $finder->find('box');
+
+        if (null === $box) {
+            $this->markTestSkipped('box is not installed.');
+        }
+
         $castorAppDirPath = self::setupRepackedCastorApp('castor-test-repack');
 
         (new Process([


### PR DESCRIPTION
I'm on arch linux and also on WSL depending on where i work, and i often have some tests that failed not the way there are intended because of the version / binary that are on my env, i make some of them less transient : 

 * force using bash in some cases : this happens because on arch linux sh is in fact bash (it is just an alias most of the time) and so the output is slightly different, i believe this is the same problem as reported in https://github.com/jolicode/castor/pull/377
 
 * force using an existing file for upload, otherwise on some versions of scp it will first test if the file is available before attempting to connect to the remote (which report a different error then)
 
 * skip test if there is no box installed (i don't have it everywhere, and i don't think this is relevant for most setups)