### PR TITLE
feat(run): add possibility to specify verbose arguments for a context and rerun command with them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `Context::toInteractive()` method
 * Add `Castor\Event\ContextCreatedEvent` to allow updating the context after it is created
 * Add `run_phar()` function to run a phar file in all contexts
+* Add `Context::withVerboseArguments()` method to pass verbose arguments to the underlying process when needed
 
 ### Vendor
 

--- a/doc/getting-started/context.md
+++ b/doc/getting-started/context.md
@@ -275,6 +275,31 @@ function foo(): void
 }
 ```
 
+## Passing verbose arguments
+
+Castor allow you to pass verbose arguments to the underlying process. You can
+do that by using the `withVerboseArguments` method:
+
+```php
+use Castor\Attribute\AsTask;
+
+use function Castor\context;
+use function Castor\run;
+
+#[AsTask()]
+function foo(): void
+{
+    run('php bin/console do:some:task', context: context()->withVerboseArguments(['-v']));
+}
+```
+
+By default, Castor will not pass any verbose arguments to the command. However
+if you run castor with the `-v` option, it will pass the verbose arguments to this command.
+
+Also if this command fails, castor will ask you if you want to retry the command 
+with the verbose arguments.
+
+
 ## Advanced usage
 
 See [this documentation](../going-further/interacting-with-castor/advanced-context.md) for more usage about

--- a/examples/failure.php
+++ b/examples/failure.php
@@ -18,3 +18,9 @@ function allow_failure(): void
 {
     run('bash -c i_do_not_exist', context: context()->withAllowFailure()->withPty(false));
 }
+
+#[AsTask(description: 'A failing task authorized to fail')]
+function verbose_arguments(): void
+{
+    run('bash -c i_do_not_exist', context: context()->withVerboseArguments(['-x', '-e']));
+}

--- a/src/Context.php
+++ b/src/Context.php
@@ -15,7 +15,8 @@ class Context implements \ArrayAccess
     /**
      * @phpstan-param ContextData $data The input parameter accepts an array or an Object
      *
-     * @param array<string, string|\Stringable|int> $environment A list of environment variables to add to the task
+     * @param array<string, string|\Stringable|int> $environment      A list of environment variables to add to the task
+     * @param string[]                              $verboseArguments A list of arguments to pass to the command to enable verbose output
      */
     public function __construct(
         public readonly array $data = [],
@@ -31,6 +32,7 @@ class Context implements \ArrayAccess
         // Do not use this argument, it is only used internally by the application
         public readonly string $name = '',
         public readonly string $notificationTitle = '',
+        public readonly array $verboseArguments = [],
     ) {
         $this->workingDirectory = $workingDirectory ?? PathHelper::getRoot();
     }
@@ -85,6 +87,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -104,6 +107,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -129,6 +133,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -147,6 +152,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -165,6 +171,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -183,6 +190,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -201,6 +209,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -219,6 +228,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -237,6 +247,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -255,6 +266,7 @@ class Context implements \ArrayAccess
             $verbosityLevel,
             $this->name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -273,6 +285,7 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $name,
             $this->notificationTitle,
+            $this->verboseArguments,
         );
     }
 
@@ -291,6 +304,27 @@ class Context implements \ArrayAccess
             $this->verbosityLevel,
             $this->name,
             $notificationTitle,
+            $this->verboseArguments,
+        );
+    }
+
+    /** @param string[] $arguments */
+    public function withVerboseArguments(array $arguments = []): self
+    {
+        return new self(
+            $this->data,
+            $this->environment,
+            $this->workingDirectory,
+            $this->tty,
+            $this->pty,
+            $this->timeout,
+            $this->quiet,
+            $this->allowFailure,
+            $this->notify,
+            $this->verbosityLevel,
+            $this->name,
+            $this->notificationTitle,
+            $arguments,
         );
     }
 

--- a/tests/Generated/FailureVerboseArgumentsTest.php
+++ b/tests/Generated/FailureVerboseArgumentsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class FailureVerboseArgumentsTest extends TaskTestCase
+{
+    // failure:verbose-arguments
+    public function test(): void
+    {
+        $process = $this->runTask(['failure:verbose-arguments']);
+
+        if (1 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/FailureVerboseArgumentsTest.php.err.txt
+++ b/tests/Generated/FailureVerboseArgumentsTest.php.err.txt
@@ -1,0 +1,7 @@
+In failure.php line 25:
+
+  The command "bash -c i_do_not_exist" failed.
+
+
+failure:verbose-arguments
+

--- a/tests/Generated/FailureVerboseArgumentsTest.php.output.txt
+++ b/tests/Generated/FailureVerboseArgumentsTest.php.output.txt
@@ -1,0 +1,4 @@
+bash: line 1: i_do_not_exist: command not found
+
+ Do you want to retry the command with verbose arguments? (yes/no) [no]:
+ >

--- a/tests/Generated/FailureVerboseArgumentsTrueTest.php
+++ b/tests/Generated/FailureVerboseArgumentsTrueTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class FailureVerboseArgumentsTrueTest extends TaskTestCase
+{
+    // failure:verbose-arguments
+    public function test(): void
+    {
+        $process = $this->runTask(['failure:verbose-arguments'], input: 'yes
+');
+
+        if (1 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertStringEqualsFile(__FILE__ . '.err.txt', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/FailureVerboseArgumentsTrueTest.php.err.txt
+++ b/tests/Generated/FailureVerboseArgumentsTrueTest.php.err.txt
@@ -1,0 +1,19 @@
+In ProcessRunner.php line XXXX:
+
+  The command "bash -c i_do_not_exist -x -e" failed.
+
+  Exit Code: 127(Command not found)
+
+  Working directory: ...
+
+  Output:
+  ================
+  -x: line 1: i_do_not_exist: command not found
+
+
+  Error Output:
+  ================
+
+
+failure:verbose-arguments
+

--- a/tests/Generated/FailureVerboseArgumentsTrueTest.php.output.txt
+++ b/tests/Generated/FailureVerboseArgumentsTrueTest.php.output.txt
@@ -1,0 +1,5 @@
+bash: line 1: i_do_not_exist: command not found
+
+ Do you want to retry the command with verbose arguments? (yes/no) [no]:
+ >
+-x: line 1: i_do_not_exist: command not found

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -33,6 +33,7 @@ env:env                                                           Display enviro
 event-listener:my-task                                            An dummy task with event listeners attached
 failure:allow-failure                                             A failing task authorized to fail
 failure:failure                                                   A failing task not authorized to fail
+failure:verbose-arguments                                         A failing task authorized to fail
 filesystem:filesystem                                             Performs some operations on the filesystem
 filesystem:find                                                   Search files and directories on the filesystem
 fingerprint:task-with-a-fingerprint                               Execute a callback only if the fingerprint has changed


### PR DESCRIPTION
This add the possibility to rerun a command a with additional arguments when it failed

This would allow when running a lot of commands to retry only the one that failed with additional arguments so we can have more information only in this case.

Also having this would pass the verbose arguments to command when castor is run with verbose (without having to edit the castor file)
