### PR TITLE
fixed a deprecation in the open() function

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -826,7 +826,7 @@ function open(string ...$urls): void
     $parallelCallbacks = [];
 
     foreach ($urls as $url) {
-        $parallelCallbacks[] = fn () => run([$command, $url], quiet: true);
+        $parallelCallbacks[] = fn () => run([$command, $url], context: context()->withQuiet(true));
     }
 
     parallel(...$parallelCallbacks);


### PR DESCRIPTION
Avoid a deprecation notice when using `open()`