### PR TITLE
Remove #[Exclude] from TaskCommand

### DIFF
--- a/src/Console/Command/TaskCommand.php
+++ b/src/Console/Command/TaskCommand.php
@@ -22,11 +22,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\Attribute\Exclude;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /** @internal */
-#[Exclude]
 class TaskCommand extends Command implements SignalableCommandInterface
 {
     use GetRawTokenTrait;


### PR DESCRIPTION
**Problem**
Currently, `Castor\Console\Command\TaskCommand` class is marked with `#[Exclude]` attribute which prevents it from being included in the generated stubs. However, this class is required for proper type-hinting in public event classes like `Castor\Event\BeforeExecuteTaskEvent` and `Castor\Event\AfterExecuteTaskEvent`.

**Proposal change**
Remove the `#[Exclude]` attribute from `TaskCommand` while keeping the `@internal` PHPDoc annotation:


**This would**
- Keep indicating that the class is not meant for direct usage (`@internal`)
- Allow proper type-hinting in IDEs for events
- Maintain type safety when working with events
- Improve developer experience with better autocompletion
