### PR TITLE
Enable 'filter' extension by default when compiling

### DIFF
--- a/src/Console/Command/CompileCommand.php
+++ b/src/Console/Command/CompileCommand.php
@@ -19,7 +19,7 @@ class CompileCommand extends Command
 {
     // When something **important** related to the compilation changed, increase
     // this version to invalide the cache
-    private const CACHE_VERSION = '1';
+    private const CACHE_VERSION = '2';
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
@@ -39,7 +39,7 @@ class CompileCommand extends Command
             ->addOption('os', null, InputOption::VALUE_REQUIRED, 'Target OS for PHP compilation', 'linux', ['linux', 'macos'])
             ->addOption('arch', null, InputOption::VALUE_REQUIRED, 'Target architecture for PHP compilation', 'x86_64', ['x86_64', 'aarch64'])
             ->addOption('php-version', null, InputOption::VALUE_REQUIRED, 'PHP version in major.minor format', '8.3')
-            ->addOption('php-extensions', null, InputOption::VALUE_REQUIRED, 'PHP extensions required, in a comma-separated format. Defaults are the minimum required to run a basic "Hello World" task in Castor.', 'mbstring,phar,posix,tokenizer,curl,openssl')
+            ->addOption('php-extensions', null, InputOption::VALUE_REQUIRED, 'PHP extensions required, in a comma-separated format. Defaults are the minimum required to run a basic "Hello World" task in Castor.', 'mbstring,phar,posix,tokenizer,curl,filter,openssl')
             ->addOption('php-rebuild', null, InputOption::VALUE_NONE, 'Ignore cache and force PHP build compilation.')
             ->setHidden(true)
         ;


### PR DESCRIPTION
fix #385
