### PR TITLE
feat(run): deprecate parameters in run function that are in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 * Add `Castor\Event\ContextCreatedEvent` to allow updating the context after it is created
 * Add `run_phar()` function to run a phar file in all contexts
 
+### Deprecations
+
+* Deprecate all arguments in `run()` function that are already in the context
+
 ## 0.17.1 (2024-05-31)
 
 ### Fixes

--- a/doc/getting-started/run.md
+++ b/doc/getting-started/run.md
@@ -43,84 +43,22 @@ function foo(): void
 > [!TIP]
 > Related example: [run.php](https://github.com/jolicode/castor/blob/main/examples/run.php)
 
-## Failure
-
-By default, Castor will throw an exception if the process fails. You can disable
-that by setting the `allowFailure` option to `true`:
-
-```php
-use Castor\Attribute\AsTask;
-
-use function Castor\run;
-
-#[AsTask()]
-function foo(): void
-{
-    run('a_command_that_does_not_exist', allowFailure: true);
-}
-```
-
-> [!TIP]
-> Related example: [failure.php](https://github.com/jolicode/castor/blob/main/examples/failure.php)
-
-## Working directory
-
-By default, Castor will execute the process in the same directory as
-the `castor.php` file. You can change that by setting the `workingDirectory`
-argument. It can be either a relative or an absolute path:
-
-```php
-use Castor\Attribute\AsTask;
-
-use function Castor\run;
-
-#[AsTask()]
-function foo(): void
-{
-    run('pwd', workingDirectory: '../'); // run the process in the parent directory of the castor.php file
-    run('pwd', workingDirectory: '/tmp'); // run the process in the /tmp directory
-}
-```
-
-> [!TIP]
-> Related example: [cd.php](https://github.com/jolicode/castor/blob/main/examples/cd.php)
-
-## Environment variables
-
-By default, Castor will use the same environment variables as the current
-process. You can add or override environment variables by setting
-the `environment` argument:
-
-```php
-use Castor\Attribute\AsTask;
-
-use function Castor\run;
-
-#[AsTask()]
-function foo(): void
-{
-    run('echo $FOO', environment: ['FOO' => 'bar']); // will print "bar"
-}
-```
-
-> [!TIP]
-> Related example: [env.php](https://github.com/jolicode/castor/blob/main/examples/env.php)
-
 ## Processing the output
 
 By default, Castor will forward the stdout and stderr to the current terminal.
-If you do not want to print the process output you can set the `quiet`
-option to `true`:
+If you do not want to print the process output you can use a context with the
+`quiet` option to true:
 
 ```php
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\run;
 
 #[AsTask()]
 function foo(): void
 {
-    run('echo "bar"', quiet: true); // will not print anything
+    run('echo "bar"', context: context()->withQuiet()); // will not print anything
 }
 ```
 
@@ -130,12 +68,13 @@ returned `Symfony\Component\Process\Process` object:
 ```php
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\run;
 
 #[AsTask()]
 function foo(): void
 {
-    $process = run('echo "bar"', quiet: true); // will not print anything
+    $process = run('echo "bar"', context: context()->withQuiet())); // will not print anything
     $output = $process->getOutput(); // will return "bar\n"
 }
 ```
@@ -186,29 +125,6 @@ function cs(): int
 
 > [!TIP]
 > Related example: [run.php](https://github.com/jolicode/castor/blob/main/examples/run.php)
-
-## Timeout
-
-By default, Castor allow your `run()` calls to go indefinitly.
-
-If you want to tweak that you need to set the `timeout` argument.
-
-```php
-use Castor\Attribute\AsTask;
-
-use function Castor\run;
-
-#[AsTask()]
-function foo(): void
-{
-    run('my-script.sh', timeout: 120);
-}
-```
-
-This process will have a 2 minutes timeout.
-
-> [!TIP]
-> Related example: [wait_for.php](https://github.com/jolicode/castor/blob/main/examples/wait_for.php)
 
 ## Interactive Process
 

--- a/doc/going-further/extending-castor/mount.md
+++ b/doc/going-further/extending-castor/mount.md
@@ -46,11 +46,12 @@ kind of code:
 ```php
 use function Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\run;
 
 #[AsTask()]
 function foobar() {
-    run($command, workingDirectory: __DIR__);
+    run($command, context: context()->withWorkingDirectory(__DIR__));
 }
 ```
 

--- a/doc/going-further/helpers/notify.md
+++ b/doc/going-further/helpers/notify.md
@@ -21,19 +21,20 @@ function notify()
 
 ## Notify with `run()`
 
-You can use the `notify` argument of the `run()` function to display a
+You can use the `withNotify` method of the `Context` object to display a
 notification when a command has been executed:
 
 ```php
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\run;
 
 #[AsTask()]
 function notify()
 {
-    run(['echo', 'notify'], notify: true); // will display a success notification
-    run('command_that_does_not_exist', notify: true); // will display a failure notification
+    run(['echo', 'notify'], context: context()->withNotify(true)); // will display a success notification
+    run('command_that_does_not_exist', context: context()->withNotify(true)); // will display a failure notification
 }
 ```
 
@@ -45,6 +46,7 @@ You can set the `notify` property in the context to `false` to disable notificat
 use Castor\Attribute\AsTask;
 
 use Castor\Context;
+use function Castor\context;
 use function Castor\notify;
 use function Castor\run;
 use function Castor\with;
@@ -57,7 +59,7 @@ function notify()
             notify('Hello world!'); // will not display a notification
             run('ls'); // will not display a notification
             
-            run('ls', notify: true); // will display a notification (you override the context value on the fly)
+            run('ls', context: context()->withNotify()); // will display a notification (you override the context value on the fly)
         },
         context: new Context(notify: false),
     );
@@ -72,6 +74,7 @@ You can also set the `notify` property in the context to `null` that mean all us
 use Castor\Attribute\AsTask;
 
 use Castor\Context;
+use function Castor\context;
 use function Castor\notify;
 
 #[AsTask()]
@@ -80,7 +83,7 @@ function notify()
     with(
         callback: function () {
             run('ls'); // will not display a notification
-            run('ls', notify: true); // will display a notification
+            run('ls', context: context()->withNotify()); // will display a notification
             notify('Hello world!'); // will display a notification
         },
         context: new Context(notify: null),

--- a/doc/going-further/helpers/parallel.md
+++ b/doc/going-further/helpers/parallel.md
@@ -8,6 +8,7 @@ so you do not have to wait for a function to finish before starting another one:
 ```php
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\io;
 use function Castor\parallel;
 
@@ -16,10 +17,10 @@ function foo(): void
 {
     [$foo, $bar] = parallel(
         function () {
-            return run('sleep 2 && echo foo', quiet: true);
+            return run('sleep 2 && echo foo', context: context()->withQuiet());
         },
         function () {
-            return run('sleep 2 && echo bar', quiet: true);
+            return run('sleep 2 && echo bar', context: context()->withQuiet());
         }
     );
 

--- a/doc/going-further/helpers/wait-for.md
+++ b/doc/going-further/helpers/wait-for.md
@@ -143,7 +143,7 @@ Example:
 wait_for_docker_container(
     container: 'mysql-container',
     containerChecker: function ($containerId) {
-        return run("docker exec $containerId mysql -uroot -proot -e 'SELECT 1'", allowFailure: true)->isSuccessful();
+        return run("docker exec $containerId mysql -uroot -proot -e 'SELECT 1'", context: context()->withAllowFailure()))->isSuccessful();
     },
     portsToCheck: [3306]
     timeout: 30,

--- a/examples/cd.php
+++ b/examples/cd.php
@@ -4,12 +4,13 @@ namespace cd;
 
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\run;
 
 #[AsTask(description: 'Changes directory')]
 function directory(): void
 {
     run(['pwd']);
-    run(['pwd'], workingDirectory: 'src/Attribute');
+    run(['pwd'], context: context()->withWorkingDirectory('src/Attribute'));
     run(['pwd']);
 }

--- a/examples/context.php
+++ b/examples/context.php
@@ -62,8 +62,8 @@ function productionContext(): Context
 function runContext(): Context
 {
     $blankContext = new Context();
-    $production = (bool) trim(run('echo $PRODUCTION', quiet: true, context: $blankContext)->getOutput());
-    $foo = trim(run('echo $FOO', quiet: true, context: $blankContext)->getOutput()) ?: 'no defined';
+    $production = (bool) trim(run('echo $PRODUCTION', context: $blankContext->withQuiet())->getOutput());
+    $foo = trim(run('echo $FOO', context: $blankContext->withQuiet())->getOutput()) ?: 'no defined';
 
     return new Context([
         'name' => 'run',

--- a/examples/env.php
+++ b/examples/env.php
@@ -4,12 +4,13 @@ namespace env;
 
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\run;
 
 #[AsTask(description: 'Display environment variables')]
 function env(): void
 {
-    run('echo \"$FOO\"', environment: [
+    run('echo \"$FOO\"', context: context()->withEnvironment([
         'FOO' => 'toto',
-    ]);
+    ]));
 }

--- a/examples/failure.php
+++ b/examples/failure.php
@@ -4,16 +4,17 @@ namespace failure;
 
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\run;
 
 #[AsTask(description: 'A failing task not authorized to fail')]
 function failure(): void
 {
-    run('bash -c i_do_not_exist', workingDirectory: '/tmp', pty: false);
+    run('bash -c i_do_not_exist', context: context()->withWorkingDirectory('/tmp')->withPty(false));
 }
 
 #[AsTask(description: 'A failing task authorized to fail')]
 function allow_failure(): void
 {
-    run('bash -c i_do_not_exist', allowFailure: true, pty: false);
+    run('bash -c i_do_not_exist', context: context()->withAllowFailure()->withPty(false));
 }

--- a/examples/notify.php
+++ b/examples/notify.php
@@ -12,7 +12,7 @@ use function Castor\with;
 #[AsTask(description: 'Sends a notification when the task finishes')]
 function notify_on_finish(): void
 {
-    run(['sleep', '0.1'], notify: true);
+    run(['sleep', '0.1'], context: context()->withNotify());
 }
 
 #[AsTask(description: 'Sends a notification')]
@@ -24,7 +24,7 @@ function send_notify(): void
             run(['sleep', '0.1']); // Will not send a notification
             notify('Hello world! (send with null)'); // Will send a notification
 
-            run(['sleep', '0.1'], notify: true); // Will send a notification for this specific run
+            run(['sleep', '0.1'], context: context()->withNotify()); // Will send a notification for this specific run
         },
         context: context()->withNotify(null)
     );
@@ -35,7 +35,7 @@ function send_notify(): void
             run(['sleep', '0.1']); // Will not send a notification
             notify('Hello world! (not send)'); // Will not send a notification
 
-            run(['sleep', '0.1'], notify: true); // Will send a notification
+            run(['sleep', '0.1'], context: context()->withNotify()); // Will send a notification
         },
         context: context()->withNotify(false)
     );
@@ -46,7 +46,7 @@ function send_notify(): void
             run(['sleep', '0.1']); // Will send a notification
             notify('Hello world! (send with true)'); // Will send a notification
 
-            run(['sleep', '0.1'], notify: false); // Will not send a notification for this specific run
+            run(['sleep', '0.1'], context: context()->withNotify(false)); // Will not send a notification for this specific run
         },
         context: context()->withNotify(true)
     );

--- a/examples/quiet.php
+++ b/examples/quiet.php
@@ -4,10 +4,11 @@ namespace quiet;
 
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\run;
 
 #[AsTask(description: 'Executes something but does not output anything')]
 function quiet(): void
 {
-    run('ls -alh', quiet: true);
+    run('ls -alh', context: context()->withQuiet());
 }

--- a/examples/run.php
+++ b/examples/run.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Helper\ProcessHelper;
 
 use function Castor\app;
 use function Castor\capture;
+use function Castor\context;
 use function Castor\exit_code;
 use function Castor\io;
 use function Castor\output;
@@ -19,7 +20,7 @@ function ls(): void
     if (OsHelper::isWindows()) {
         $process = run('dir');
     } else {
-        $process = run('ls -alh && echo $foo', quiet: true, environment: ['foo' => 'ba\'"`r']);
+        $process = run('ls -alh && echo $foo', context: context()->withQuiet()->withEnvironment(['foo' => 'ba\'"`r']));
     }
 
     io()->writeln('Output:' . $process->getOutput());
@@ -30,7 +31,7 @@ function ls(): void
 #[AsTask(description: 'Run a sub-process with environment variables and display information about it')]
 function variables(): void
 {
-    $process = run('echo $foo', quiet: true, environment: ['foo' => 'ba\'"`r']);
+    $process = run('echo $foo', context: context()->withQuiet()->withEnvironment(['foo' => 'ba\'"`r']));
 
     io()->writeln('Output: ' . $process->getOutput());
     io()->writeln('Error output: ' . $process->getErrorOutput());
@@ -60,7 +61,7 @@ function exception(): void
         output()->writeln('Re-run with -v, -vv, -vvv for different output.');
     }
 
-    run('echo foo; echo bar>&2; exit 1', pty: false, quiet: true);
+    run('echo foo; echo bar>&2; exit 1', context: context()->withPty(false)->withQuiet());
 }
 
 #[AsTask(description: 'Run a sub-process and display information about it, with ProcessHelper')]

--- a/examples/shell.php
+++ b/examples/shell.php
@@ -4,16 +4,17 @@ namespace shell;
 
 use Castor\Attribute\AsTask;
 
+use function Castor\context;
 use function Castor\run;
 
 #[AsTask(description: 'Runs a bash')]
 function bash(): void
 {
-    run('bash', tty: true);
+    run('bash', context: context()->withTty());
 }
 
 #[AsTask(description: 'Runs a sh')]
 function sh(): void
 {
-    run('sh', tty: true);
+    run('sh', context: context()->withTty());
 }

--- a/examples/wait_for.php
+++ b/examples/wait_for.php
@@ -8,6 +8,7 @@ use Castor\Exception\WaitFor\TimeoutReachedException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 use function Castor\capture;
+use function Castor\context;
 use function Castor\io;
 use function Castor\run;
 use function Castor\wait_for;
@@ -100,13 +101,13 @@ function wait_for_docker_container_task(): void
 {
     try {
         $checkLogSince = date(\DATE_RFC3339);
-        run('docker run -d --rm --name helloworld alpine sh -c "echo hello world ; sleep 10"', quiet: true);
+        run('docker run -d --rm --name helloworld alpine sh -c "echo hello world ; sleep 10"', context: context()->withQuiet());
         wait_for_docker_container(
             containerName: 'helloworld',
             timeout: 5,
             containerChecker: function ($containerId) use ($checkLogSince): bool {
                 // Check some things (logs, command result, etc.)
-                $output = capture("docker logs --since {$checkLogSince} {$containerId}", allowFailure: true);
+                $output = capture("docker logs --since {$checkLogSince} {$containerId}", context: context()->withAllowFailure());
 
                 return u($output)->containsAny(['hello world']);
             },

--- a/src/Helper/Waiter.php
+++ b/src/Helper/Waiter.php
@@ -15,6 +15,8 @@ use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+use function Castor\context;
+
 /** @internal */
 final class Waiter
 {
@@ -238,9 +240,9 @@ final class Waiter
         $this->waitFor(
             io: $io,
             callback: function () use ($timeout, $io, $portsToCheck, $containerChecker, $containerName) {
-                $containerId = $this->processRunner->capture("docker ps -a -q --filter name={$containerName}", allowFailure: true);
+                $containerId = $this->processRunner->capture("docker ps -a -q --filter name={$containerName}", context: context()->withAllowFailure());
                 $isContainerExist = (bool) $containerId;
-                $isContainerRunning = (bool) $this->processRunner->capture("docker inspect -f '{{.State.Running}}' {$containerId}", allowFailure: true);
+                $isContainerRunning = (bool) $this->processRunner->capture("docker inspect -f '{{.State.Running}}' {$containerId}", context: context()->withAllowFailure());
 
                 if (false === $isContainerExist) {
                     throw new DockerContainerStateException($containerName, 'not exist');

--- a/src/Import/Remote/Composer.php
+++ b/src/Import/Remote/Composer.php
@@ -116,7 +116,7 @@ class Composer
 
         if ('composer' === $scheme || 'package' === $scheme) {
             if ('package' === $scheme) {
-                @trigger_deprecation('castor/castor', '0.16.0', 'The "package" scheme is deprecated, use "composer" instead.');
+                trigger_deprecation('castor/castor', '0.16.0', 'The "package" scheme is deprecated, use "composer" instead.');
             }
 
             $packageDirectory = PathHelper::getCastorVendorDir() . '/' . $package;

--- a/src/Runner/ProcessRunner.php
+++ b/src/Runner/ProcessRunner.php
@@ -14,8 +14,10 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
+use function Castor\context;
 use function Castor\Internal\fix_exception;
 
+/** @internal */
 class ProcessRunner
 {
     public function __construct(
@@ -48,34 +50,50 @@ class ProcessRunner
         $context ??= $this->contextRegistry->getCurrentContext();
 
         if (null !== $environment) {
+            trigger_deprecation('jolicode/castor', '0.18', 'The "environment" argument is deprecated, use the "Context" object instead.');
+
             $context = $context->withEnvironment($environment);
         }
 
         if ($workingDirectory) {
+            trigger_deprecation('jolicode/castor', '0.18', 'The "workingDirectory" argument is deprecated, use the "Context" object instead.');
+
             $context = $context->withWorkingDirectory($workingDirectory);
         }
 
         if (null !== $tty) {
+            trigger_deprecation('jolicode/castor', '0.18', 'The "tty" argument is deprecated, use the "Context" object instead.');
+
             $context = $context->withTty($tty);
         }
 
         if (null !== $pty) {
+            trigger_deprecation('jolicode/castor', '0.18', 'The "pty" argument is deprecated, use the "Context" object instead.');
+
             $context = $context->withPty($pty);
         }
 
         if (null !== $timeout) {
+            trigger_deprecation('jolicode/castor', '0.18', 'The "timeout" argument is deprecated, use the "Context" object instead.');
+
             $context = $context->withTimeout($timeout);
         }
 
         if (null !== $quiet) {
+            trigger_deprecation('jolicode/castor', '0.18', 'The "quiet" argument is deprecated, use the "Context" object instead.');
+
             $context = $context->withQuiet($quiet);
         }
 
         if (null !== $allowFailure) {
+            trigger_deprecation('jolicode/castor', '0.18', 'The "allowFailure" argument is deprecated, use the "Context" object instead.');
+
             $context = $context->withAllowFailure($allowFailure);
         }
 
         if (null !== $notify) {
+            trigger_deprecation('jolicode/castor', '0.18', 'The "notify" argument is deprecated, use the "Context" object instead.');
+
             $context = $context->withNotify($notify);
         }
 
@@ -184,11 +202,14 @@ class ProcessRunner
         ?Context $context = null,
     ): string {
         $hasOnFailure = null !== $onFailure;
+        $context ??= context();
+
         if ($hasOnFailure) {
             if (null !== $allowFailure) {
                 throw new \LogicException('The "allowFailure" argument cannot be used with "onFailure".');
             }
-            $allowFailure = true;
+
+            $context = $context->withAllowFailure();
         }
 
         $process = $this->run(
@@ -197,8 +218,7 @@ class ProcessRunner
             workingDirectory: $workingDirectory,
             timeout: $timeout,
             allowFailure: $allowFailure,
-            context: $context,
-            quiet: true,
+            context: $context->withQuiet(),
         );
 
         if ($hasOnFailure && !$process->isSuccessful()) {
@@ -225,8 +245,7 @@ class ProcessRunner
             environment: $environment,
             workingDirectory: $workingDirectory,
             timeout: $timeout,
-            allowFailure: true,
-            context: $context,
+            context: ($context ?? context())->withAllowFailure(),
             quiet: $quiet,
         );
 

--- a/src/Runner/SshRunner.php
+++ b/src/Runner/SshRunner.php
@@ -5,6 +5,8 @@ namespace Castor\Runner;
 use Spatie\Ssh\Ssh;
 use Symfony\Component\Process\Process;
 
+use function Castor\context;
+
 /** @internal */
 final class SshRunner
 {
@@ -81,14 +83,12 @@ final class SshRunner
     ): Process {
         return $this->processRunner->run(
             $command,
-            environment: [],
-            tty: false,
-            pty: false,
             timeout: $timeout,
             quiet: $quiet,
             allowFailure: $allowFailure,
             notify: $notify,
-            callback: $callback
+            callback: $callback,
+            context: context()->withPty(false)->withTty(false)->withEnvironment([]),
         );
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -65,7 +65,7 @@ function run(
         throw new \LogicException('You cannot use both the "path" and "workingDirectory" arguments at the same time.');
     }
     if ($path) {
-        trigger_deprecation('castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
+        trigger_deprecation('jolicode/castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
 
         $workingDirectory = $path;
     }
@@ -103,7 +103,7 @@ function capture(
         throw new \LogicException('You cannot use both the "path" and "workingDirectory" arguments at the same time.');
     }
     if ($path) {
-        trigger_deprecation('castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
+        trigger_deprecation('jolicode/castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
 
         $workingDirectory = $path;
     }
@@ -136,7 +136,7 @@ function exit_code(
         throw new \LogicException('You cannot use both the "path" and "workingDirectory" arguments at the same time.');
     }
     if ($path) {
-        trigger_deprecation('castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
+        trigger_deprecation('jolicode/castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
 
         $workingDirectory = $path;
     }
@@ -460,7 +460,7 @@ function http_client(): HttpClientInterface
 function import(string $path, ?string $file = null, ?string $version = null, ?string $vcs = null, ?array $source = null): void
 {
     if (null !== $version || null !== $vcs || null !== $source) {
-        @trigger_deprecation('castor/castor', '0.16.0', 'The "version", "vcs" and "source" arguments are deprecated, use the `castor.composer.json` file instead.');
+        trigger_deprecation('jolicode/castor', '0.16.0', 'The "version", "vcs" and "source" arguments are deprecated, use the `castor.composer.json` file instead.');
     }
 
     Container::get()->importer->import($path, $file);
@@ -537,7 +537,7 @@ function with(
         }
     }
     if ($path) {
-        trigger_deprecation('castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
+        trigger_deprecation('jolicode/castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
 
         $context = $context->withWorkingDirectory($path);
     }
@@ -811,27 +811,12 @@ function open(string ...$urls): void
 }
 
 /**
- * @param array<string|\Stringable>                      $arguments
- * @param array<string, string|\Stringable|int>|null     $environment
- * @param (callable(string, string, Process) :void)|null $callback
+ * @param array<string|\Stringable> $arguments
  */
-function run_phar(
-    string $pharPath,
-    array $arguments = [],
-    ?array $environment = null,
-    ?string $workingDirectory = null,
-    ?bool $tty = null,
-    ?bool $pty = null,
-    ?float $timeout = null,
-    ?bool $quiet = null,
-    ?bool $allowFailure = null,
-    ?bool $notify = null,
-    ?callable $callback = null,
-    ?Context $context = null,
-    ?string $path = null): Process
+function run_phar(string $pharPath, array $arguments = [], ?Context $context = null): Process
 {
     // get program path
     $castorPath = $_SERVER['argv'][0];
 
-    return run([$castorPath, 'run-phar', $pharPath, ...$arguments], $environment, $workingDirectory, $tty, $pty, $timeout, $quiet, $allowFailure, $notify, $callback, $context, $path);
+    return run([$castorPath, 'run-phar', $pharPath, ...$arguments], context: $context);
 }

--- a/tests/Generated/FailureFailureTest.php.err.txt
+++ b/tests/Generated/FailureFailureTest.php.err.txt
@@ -1,6 +1,6 @@
 bash: line 1: i_do_not_exist: command not found
 
-In failure.php line 12:
+In failure.php line 13:
 
   The command "bash -c i_do_not_exist" failed.
 

--- a/tests/Generated/RunExceptionTest.php.err.txt
+++ b/tests/Generated/RunExceptionTest.php.err.txt
@@ -1,4 +1,4 @@
-In run.php line 63:
+In run.php line 64:
 
   The command "echo foo; echo bar>&2; exit 1" failed.
 


### PR DESCRIPTION
Goal is each parameters that is available in context should not be duplicated in the run function (or function depending on it), should simplify calls in the futures