### PR TITLE
fix(fingerprint): Add $global Parameter to Fingerprint Functions and Path Handling Fixes

### DIFF
--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -86,6 +86,7 @@ $taskFilterList = [
     'qa:phpstan:update',
     // Customized tests
     'fingerprint:task-with-a-fingerprint-and-force',
+    'fingerprint:task-with-a-fingerprint-global',
     'fingerprint:task-with-a-fingerprint',
     'fingerprint:task-with-complete-fingerprint-check',
     'log:all-level',

--- a/doc/going-further/helpers/fingerprint.md
+++ b/doc/going-further/helpers/fingerprint.md
@@ -32,6 +32,10 @@ function task_with_a_fingerprint(): void
 > You can use the `$force` parameter of the `fingerprint()` function to force
 > the execution of the callback even if the fingerprint has not changed.
 
+> [!NOTE]
+> By default the fingerprint is scoped to the current project, but you can use
+> the `$global` parameter to make it shared across all projects.
+
 ## The `hasher()` function
 
 Most of the time, you will want your fingerprint hash to be based on the content

--- a/examples/fingerprint.php
+++ b/examples/fingerprint.php
@@ -29,6 +29,23 @@ function task_with_a_fingerprint(): void
     io()->writeln('Cool! I finished!');
 }
 
+#[AsTask(description: 'Execute a callback only if the global fingerprint has changed (Shared across all projects)')]
+function task_with_a_fingerprint_global(): void
+{
+    io()->writeln('Hello Task with Global Fingerprint!');
+
+    fingerprint(
+        callback: function () {
+            io()->writeln('Cool, no global fingerprint! Executing...');
+        },
+        id: 'my_global_fingerprint_check',
+        fingerprint: my_fingerprint_check(),
+        global: true, // This ensures that the fingerprint is shared across all projects (not only the current one)
+    );
+
+    io()->writeln('Cool! I finished global!');
+}
+
 #[AsTask(description: 'Check if the fingerprint has changed before executing some code')]
 function task_with_complete_fingerprint_check(): void
 {

--- a/src/Helper/HasherHelper.php
+++ b/src/Helper/HasherHelper.php
@@ -43,6 +43,12 @@ class HasherHelper
             $path = getcwd() . '/' . $path;
         }
 
+        $path = realpath($path);
+
+        if (false === $path) {
+            throw new \InvalidArgumentException(\sprintf('The path "%s" is not a valid path.', $path));
+        }
+
         if (!is_file($path)) {
             throw new \InvalidArgumentException(\sprintf('The path "%s" is not a file.', $path));
         }
@@ -79,11 +85,11 @@ class HasherHelper
         foreach ($finder as $file) {
             switch ($strategy) {
                 case FileHashStrategy::Content:
-                    hash_update_file($this->hashContext, $file->getPathname());
+                    hash_update_file($this->hashContext, $file->getRealPath());
 
                     break;
                 case FileHashStrategy::MTimes:
-                    hash_update($this->hashContext, "{$file->getPathname()}:{$file->getMTime()}");
+                    hash_update($this->hashContext, "{$file->getRealPath()}:{$file->getMTime()}");
 
                     break;
             }
@@ -104,6 +110,9 @@ class HasherHelper
         if (false === $files) {
             throw new \InvalidArgumentException(\sprintf('The pattern "%s" is invalid.', $pattern));
         }
+
+        $files = array_map('realpath', $files);
+        $files = array_filter($files);
 
         foreach ($files as $file) {
             switch ($strategy) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -591,7 +591,7 @@ function hasher(string $algo = 'xxh128'): HasherHelper
     );
 }
 
-function fingerprint_exists(string $id, ?string $fingerprint = null): bool
+function fingerprint_exists(string $id, ?string $fingerprint = null, bool $global = false): bool
 {
     if (null === $fingerprint) {
         trigger_deprecation('castor/castor', '0.18.0', 'since 0.18 fingerprint functions require an id argument.');
@@ -599,10 +599,10 @@ function fingerprint_exists(string $id, ?string $fingerprint = null): bool
         $fingerprint = $id;
     }
 
-    return Container::get()->fingerprintHelper->verifyFingerprintFromHash($id, $fingerprint);
+    return Container::get()->fingerprintHelper->verifyFingerprintFromHash($id, $fingerprint, $global);
 }
 
-function fingerprint_save(string $id, ?string $fingerprint = null): void
+function fingerprint_save(string $id, ?string $fingerprint = null, bool $global = false): void
 {
     if (null === $fingerprint) {
         trigger_deprecation('castor/castor', '0.18.0', 'since 0.18 fingerprint functions require an id argument.');
@@ -610,7 +610,7 @@ function fingerprint_save(string $id, ?string $fingerprint = null): void
         $fingerprint = $id;
     }
 
-    Container::get()->fingerprintHelper->postProcessFingerprintForHash($id, $fingerprint);
+    Container::get()->fingerprintHelper->postProcessFingerprintForHash($id, $fingerprint, $global);
 }
 
 // function fingerprint(callable $callback, string $fingerprint, bool $force = false): bool
@@ -618,7 +618,7 @@ function fingerprint_save(string $id, ?string $fingerprint = null): void
  * @param string $id
  * @param string $fingerprint
  */
