### PR TITLE
Fix deprecated run() usage in SshRunner

### DIFF
--- a/src/Runner/SshRunner.php
+++ b/src/Runner/SshRunner.php
@@ -83,12 +83,14 @@ final class SshRunner
     ): Process {
         return $this->processRunner->run(
             $command,
-            timeout: $timeout,
-            quiet: $quiet,
-            allowFailure: $allowFailure,
-            notify: $notify,
             callback: $callback,
-            context: context()->withPty(false)->withTty(false)->withEnvironment([]),
+            context: context()->withPty(false)
+                                ->withTty(false)
+                                ->withEnvironment([])
+                                ->withQuiet($quiet ?? false)
+                                ->withAllowFailure($allowFailure ?? false)
+                                ->withNotify($notify)
+                                ->withTimeout($timeout),
         );
     }
 


### PR DESCRIPTION
Hello

The SshRunner is triggering a `Since jolicode/castor 0.18: The "quiet" argument is deprecated, use the "Context" object instead.`  deprecation when used.

Here is the code migrated to the context() syntax