### PR TITLE
fix: Auto create `.castor` directory when calling `init` composer command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Deprecate `AfterApplicationInitializationEvent` event. Use
   `FunctionsResolvedEvent` instead.
 * Fix multiple remote imports of the same package with default version
+* Fix issue for init `castor.composer.json` when `.castor` directory not exists
 
 ## 0.15.0 (2024-04-03)
 

--- a/src/Console/Command/ComposerCommand.php
+++ b/src/Console/Command/ComposerCommand.php
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
+use function Castor\io;
+
 /** @internal */
 #[AsCommand(
     name: 'castor:composer',
@@ -39,14 +41,28 @@ final class ComposerCommand extends Command
     {
         $extra = array_filter($this->getRawTokens($input), fn ($item) => 'composer' !== $item);
 
-        $vendorDirectory = $this->rootDir . Composer::VENDOR_DIR;
+        $workingDirectory = $this->rootDir . Composer::WORKING_DIR;
+
+        $isInit = \in_array('init', $extra, true);
+
+        if (!is_dir($workingDirectory)) {
+            if ($isInit) {
+                if (!mkdir($workingDirectory, 0o777, true) && !is_dir($workingDirectory)) {
+                    throw new \RuntimeException(sprintf('Directory "%s" was not created', $workingDirectory));
+                }
+            } elseif (!is_dir($workingDirectory)) {
+                io()->error('No vendor directory found. Run "castor composer init" to initialize composer.');
+
+                return Command::FAILURE;
+            }
+        }
 
         if (!file_exists($file = $this->rootDir . '/castor.composer.json') && !file_exists($file = $this->rootDir . '/.castor/castor.composer.json')) {
             // Default to the root directory (so someone can do a composer init by example)
             $file = $this->rootDir . '/castor.composer.json';
         }
 
-        $this->composer->run($file, $vendorDirectory, $extra, $output, true);
+        $this->composer->run($file, $workingDirectory, $extra, $output, true);
 
         return Command::SUCCESS;
     }

--- a/src/Import/Remote/Composer.php
+++ b/src/Import/Remote/Composer.php
@@ -17,6 +17,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class Composer
 {
     public const VENDOR_DIR = '/.castor/vendor/';
+    public const WORKING_DIR = '/.castor';
 
     public function __construct(
         private readonly Filesystem $filesystem,
@@ -28,6 +29,7 @@ class Composer
     public function install(string $entrypointDirectory, bool $update = false, bool $displayProgress = true): void
     {
         $vendorDirectory = $entrypointDirectory . self::VENDOR_DIR;
+        $workingDir = $entrypointDirectory . self::WORKING_DIR;
 
         if (!file_exists($file = $entrypointDirectory . '/castor.composer.json') && !file_exists($file = $entrypointDirectory . '/.castor/castor.composer.json')) {
             $this->logger->debug(sprintf('The castor.composer.json file does not exists in %s or %s/.castor, skipping composer install.', $entrypointDirectory, $entrypointDirectory));
@@ -54,7 +56,7 @@ class Composer
 
         $command = $update ? 'update' : 'install';
 
-        $this->run($file, $vendorDirectory, [$command], callback: function () use ($progressIndicator) {
+        $this->run($file, $workingDir, [$command], callback: function () use ($progressIndicator) {
             if ($progressIndicator) {
                 $progressIndicator->advance();
             }
@@ -75,10 +77,10 @@ class Composer
     /**
      * @param string[] $args
      */
-    public function run(string $composerJsonFilePath, string $vendorDirectory, array $args, callable|OutputInterface $callback, bool $allowInteraction = false): void
+    public function run(string $composerJsonFilePath, string $workingDirectory, array $args, callable|OutputInterface $callback, bool $allowInteraction = false): void
     {
         $args[] = '--working-dir';
-        $args[] = \dirname($vendorDirectory);
+        $args[] = $workingDirectory;
 
         if (!$allowInteraction) {
             $args[] = '--no-interaction';


### PR DESCRIPTION
Hello !

Just wanted to test new import system, and an error occur when no `.castor` directory is present.

Because by default the working directory of composer is defined to `.castor` and composer don't accept it : 
![image](https://github.com/jolicode/castor/assets/72203064/db80a52d-d018-4c59-aea1-c48deb8e3762)

The fixed behavior now : 
![image](https://github.com/jolicode/castor/assets/72203064/e38e18a6-b04e-4d32-8485-b7f3fd3ffe38)
