### PR TITLE
Fix GA static build

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -82,6 +82,8 @@ jobs:
       - uses: ./.github/actions/static
         with:
           os: 'linux'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload the Linux amd64 static binary
         uses: actions/upload-artifact@v4
@@ -113,6 +115,8 @@ jobs:
       - uses: ./.github/actions/static
         with:
           os: 'darwin-amd64'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload the MacOs amd64 static binary
         uses: actions/upload-artifact@v4
@@ -144,6 +148,8 @@ jobs:
       - uses: ./.github/actions/static
         with:
           os: 'darwin-arm64'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload the MacOs arm64 static binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,5 @@ jobs:
       - uses: ./.github/actions/cache
       - uses: ./.github/actions/phar
       - uses: ./.github/actions/static
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Should fix the building error we see on the job "[Create MacOs arm64 static binary and upload](https://github.com/jolicode/castor/actions/runs/9125301982/job/25091230617#logs)"

Before : 
![image](https://github.com/jolicode/castor/assets/2021641/bc843ea0-7749-45d3-a312-ba992be3c062)

After, the token seems to be correctly taken into account :

![image](https://github.com/jolicode/castor/assets/2021641/cbfb9545-546a-4bf1-b975-4dcc1c5b68dc)

Note: This is handled by this code in [static-php-cli](https://github.com/crazywhalecc/static-php-cli/blob/5d2bd93bd7adc6898dc230d40d11a137510b8344/src/SPC/store/CurlHook.php#L16).