### PR TITLE
feat(execute): introduce remote execution command

### DIFF
--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -69,6 +69,7 @@ $taskFilterList = [
     'watch:stop',
     // Not examples
     'castor:compile',
+    'castor:execute',
     'castor:phar:build',
     'castor:phar:darwin',
     'castor:phar:install',

--- a/doc/_nav.md
+++ b/doc/_nav.md
@@ -5,6 +5,7 @@
     - [Executing Processes with `run()`](getting-started/run.md)
     - [Task Arguments](getting-started/arguments.md)
     - [Using the Context](getting-started/context.md)
+    - [Remote execution](getting-started/remote.md)
 - [Going further](going-further/index.md)
     - Helpers
         - [Manipulating the input and output and interacting with the Console](going-further/helpers/console-and-io.md)

--- a/doc/getting-started/remote.md
+++ b/doc/getting-started/remote.md
@@ -1,0 +1,44 @@
+# Remote execution
+
+Castor allows you to run any php package without installing it on your machine or
+withing your dependencies. This is done by using the `castor execute` command
+
+As an example, let's say you want to run the `friendsofphp/php-cs-fixer` package
+to fix your code style. You can do this by running the following command:
+
+```bash
+castor execute friendsofphp/php-cs-fixer fix
+```
+
+This will download the package and its dependencies, and then run the first
+binary command it finds in the package. In this case, it will run the `php-cs-fixer`
+binary command with the `fix` argument.
+
+All options after the package name will be passed to the binary command.
+
+## Specific binary of package
+
+If you want to run a specific binary command of a package, you can do this by
+adding the binary name after the package name separated with the `@` character :
+
+```bash
+castor execute friendsofphp/php-cs-fixer@php-cs-fixer fix
+```
+
+## Using a specific version of a package
+
+If you want to run a specific version of a package, you can do this by adding the
+version number after the package name separated with the `:` character :
+
+```bash
+castor execute friendsofphp/php-cs-fixer:3.0 fix
+```
+
+## Extra dependencies
+
+You may need several packages to run a command. For example, if you want to run
+phpstan with extensions, you can do this by running the following command:
+
+```bash
+castor execute --deps phpstan/phpstan-symfony phpstan/phpstan
+```

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -5,6 +5,7 @@ namespace Castor\Console;
 use Castor\Console\Command\CompileCommand;
 use Castor\Console\Command\ComposerCommand;
 use Castor\Console\Command\DebugCommand;
+use Castor\Console\Command\ExecuteCommand;
 use Castor\Console\Command\RepackCommand;
 use Castor\Container;
 use Castor\Helper\PathHelper;
@@ -207,6 +208,7 @@ class ApplicationFactory
                     '$containerBuilder' => service(ContainerInterface::class),
                 ])
                 ->call('add', [service(DebugCommand::class)])
+                ->call('add', [service(ExecuteCommand::class)])
                 ->call('setDispatcher', [service(EventDispatcherInterface::class)])
                 ->call('setCatchErrors', [true])
         ;

