### PR TITLE
feat(import): allow to pause execution with wait for import to use class from imported package

### DIFF
--- a/examples/remote-import-import.phpi
+++ b/examples/remote-import-import.phpi
@@ -1,0 +1,12 @@
+<?php
+
+use function Castor\import;
+use function Castor\wait_for_import;
+
+import('composer://doctrine/collections');
+
+wait_for_import();
+
+if (class_exists('Doctrine\Common\Collections\ArrayCollection')) {
+   echo "doctrine collections imported" . PHP_EOL;
+}

--- a/examples/remote-import.php
+++ b/examples/remote-import.php
@@ -17,6 +17,8 @@ import('package://pyrech/foobar', source: [
     'reference' => 'main', //  commit id, branch or tag name
 ]);
 
+import(__DIR__ . '/remote-import-import.phpi');
+
 #[AsTask(description: 'Use functions imported from remote packages')]
 function remote_tasks(): void
 {

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -71,6 +71,20 @@ final class Kernel
         if (!$hasLoadedPackages) {
             $this->packageImporter->clean();
         }
+
+        // get the list of all fiber executions for imported filed
+        $importedFilesExecution = $this->importer->getImportedFilesExecution();
+
+        /** @var \Fiber $fiber */
+        foreach ($importedFilesExecution as $fiber) {
+            if ($fiber->isTerminated()) {
+                continue;
+            }
+
+            while ($fiber->isSuspended()) {
+                $fiber->resume();
+            }
+        }
     }
 
     public function addMount(Mount $mount): void

--- a/src/functions.php
+++ b/src/functions.php
@@ -445,6 +445,13 @@ function import(string $path, ?string $file = null, ?string $version = null, ?st
     Container::get()->importer->import($path, $file, $version, $vcs, $source);
 }
 
+function wait_for_import(): void
+{
+    if ($fiber = \Fiber::getCurrent()) {
+        $fiber->suspend();
+    }
+}
+
 function mount(string $path, ?string $namespacePrefix = null): void
 {
     if (!is_dir($path)) {

--- a/tests/Examples/Remote/RemoteImportRemoteTasksTest.php.output_no_update.txt
+++ b/tests/Examples/Remote/RemoteImportRemoteTasksTest.php.output_no_update.txt
@@ -1,3 +1,5 @@
+doctrine collections imported
+
 Hello from example!
 ===================
 

--- a/tests/Examples/Remote/RemoteImportRemoteTasksTest.php.output_update.txt
+++ b/tests/Examples/Remote/RemoteImportRemoteTasksTest.php.output_update.txt
@@ -1,6 +1,7 @@
  Downloading remote packages
  Remote packages imported
 
+doctrine collections imported
 
 Hello from example!
 ===================

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -1,3 +1,4 @@
+doctrine collections imported
 completion                                                        Dump the shell completion script
 hello                                                             hello
 help                                                              Display help for a command


### PR DESCRIPTION
It's an alternate way to allow importing class from remote package without having to restart, i think this way is safer and simpler to understand / execute for end user

We basically encpasulate every require in a fiber so an user can pause execution before creating a class or using it directly

Still in draft, just wanted to poc this but i think there are edge case to cover with this (like nested fiber / wait may be badly handled however it's not something that impossible to fix)