### PR TITLE
feat: Add possibility to use custom title for notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   functions instead
 * Deprecate `AfterApplicationInitializationEvent` event. Use
   `FunctionsResolvedEvent` instead.
+* Add `notificationTitle` property to `Context` to set the application name for
+  notifications title
 
 ## 0.15.0 (2024-04-03)
 

--- a/doc/going-further/helpers/notify.md
+++ b/doc/going-further/helpers/notify.md
@@ -36,3 +36,34 @@ function notify()
     run('command_that_does_not_exist', notify: true); // will display a failure notification
 }
 ```
+
+## Customizing the notification title
+
+You can set a custom title for notifications by setting the `notificationTitle` property in the context or
+by passing a second argument to the `notify()` function:
+
+> [!NOTE]
+> By default the title is "Castor".
+> The second argument of the `notify()` function will override the title set in the context.
+
+```php
+use Castor\Attribute\AsTask;
+
+use function Castor\notify;
+use Castor\Context;
+
+#[AsContext(default: true)]
+function my_context(): Context
+{
+    return new Context(
+        notificationTitle: 'My custom title'
+    );
+}
+
+#[AsTask()]
+function notify()
+{
+    notify('Hello world!'); // will display a notification with the title "My custom title"
+    notify('Hello world!', 'Specific title'); // will display a notification with the title "Specific title"
+}
+```

--- a/examples/notify.php
+++ b/examples/notify.php
@@ -4,8 +4,10 @@ namespace notify;
 
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\notify;
 use function Castor\run;
+use function Castor\with;
 
 #[AsTask(description: 'Sends a notification when the task finishes')]
 function notify_on_finish(): void
@@ -17,4 +19,21 @@ function notify_on_finish(): void
 function send_notify(): void
 {
     notify('Hello world!');
+}
+
+#[AsTask(description: 'Sends a notification with a custom title')]
+function send_notify_with_custom_title(): void
+{
+    notify('Hello world!'); // Will use 'Castor' by default if "notificationTitle" is not set in context
+
+    // Set application name in context
+    with(
+        callback: function () {
+            notify('Hello world!'); // Will use 'My App Name' by default
+        },
+        context: context()->withNotificationTitle('My App Name')
+    );
+
+    // Override the title of context
+    notify('Hello world!', 'Custom Title'); // Will use 'Custom Title' as title, ignoring context
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -30,6 +30,7 @@ class Context implements \ArrayAccess
         public readonly VerbosityLevel|LegacyVerbosityLevel $verbosityLevel = VerbosityLevel::NOT_CONFIGURED,
         // Do not use this argument, it is only used internally by the application
         public readonly string $name = '',
+        public readonly string $notificationTitle = '',
     ) {
         $this->workingDirectory = $workingDirectory ?? PathHelper::getRoot();
     }
@@ -48,6 +49,7 @@ class Context implements \ArrayAccess
             'allowFailure' => $this->allowFailure,
             'notify' => $this->notify,
             'verbosityLevel' => $this->verbosityLevel,
+            'notificationTitle' => $this->notificationTitle,
         ];
     }
 
@@ -82,6 +84,7 @@ class Context implements \ArrayAccess
             $this->notify,
             $this->verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -100,6 +103,7 @@ class Context implements \ArrayAccess
             $this->notify,
             $this->verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -124,6 +128,7 @@ class Context implements \ArrayAccess
             $this->notify,
             $this->verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -141,6 +146,7 @@ class Context implements \ArrayAccess
             $this->notify,
             $this->verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -158,6 +164,7 @@ class Context implements \ArrayAccess
             $this->notify,
             $this->verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -175,6 +182,7 @@ class Context implements \ArrayAccess
             $this->notify,
             $this->verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -192,6 +200,7 @@ class Context implements \ArrayAccess
             $this->notify,
             $this->verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -209,6 +218,7 @@ class Context implements \ArrayAccess
             $this->notify,
             $this->verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -226,6 +236,7 @@ class Context implements \ArrayAccess
             $notify,
             $this->verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -243,6 +254,7 @@ class Context implements \ArrayAccess
             $this->notify,
             $verbosityLevel,
             $this->name,
+            $this->notificationTitle,
         );
     }
 
@@ -260,6 +272,25 @@ class Context implements \ArrayAccess
             $this->notify,
             $this->verbosityLevel,
             $name,
+            $this->notificationTitle,
+        );
+    }
+
+    public function withNotificationTitle(string $notificationTitle): self
+    {
+        return new self(
+            $this->data,
+            $this->environment,
+            $this->workingDirectory,
+            $this->tty,
+            $this->pty,
+            $this->timeout,
+            $this->quiet,
+            $this->allowFailure,
+            $this->notify,
+            $this->verbosityLevel,
+            $this->name,
+            $notificationTitle,
         );
     }
 

--- a/src/Helper/Notifier.php
+++ b/src/Helper/Notifier.php
@@ -8,6 +8,8 @@ use Joli\JoliNotif\Notifier as JoliNotifier;
 use Joli\JoliNotif\Notifier\NullNotifier;
 use Psr\Log\LoggerInterface;
 
+use function Castor\context;
+
 class Notifier
 {
     public function __construct(
@@ -16,10 +18,10 @@ class Notifier
     ) {
     }
 
-    public function send(string $message): void
+    public function send(string $message, ?string $title = null): void
     {
         $notification = (new Notification())
-            ->setTitle('Castor')
+            ->setTitle($title ?? $this->getNotifyTitle())
             ->setBody($message)
         ;
 
@@ -40,5 +42,14 @@ class Notifier
         } catch (\Throwable $e) {
             $this->logger->error('Failed to send notification: ' . $e->getMessage());
         }
+    }
+
+    private function getNotifyTitle(): string
+    {
+        if ('' !== context()->notificationTitle) {
+            return context()->notificationTitle;
+        }
+
+        return 'Castor';
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -247,9 +247,9 @@ function ssh_download(
     return Container::get()->sshRunner->download($sourcePath, $destinationPath, $host, $user, $sshOptions, $quiet, $allowFailure, $notify, $timeout);
 }
 
-function notify(string $message): void
+function notify(string $message, ?string $title = null): void
 {
-    Container::get()->notifier->send($message);
+    Container::get()->notifier->send($message, $title);
 }
 
 /**

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -47,6 +47,7 @@ log:with-context                                                  Logs an "error
 not-rename:renamed                                                Task that was renamed
 notify:notify-on-finish                                           Sends a notification when the task finishes
 notify:send-notify                                                Sends a notification
+notify:send-notify-with-custom-title                              Sends a notification with a custom title
 open:documentation                                                Open Castor documentation in the default browser
 open:multiple                                                     Open an URL and a file in the default applications
 output:output                                                     Plays with Symfony Style

--- a/tests/Generated/NotifySendNotifyWithCustomTitleTest.php
+++ b/tests/Generated/NotifySendNotifyWithCustomTitleTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class NotifySendNotifyWithCustomTitleTest extends TaskTestCase
+{
+    // notify:send-notify-with-custom-title
+    public function test(): void
+    {
+        $process = $this->runTask(['notify:send-notify-with-custom-title']);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertSame('', $process->getErrorOutput());
+    }
+}


### PR DESCRIPTION
## Description
This pull request introduces a new method `set_notify_title()` to allow customization of notification title. Currently, the title of notifications is fixed, but with this enhancement, users can set a custom title for notifications according to their preferences. 

This customization is particularly useful for distinguishing notifications from different applications. By default, notifications are sent with the title `Castor`, making it difficult to determine which application triggered the notification. With this enhancement, users can specify a meaningful title, providing clarity on the source of the notification.

## Changes Made
- Added `set_notify_title()` method to allow setting custom notification title.

## Usage Example
```php
use Castor\Attribute\AsTask;

use function Castor\notify;
use function Castor\set_notify_title;

set_notify_title('My custom title');

#[AsTask()]
function notify()
{
    notify('Hello world!'); // will display a notification with the title "My custom title"
}
```

Waiting for your feeback :smile: 

Update : 

## Changes Made
- Added `notificationTitle` property in `Context` with empty default value
- Added second argument named `title` to `notify` to override the title 