-function fingerprint(callable $callback, /* string */ $id = null, /* string */ $fingerprint = null, bool $force = false): bool
+function fingerprint(callable $callback, /* string */ $id = null, /* string */ $fingerprint = null, bool $force = false, bool $global = false): bool
 {
     // Could only occur due du BC layer
     if (null === $fingerprint && null === $id) {
@@ -642,9 +642,9 @@ function fingerprint(callable $callback, /* string */ $id = null, /* string */ $
         $id = $fingerprint;
     }
 
-    if ($force || !fingerprint_exists($id, $fingerprint)) {
+    if ($force || !fingerprint_exists($id, $fingerprint, $global)) {
         $callback();
-        fingerprint_save($id, $fingerprint);
+        fingerprint_save($id, $fingerprint, $global);
 
         return true;
     }

--- a/tests/Examples/Fingerprint/FingerprintTaskWithAFingerprintTest.php.output_runnable.txt
+++ b/tests/Examples/Fingerprint/FingerprintTaskWithAFingerprintTest.php.output_runnable.txt
@@ -1,3 +1,0 @@
-Hello Task with Fingerprint!
-Cool, no fingerprint! Executing...
-Cool! I finished!

--- a/tests/Examples/Fingerprint/FingerprintTaskWithAGlobalFingerprintTest.php
+++ b/tests/Examples/Fingerprint/FingerprintTaskWithAGlobalFingerprintTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Castor\Tests\Examples\Fingerprint;
+
+class FingerprintTaskWithAGlobalFingerprintTest extends FingerprintedTestCase
+{
+    // fingerprint:task-with-a-fingerprint-global
+    public function test(): void
+    {
+        // Run for the first time, should run
+        $this->runProcessAndExpect(__FILE__ . '.output_runnable.txt');
+
+        // should not run because the fingerprint is the same
+        $this->runProcessAndExpect(__FILE__ . '.output_not_runnable.txt');
+
+        // change file content, should run
+        $this->runProcessAndExpect(__FILE__ . '.output_runnable.txt', 'Hello World');
+    }
+
+    private function runProcessAndExpect(string $expectedOutputFilePath, string $withFileContent = 'Hello'): void
+    {
+        $filepath = \dirname(__DIR__, 3) . '/examples/fingerprint_file.fingerprint_single';
+        if (file_exists($filepath)) {
+            unlink($filepath);
+        }
+
+        file_put_contents($filepath, $withFileContent);
+
+        $process = $this->runTask(['fingerprint:task-with-a-fingerprint-global']);
+
+        if (file_exists($expectedOutputFilePath)) {
+            $this->assertStringEqualsFile($expectedOutputFilePath, $process->getOutput());
+        }
+
+        $this->assertSame(0, $process->getExitCode());
+    }
+}

--- a/tests/Examples/Fingerprint/FingerprintTaskWithAGlobalFingerprintTest.php.output_not_runnable.txt
+++ b/tests/Examples/Fingerprint/FingerprintTaskWithAGlobalFingerprintTest.php.output_not_runnable.txt
@@ -1,0 +1,2 @@
+Hello Task with Global Fingerprint!
+Cool! I finished global!

--- a/tests/Examples/Fingerprint/FingerprintTaskWithAGlobalFingerprintTest.php.output_runnable.txt
+++ b/tests/Examples/Fingerprint/FingerprintTaskWithAGlobalFingerprintTest.php.output_runnable.txt
@@ -1,0 +1,3 @@
+Hello Task with Global Fingerprint!
+Cool, no global fingerprint! Executing...
+Cool! I finished global!

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -37,6 +37,7 @@ filesystem:filesystem                                             Performs some 
 filesystem:find                                                   Search files and directories on the filesystem
 fingerprint:task-with-a-fingerprint                               Execute a callback only if the fingerprint has changed
 fingerprint:task-with-a-fingerprint-and-force                     Check if the fingerprint has changed before executing a callback (with force option)
+fingerprint:task-with-a-fingerprint-global                        Execute a callback only if the global fingerprint has changed (Shared across all projects)
 fingerprint:task-with-complete-fingerprint-check                  Check if the fingerprint has changed before executing some code
 foo:bar                                                           Echo foo bar
 foo:foo                                                           Prints foo


### PR DESCRIPTION
## Add `$global` Parameter to Fingerprint Functions and Path Handling Fixes

### Summary

- **Added**: A `$global` parameter to fingerprint functions, allowing the option to use a global scope for fingerprint. By default, fingerprints are scoped by the project based on the directory path. Setting `$global` to `true` enables global fingerprinting, independent of the project path.
  
- **Fixed**: Path handling issues for file operations such as `hasher()->writeFile('../test.txt')->finish();`. Previously, the relative path could cause incorrect fingerprint generation due to differences in project directories. Now, the path is normalized using `realpath()` to ensure consistency.

### Changes

1. **Global Scope for Fingerprints**:
   - Introduced a `$global` parameter to fingerprint functions, allowing for optional global scoping of fingerprints.
   - By default, fingerprints are scoped based on the project path, but setting `$global = true` will ensure fingerprints are globally consistent across different projects.

2. **Path Resolution Fix in `writeFile(...)`**:
   - Previously, if you ran the following code in two different project directories:
     ```php
     hasher()->writeFile('../test.txt')->finish();
     ```
     - In `/home/projects/project-a`, the file would resolve as `/home/projects/project-a/../test.txt`.
     - In `/home/projects/project-b`, the file would resolve as `/home/projects/project-b/../test.txt`.
     - This results in **different hashes**, even though the content is the same, due to the difference in the relative paths.
   
   - **Fix**: With the addition of `realpath()` in `writeFile(...)`, the path is now resolved to an absolute path:
     - `/home/projects/test.txt` in both cases.
     - This ensures that the same file results in the **same hash**, regardless of the project directory from which it is referenced.

3. **Path Resolution in `writeGlob(...)` and `writeFinder(...)`**:
   - Similarly, `realpath()` is used in `writeGlob(...)`, and `->getRealPath()` is applied in `writeFinder(...)` to ensure correct absolute path resolution across different project contexts.