### PR TITLE
feat(fingerprint): add id for fingerprint to avoid wrong bad cache hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+* Add an id parameter to fingerprint to avoid bad cache hit
 * Fix completion when update is available
 * Fix repack when there is composer dependencies to castor
 * Fix wait_for_docker_container example to avoid checking previous docker logs

--- a/doc/going-further/helpers/fingerprint.md
+++ b/doc/going-further/helpers/fingerprint.md
@@ -22,6 +22,7 @@ function task_with_a_fingerprint(): void
         callback: function () {
             io()->writeln('Cool, no fingerprint! Executing...');
         },
+        id: 'my-fingerprint',
         fingerprint: "my fingerprint",
     );
 }
@@ -72,6 +73,7 @@ function task_with_a_fingerprint(): void
         callback: function () {
             io()->writeln('Executing the callback because my-file.json has changed.');
         },
+        id: 'task-id',
         fingerprint: hasher()->writeFile('my-file.json', FileHashStrategy::Content)->finish(),
     );
 }
@@ -94,9 +96,9 @@ use function Castor\hasher;
 #[AsTask(description: 'Check if the fingerprint has changed before executing some code')]
 function task_with_some_fingerprint(): void
 {
-    if (!fingerprint_exists(my_fingerprint_check())) {
+    if (!fingerprint_exists('task-id', my_fingerprint_check())) {
         io()->writeln('Executing some code because fingerprint has changed.');
-        fingerprint_save(my_fingerprint_check());
+        fingerprint_save('task-id', my_fingerprint_check());
     }
 }
 

--- a/examples/fingerprint.php
+++ b/examples/fingerprint.php
@@ -22,6 +22,7 @@ function task_with_a_fingerprint(): void
         callback: function () {
             io()->writeln('Cool, no fingerprint! Executing...');
         },
+        id: 'my_fingerprint_check',
         fingerprint: my_fingerprint_check()
     );
 
@@ -33,9 +34,9 @@ function task_with_complete_fingerprint_check(): void
 {
     io()->writeln('Hello Task with Fingerprint!');
 
-    if (!fingerprint_exists(my_fingerprint_check())) {
+    if (!fingerprint_exists('my_fingerprint_check', my_fingerprint_check())) {
         io()->writeln('Cool, no fingerprint! Executing...');
-        fingerprint_save(my_fingerprint_check());
+        fingerprint_save('my_fingerprint_check', my_fingerprint_check());
     }
 
     io()->writeln('Cool! I finished!');
@@ -51,6 +52,7 @@ function task_with_a_fingerprint_and_force(
         callback: function () {
             io()->writeln('Cool, no fingerprint! Executing...');
         },
+        id: 'my_fingerprint_check',
         fingerprint: my_fingerprint_check(),
         force: $force // This option will force the task to run even if the fingerprint has not changed
     );

--- a/src/Fingerprint/FingerprintHelper.php
+++ b/src/Fingerprint/FingerprintHelper.php
@@ -15,9 +15,9 @@ class FingerprintHelper
     ) {
     }
 
-    public function verifyFingerprintFromHash(string $fingerprint): bool
+    public function verifyFingerprintFromHash(string $id, string $fingerprint): bool
     {
-        $itemKey = $fingerprint . self::SUFFIX;
+        $itemKey = $id . self::SUFFIX;
 
         if (false === $this->cache->hasItem($itemKey)) {
             return false;
@@ -36,9 +36,9 @@ class FingerprintHelper
         return false;
     }
 
-    public function postProcessFingerprintForHash(string $hash): void
+    public function postProcessFingerprintForHash(string $id, string $hash): void
     {
-        $itemKey = $hash . self::SUFFIX;
+        $itemKey = $id . self::SUFFIX;
 
         $cacheItem = $this->cache->getItem($itemKey);
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -590,21 +590,39 @@ function hasher(string $algo = 'xxh128'): HasherHelper
     );
 }
 
-function fingerprint_exists(string $fingerprint): bool
+function fingerprint_exists(string $id, ?string $fingerprint = null): bool
 {
-    return Container::get()->fingerprintHelper->verifyFingerprintFromHash($fingerprint);
+    if (null === $fingerprint) {
+        trigger_deprecation('castor/castor', '0.18.0', 'since 0.18 fingerprint functions require an id argument.');
+
+        $fingerprint = $id;
+    }
+
+    return Container::get()->fingerprintHelper->verifyFingerprintFromHash($id, $fingerprint);
 }
 
-function fingerprint_save(string $fingerprint): void
+function fingerprint_save(string $id, ?string $fingerprint = null): void
 {
-    Container::get()->fingerprintHelper->postProcessFingerprintForHash($fingerprint);
+    if (null === $fingerprint) {
+        trigger_deprecation('castor/castor', '0.18.0', 'since 0.18 fingerprint functions require an id argument.');
+
+        $fingerprint = $id;
+    }
+
+    Container::get()->fingerprintHelper->postProcessFingerprintForHash($id, $fingerprint);
 }
 
-function fingerprint(callable $callback, string $fingerprint, bool $force = false): bool
+function fingerprint(callable $callback, string $id, ?string $fingerprint = null, bool $force = false): bool
 {
-    if ($force || !fingerprint_exists($fingerprint)) {
+    if (null === $fingerprint) {
+        trigger_deprecation('castor/castor', '0.18.0', 'since 0.18 fingerprint functions require an id argument.');
+
+        $fingerprint = $id;
+    }
+
+    if ($force || !fingerprint_exists($id, $fingerprint)) {
         $callback();
-        fingerprint_save($fingerprint);
+        fingerprint_save($id, $fingerprint);
 
         return true;
     }


### PR DESCRIPTION
Fix https://github.com/jolicode/castor/issues/446

We currently use the fingerprint hash as the fingerprint cache key, main problem is that if we register a callback on the hash of a file by example when switching back and forth to previous existing one (like reverting the code), castor will consider this as an existing one and will have a cache HIT where in most cases it should be a miss.

To avoid that, fingerprint now requires an id parameter which will be used for the cache key so old values will be cleared when the same key is used.