### PR TITLE
Allow to use imported class in task from remote import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@
 * Add support for SSH connection without specifying a user
 * Marked SSH features as stable
 * Import and load task from remote import automatically
-* Fix multiple remote imports of the same package with default version
+* Allow to use imported class in task from remote import
 * Do not load task from `vendor` directory
 * Add `context()` function in expression language to enable a task
 * Deprecate `Castor\GlobalHelper` class. There are no replacements. Use raw
   functions instead
 * Deprecate `AfterApplicationInitializationEvent` event. Use
   `FunctionsResolvedEvent` instead.
+* Fix multiple remote imports of the same package with default version
 
 ## 0.15.0 (2024-04-03)
 

--- a/src/Import/Remote/Composer.php
+++ b/src/Import/Remote/Composer.php
@@ -60,8 +60,7 @@ class Composer
             $this->filesystem->mkdir($dir);
 
             file_put_contents($dir . '.gitignore', "*\n");
-
-            $this->writeJsonFile($dir);
+            file_put_contents("{$dir}/composer.json", json_encode($this->configuration, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
 
             $progressIndicator = null;
             if ($displayProgress) {
@@ -120,11 +119,6 @@ class Composer
             'args' => implode(' ', $args),
             'output' => $process->getOutput(),
         ]);
-    }
-
-    private function writeJsonFile(string $path): void
-    {
-        file_put_contents("{$path}/composer.json", json_encode($this->configuration, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
     }
 
     private function writeInstalled(string $path): void

--- a/src/Import/Remote/PackageImporter.php
+++ b/src/Import/Remote/PackageImporter.php
@@ -24,6 +24,17 @@ class PackageImporter
     ) {
     }
 
+    public function requireAutoload(): void
+    {
+        $autoloadPath = PathHelper::getRoot() . Composer::VENDOR_DIR . 'autoload.php';
+
+        if (!file_exists($autoloadPath)) {
+            return;
+        }
+
+        require $autoloadPath;
+    }
+
     /** @phpstan-param ImportSource $source */
     public function addPackage(string $scheme, string $package, ?string $file = null, ?string $version = null, ?string $vcs = null, ?array $source = null): void
     {
@@ -77,15 +88,9 @@ class PackageImporter
         $forceUpdate = true !== $this->input->getParameterOption('--update-remotes', true);
         $displayProgress = 'list' !== $this->input->getFirstArgument();
 
-        $autoloadPath = PathHelper::getRoot() . Composer::VENDOR_DIR . 'autoload.php';
-
-        if (!file_exists($autoloadPath)) {
-            $forceUpdate = true;
-        }
-
         $this->composer->update($forceUpdate, $displayProgress);
 
-        require_once $autoloadPath;
+        $this->requireAutoload();
 
         foreach ($this->imports as $package => $import) {
             foreach ($import->getFiles() as $file) {

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -49,6 +49,8 @@ final class Kernel
 
     public function boot(InputInterface $input, OutputInterface $output): void
     {
+        $this->packageImporter->requireAutoload();
+
         $this->eventDispatcher->dispatch(new BeforeBootEvent($this->application));
 
         $this->addMount(new Mount($this->rootDir));


### PR DESCRIPTION
Note: Due to the nature of PHP (cannot re-require a file), on the very first run, conditionned task are not loaded.

usage:

```php
<?php
# castor.php
use Doctrine\Common\Collections\Selectable;

use function Castor\import;

import('composer://doctrine/collections', version: '^2.0');

if (interface_exists(Selectable::class)) {
    import(__DIR__.'/test.php');
}
```

```php
<?php
#test.php
use Castor\Attribute\AsTask;
use Doctrine\Common\Collections\ArrayCollection;
use Doctrine\Common\Collections\Criteria;
use Doctrine\Common\Collections\Selectable;

use function Castor\io;

#[AsTask(description: 'Use classes that use imported from remote packages')]
function collection(): void
{
    $collection = new ArrayCollection([1, 2, 3, 4, 5]);

    io()->title('Collection Items');
    foreach ($collection as $item) {
        io()->writeln($item);
    }

    io()->title('Collection Items (matching)');
    $collection = (new TestSelectable())->matching(Criteria::create());

    var_dump($collection->toArray());
}

class TestSelectable implements Selectable
{
    public function matching(Criteria $criteria): ArrayCollection
    {
        return new ArrayCollection(['a', 'b', 'c']);
    }
}
```

cc @TheoD02 