### PR TITLE
fix: fix macos static builds

### DIFF
--- a/src/Console/Command/CompileCommand.php
+++ b/src/Console/Command/CompileCommand.php
@@ -83,6 +83,7 @@ class CompileCommand extends Command
             $this->buildPHP(
                 $spcBinaryPath,
                 $phpExtensions,
+                $os = $input->getOption('os'),
                 ('macos' === $os && 'aarch64' === $arch) ? 'arm64' : $arch,
                 $spcBinaryDir,
                 $io,
@@ -173,7 +174,7 @@ class CompileCommand extends Command
         $downloadProcess->mustRun(fn ($type, $buffer) => print $buffer);
     }
 
-    private function buildPHP(string $spcBinaryPath, mixed $phpExtensions, mixed $arch, string $spcBinaryDir, SymfonyStyle $io, bool $debug = false): void
+    private function buildPHP(string $spcBinaryPath, mixed $phpExtensions, mixed $os, mixed $arch, string $spcBinaryDir, SymfonyStyle $io, bool $debug = false): void
     {
         $command = [
             $spcBinaryPath, 'build', $phpExtensions,
@@ -189,10 +190,10 @@ class CompileCommand extends Command
         $buildProcess = new Process(
             command: $command,
             cwd: $spcBinaryDir,
-            env: [
+            env: ('linux' === $os) ? [
                 'OPENSSL_LIBS' => '-l:libssl.a -l:libcrypto.a -ldl -lpthread',
                 'OPENSSL_CFLAGS' => sprintf('-I%s/source/openssl/include', $spcBinaryDir),
-            ],
+            ] : [],
             timeout: null,
         );
         $io->text('Running command: ' . $buildProcess->getCommandLine());


### PR DESCRIPTION
@joelwurtz this should fix the macos static builds.
currently running here: https://github.com/tucksaun/castor/actions/runs/8701701252/job/23864214352

I checked that the binary produced is indeed fully static:
```
 castor-debug $ otool -L /Users/tucksaun/Work/src/github.com/jolicode/castor/castor.darwin-arm64
/Users/tucksaun/Work/src/github.com/jolicode/castor/castor.darwin-arm64:
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 2420.0.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
	/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration (compatibility version 1.0.0, current version 1300.100.9)
	/usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
 castor-debug $ /Users/tucksaun/Work/src/github.com/jolicode/castor/castor.darwin-arm64 --version
castor v0.14.0
```