### PR TITLE
chore(ci): fix building amd64 binary for macos

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -95,7 +95,7 @@ jobs:
   static-darwin-amd64:
     needs: phars
     name: Create MacOs amd64 static binary and upload
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Ref https://github.com/actions/runner-images/issues/9741