--- a/src/Console/Command/ExecuteCommand.php
+++ b/src/Console/Command/ExecuteCommand.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Castor\Console\Command;
+
+use Castor\Console\Input\GetRawTokenTrait;
+use Castor\Exception\ProblemException;
+use Castor\Import\Remote\Composer;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Filesystem;
+
+use function Castor\run_php;
+
+/** @internal */
+#[AsCommand(
+    name: 'castor:execute',
+    description: 'Execute a remote task from a packagist directory',
+    aliases: ['execute'],
+)]
+final class ExecuteCommand extends Command
+{
+    use GetRawTokenTrait;
+
+    public function __construct(
+        #[Autowire(lazy: true)]
+        private readonly Composer $composer,
+        private readonly Filesystem $filesystem,
+        private readonly string $cacheDir,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('deps', 'd', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Additional dependencies to install')
+            ->addArgument('package', InputArgument::REQUIRED, 'Package to execute in the format "vendor/package:version@binary" or "vendor/package@binary" or "vendor/package"')
+            ->ignoreValidationErrors()
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // Create temporary directory
+        $tmpDir = tempnam($this->cacheDir, 'castor-exec-');
+
+        if (!$tmpDir) {
+            throw new \RuntimeException('Could not create temporary directory');
+        }
+
+        unlink($tmpDir);
+
+        // format of execute is "vendor/package:version@binary"
+        /** @var string[] $deps */
+        $deps = $input->getOption('deps') ?? [];
+        $name = $input->getArgument('package');
+        $nameSplitted = explode('@', $name);
+
+        if (\count($nameSplitted) >= 2) {
+            $deps[] = $nameSplitted[0];
+            $binary = $nameSplitted[1];
+        } else {
+            $deps[] = $name;
+            $binary = null;
+        }
+
+        $composerJsonPath = $tmpDir . '/composer.json';
+        $vendorDirectory = $tmpDir . '/vendor';
+        $binaryDirectory = $tmpDir . '/bin';
+        $tokens = $this->getRawTokens($input);
+
+        $args = [];
+        $foundPackageName = false;
+
+        foreach ($tokens as $token) {
+            if ($foundPackageName) {
+                $args[] = $token;
+            } else {
+                if ($token === $name) {
+                    $foundPackageName = true;
+                }
+            }
+        }
+
+        try {
+            $this->filesystem->mkdir($tmpDir, 0o755);
+            /** @var list<string> $composerArgs */
+            $composerArgs = ['require', ...$deps, '--no-interaction'];
+            $this->composer->run($composerJsonPath, $vendorDirectory, $composerArgs, $output, $input->isInteractive(), $binaryDirectory);
+
+            if (null === $binary) {
+                // / Get first binary declared in the package if none was specified
+                $lockFilePath = $tmpDir . '/composer.lock';
+                $lockContent = json_decode(file_get_contents($lockFilePath) ?: '{}', true);
+
+                $foundPackage = [];
+
+                foreach ($lockContent['packages'] as $package) {
+                    if ($package['name'] === $nameSplitted[0]) {
+                        $foundPackage = $package;
+
+                        break;
+                    }
+                }
+
+                $binary = $foundPackage['bin'][0] ?? null;
+                $binary = $binary ? basename($binary) : null;
+
+                if (null === $binary) {
+                    throw new ProblemException("No binary found for package '{$nameSplitted[0]}': you must use a package with a vendor binary, see \nhttps://getcomposer.org/doc/articles/vendor-binaries.md for more information");
+                }
+            }
+
+            return run_php($binaryDirectory . '/' . $binary, $args)->wait();
+        } finally {
+            $this->filesystem->remove($tmpDir);
+        }
+    }
+}

--- a/src/Import/Remote/Composer.php
+++ b/src/Import/Remote/Composer.php
@@ -149,7 +149,7 @@ class Composer
     /**
      * @param list<string> $args
      */
-    public function run(string $composerJsonFilePath, string $vendorDirectory, array $args, callable|OutputInterface $callback, bool $interactive = false): void
+    public function run(string $composerJsonFilePath, string $vendorDirectory, array $args, callable|OutputInterface $callback, bool $interactive = false, ?string $binDir = null): void
     {
         $this->filesystem->mkdir($vendorDirectory);
 
@@ -163,6 +163,12 @@ class Composer
         putenv('COMPOSER=' . $composerJsonFilePath);
         $_ENV['COMPOSER'] = $composerJsonFilePath;
         $_SERVER['COMPOSER'] = $composerJsonFilePath;
+
+        if ($binDir) {
+            putenv('COMPOSER_BIN_DIR=' . $binDir);
+            $_ENV['COMPOSER_BIN_DIR'] = $binDir;
+            $_SERVER['COMPOSER_BIN_DIR'] = $binDir;
+        }
 
         $composerApplication = new ComposerApplication();
         $composerApplication->setAutoExit(false);
@@ -197,6 +203,11 @@ class Composer
 
         putenv('COMPOSER=');
         unset($_ENV['COMPOSER'], $_SERVER['COMPOSER']);
+
+        if ($binDir) {
+            putenv('COMPOSER_BIN_DIR=');
+            unset($_ENV['COMPOSER_BIN_DIR'], $_SERVER['COMPOSER_BIN_DIR']);
+        }
 
         if (0 !== $exitCode) {
             throw new ComposerError('The Composer process failed: ' . $bufferedOutput);

--- a/tests/Generated/ImportSamePackageWithDefaultVersionTest.php.output.txt
+++ b/tests/Generated/ImportSamePackageWithDefaultVersionTest.php.output.txt
@@ -33,5 +33,6 @@ Available commands:
   list                  List commands
  castor
   castor:composer       [composer] Interact with built-in Composer for castor
+  castor:execute        [execute] Execute a remote task from a packagist directory
  pyrech
   pyrech:hello-example  Hello from example!

--- a/tests/Generated/LayoutWithFolderTest.php.output.txt
+++ b/tests/Generated/LayoutWithFolderTest.php.output.txt
@@ -30,3 +30,4 @@ Available commands:
   list             List commands
  castor
   castor:composer  [composer] Interact with built-in Composer for castor
+  castor:execute   [execute] Execute a remote task from a packagist directory

--- a/tests/Generated/LayoutWithOldFolderTest.php.output.txt
+++ b/tests/Generated/LayoutWithOldFolderTest.php.output.txt
@@ -32,3 +32,4 @@ Available commands:
   list             List commands
  castor
   castor:composer  [composer] Interact with built-in Composer for castor
+  castor:execute   [execute] Execute a remote task from a packagist directory

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -17,6 +17,7 @@ assertion:throw-an-exception                                      Throws a Probl
 cache:complex                                                     Cache with usage of CacheItemInterface
 cache:simple                                                      Cache a simple call
 castor:composer                                                   Interact with built-in Composer for castor
+castor:execute                                                    Execute a remote task from a packagist directory
 castor:phar:build                                                 Build phar for all systems
 castor:phar:darwin                                                Build phar for MacOS system
 castor:phar:install                                               install dependencies

--- a/tests/RemoteExecutionTest.php
+++ b/tests/RemoteExecutionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Castor\Tests;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class RemoteExecutionTest extends TaskTestCase
+{
+    public function test(): void
+    {
+        $process = $this->runTask(['execute', 'composer/composer@composer']);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringContainsString('Installing composer/composer', $process->getErrorOutput());
+        $this->assertStringContainsString('Composer version', $process->getOutput());
+    }
+
+    public function testVersion(): void
+    {
+        $process = $this->runTask(['execute', 'composer/composer:2.7@composer']);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringContainsString('Installing composer/composer (2.7', $process->getErrorOutput());
+        $this->assertStringContainsString('Composer version 2.7', $process->getOutput());
+    }
+}


### PR DESCRIPTION
Ref https://github.com/jolicode/castor/issues/488

This add a new command which allow castor to execute remote package 

As an example you could do the following : 

```
PHP_CS_FIXER_IGNORE_ENV=1 castor execute  friendsofphp/php-cs-fixer@php-cs-fixer fix --dry-run --diff
```

Which will 

 * download the friendsofphp/php-cs-fixer package
 * execute the php-cs-fixer binary from it with args `fix --dry-run --diff`
 * remove the package once it has been executed
 
It could also use a specific version by doing : 

```
castor execute  friendsofphp/php-cs-fixer:v3.57.1@php-cs-fixer fix --dry-run --diff
```

TODO : 

* [x] Tests
* [x] Documentation