### PR TITLE
add --since 0 to wait_for_docker_container_task example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Fix completion when update is available
 * Fix repack when there is composer dependencies to castor
+* Fix wait_for_docker_container example to avoid checking previous docker logs
 
 ### Features
 

--- a/examples/wait_for.php
+++ b/examples/wait_for.php
@@ -105,7 +105,7 @@ function wait_for_docker_container_task(): void
             timeout: 5,
             containerChecker: function ($containerId): bool {
                 // Check some things (logs, command result, etc.)
-                $output = capture("docker logs {$containerId}", allowFailure: true);
+                $output = capture("docker logs --since 0 {$containerId}", allowFailure: true);
 
                 return u($output)->containsAny(['hello world']);
             },


### PR DESCRIPTION
to avoid checking the logs from a previous container start