### PR TITLE
Add `?callable $callback = null` param to `ssh_*` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Deprecate `AfterApplicationInitializationEvent` event. Use
   `FunctionsResolvedEvent` instead.
 * Fix multiple remote imports of the same package with default version
+* Add `?callable $callback = null` param to `ssh_*` functions
 
 ## 0.15.0 (2024-04-03)
 

--- a/examples/ssh.php
+++ b/examples/ssh.php
@@ -4,6 +4,7 @@ namespace ssh;
 
 use Castor\Attribute\AsTask;
 
+use function Castor\io;
 use function Castor\ssh_download;
 use function Castor\ssh_run;
 use function Castor\ssh_upload;
@@ -34,4 +35,17 @@ function upload(): void
 function download(): void
 {
     ssh_download('/tmp/test.html', '/var/www/index.html', host: 'server-1.example.com', user: 'debian');
+}
+
+#[AsTask(description: 'Output in real-time ssh command output')]
+function realTimeOutput(): void
+{
+    ssh_run(
+        command: 'ls -alh',
+        host: 'server-1.example.com',
+        user: 'debian',
+        callback: function ($type, $buffer): void {
+            io()->writeln('REAL TIME OUTPUT> ' . $buffer);
+        }
+    );
 }

--- a/src/Runner/SshRunner.php
+++ b/src/Runner/SshRunner.php
@@ -24,6 +24,7 @@ final class SshRunner
         ?bool $allowFailure = null,
         ?bool $notify = null,
         ?float $timeout = null,
+        ?callable $callback = null,
     ): Process {
         $ssh = $this->buildSsh($host, $user, $sshOptions);
 
@@ -31,7 +32,7 @@ final class SshRunner
             $command = sprintf('cd %s && %s', $path, $command);
         }
 
-        return $this->run($ssh->getExecuteCommand($command), $quiet, $allowFailure, $notify, $timeout);
+        return $this->run($ssh->getExecuteCommand($command), $quiet, $allowFailure, $notify, $timeout, $callback);
     }
 
     /** @phpstan-param SshOptions $sshOptions */
@@ -45,10 +46,11 @@ final class SshRunner
         ?bool $allowFailure = null,
         ?bool $notify = null,
         ?float $timeout = null,
+        ?callable $callback = null,
     ): Process {
         $ssh = $this->buildSsh($host, $user, $sshOptions);
 
-        return $this->run($ssh->getUploadCommand($sourcePath, $destinationPath), $quiet, $allowFailure, $notify, $timeout);
+        return $this->run($ssh->getUploadCommand($sourcePath, $destinationPath), $quiet, $allowFailure, $notify, $timeout, $callback);
     }
 
     /** @phpstan-param SshOptions $sshOptions */
@@ -62,10 +64,11 @@ final class SshRunner
         ?bool $allowFailure = null,
         ?bool $notify = null,
         ?float $timeout = null,
+        ?callable $callback = null,
     ): Process {
         $ssh = $this->buildSsh($host, $user, $sshOptions);
 
-        return $this->run($ssh->getDownloadCommand($sourcePath, $destinationPath), $quiet, $allowFailure, $notify, $timeout);
+        return $this->run($ssh->getDownloadCommand($sourcePath, $destinationPath), $quiet, $allowFailure, $notify, $timeout, $callback);
     }
 
     private function run(
@@ -74,6 +77,7 @@ final class SshRunner
         ?bool $allowFailure = null,
         ?bool $notify = null,
         ?float $timeout = null,
+        ?callable $callback = null,
     ): Process {
         return $this->processRunner->run(
             $command,
@@ -83,7 +87,8 @@ final class SshRunner
             timeout: $timeout,
             quiet: $quiet,
             allowFailure: $allowFailure,
-            notify: $notify
+            notify: $notify,
+            callback: $callback
         );
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -182,8 +182,9 @@ function ssh_run(
     ?bool $allowFailure = null,
     ?bool $notify = null,
     ?float $timeout = null,
+    ?callable $callback = null,
 ): Process {
-    return Container::get()->sshRunner->execute($command, $path, $host, $user, $sshOptions, $quiet, $allowFailure, $notify, $timeout);
+    return Container::get()->sshRunner->execute($command, $path, $host, $user, $sshOptions, $quiet, $allowFailure, $notify, $timeout, $callback);
 }
 
 /**

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -71,6 +71,7 @@ shell:sh                                                          Runs a sh
 signal:sigusr2                                                    Captures SIGUSR2 signal
 ssh:download                                                      Downloads a file from the remote server
 ssh:ls                                                            Lists content of /var/www directory on the remote server
+ssh:real-time-output                                              Output in real-time ssh command output
 ssh:upload                                                        Uploads a file to the remote server
 ssh:whoami                                                        Connect to a remote server without specifying a user
 symfony:greet

--- a/tests/Generated/SshRealTimeOutputTest.php
+++ b/tests/Generated/SshRealTimeOutputTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class SshRealTimeOutputTest extends TaskTestCase
+{
+    // ssh:real-time-output
+    public function test(): void
+    {
+        $process = $this->runTask(['ssh:real-time-output']);
+
+        if (1 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/SshRealTimeOutputTest.php.err.txt
+++ b/tests/Generated/SshRealTimeOutputTest.php.err.txt
@@ -1,0 +1,9 @@
+In SshRunner.php line XXXX:
+
+  The command "ssh  debian@server-1.example.com 'bash -se' << \EOF-SPATIE-SSH
+  ls -alh
+  EOF-SPATIE-SSH" failed.
+
+
+ssh:real-time-output
+

--- a/tests/Generated/SshRealTimeOutputTest.php.output.txt
+++ b/tests/Generated/SshRealTimeOutputTest.php.output.txt
@@ -1,0 +1,2 @@
+REAL TIME OUTPUT> ssh: Could not resolve hostname server-1.example.com: Name or service not known
+


### PR DESCRIPTION
I wanted to use a stream of a docker postgres dump through ssh as an input stream of a local process gzipping it but found out there's no way to do that currently with ssh_* functions.

A few notes:
- ssh functions tests aren't that useful in their current state, I didn't want to introduce a ssh service on CI to fix that in this PR but definitely could be considered in an other PR if maintainers are fine with the idea.
- I wish there would be a way to use `run()` but without forcing the implicit `wait()` in its execution.
- A `pipe(...Process)` function would be a great addition in my opinion, something like:

```php
pipe(
        ssh_run('dump postgres'),
        run('gunzip'),
        run('s3://dumps/'),
    );
```
 