### PR TITLE
Rework some log level

### DIFF
--- a/src/EventDispatcher.php
+++ b/src/EventDispatcher.php
@@ -20,7 +20,7 @@ class EventDispatcher implements EventDispatcherInterface
 
     public function dispatch(object $event, ?string $eventName = null): object
     {
-        $this->logger->info("Dispatching event {$eventName}", [
+        $this->logger->debug("Dispatching event {$eventName}", [
             'event' => $event,
         ]);
 
@@ -32,7 +32,7 @@ class EventDispatcher implements EventDispatcherInterface
      */
     public function addListener(string $eventName, $listener, int $priority = 0): void
     {
-        $this->logger->info("Adding listener for event {$eventName}", [
+        $this->logger->debug("Adding listener for event {$eventName}", [
             'priority' => $priority,
             'listener' => $listener,
         ]);

--- a/src/Http/HttpDownloader.php
+++ b/src/Http/HttpDownloader.php
@@ -26,7 +26,7 @@ class HttpDownloader
      */
     public function download(string $url, ?string $filePath = null, string $method = 'GET', array $options = [], bool $stream = true): ResponseInterface
     {
-        $this->logger->info('Starting http download', ['url' => $url]);
+        $this->logger->notice('Starting HTTP download', ['url' => $url]);
 
         $lastLogTime = time();
         $startTime = microtime(true);

--- a/src/Runner/ProcessRunner.php
+++ b/src/Runner/ProcessRunner.php
@@ -157,7 +157,7 @@ class ProcessRunner
 
         $this->eventDispatcher->dispatch(new Event\ProcessCreatedEvent($process));
 
-        $this->logger->info(\sprintf('Running command: "%s".', $process->getCommandLine()), [
+        $this->logger->notice(\sprintf('Running command: "%s".', $process->getCommandLine()), [
             'process' => $process,
         ]);
 

--- a/tests/Generated/RunExceptionVerboseTest.php.output.txt
+++ b/tests/Generated/RunExceptionVerboseTest.php.output.txt
@@ -1,1 +1,2 @@
+hh:mm:ss NOTICE    [castor] Running command: "echo foo; echo bar>&2; exit 1". ["process" => ["cwd" => "...","env" => [],"runnable" => "echo foo; echo bar>&2; exit 1"]]
 hh:mm:ss NOTICE    [castor] Command finished with an error (exit code=1).


### PR DESCRIPTION
* -v now display the process, and HTTP download
* events are logged only with -vvv
