### PR TITLE
Allow to run ssh commands to localhost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,12 @@
             "Castor\\Tests\\": "tests/"
         }
     },
+     "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/pierrelemee/ssh"
+        }
+    ],
     "require": {
         "php": ">=8.1",
         "composer/composer": "^2.8.2",
@@ -40,7 +46,7 @@
         "monolog/monolog": "^3.7",
         "nikic/php-parser": "^v5.3.1",
         "phpstan/phpdoc-parser": "^1.33",
-        "spatie/ssh": "^1.12.0",
+        "spatie/ssh": "dev-feature/105-local-ssh",
         "symfony/cache": "^6.4.14",
         "symfony/config": "^6.4.14",
         "symfony/console": "^6.4.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3143a238aa9da55e98bfc5b9a3a35bc6",
+    "content-hash": "67b47151ce0967d636f1be8c16fe2b05",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1482,16 +1482,16 @@
         },
         {
             "name": "spatie/ssh",
-            "version": "1.12.0",
+            "version": "dev-feature/105-local-ssh",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spatie/ssh.git",
-                "reference": "49bc291912d1f100cdfa37b691a0f8df7e87b982"
+                "url": "https://github.com/pierrelemee/ssh.git",
+                "reference": "89f2a8ce542f3bf910e8947042d58489f94c5db9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/ssh/zipball/49bc291912d1f100cdfa37b691a0f8df7e87b982",
-                "reference": "49bc291912d1f100cdfa37b691a0f8df7e87b982",
+                "url": "https://api.github.com/repos/pierrelemee/ssh/zipball/89f2a8ce542f3bf910e8947042d58489f94c5db9",
+                "reference": "89f2a8ce542f3bf910e8947042d58489f94c5db9",
                 "shasum": ""
             },
             "require": {
@@ -1509,7 +1509,19 @@
                     "Spatie\\Ssh\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Spatie\\Ssh\\Tests\\": "tests"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "vendor/bin/pest"
+                ],
+                "test-coverage": [
+                    "vendor/bin/pest --coverage-html coverage"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -1528,16 +1540,9 @@
                 "ssh"
             ],
             "support": {
-                "issues": "https://github.com/spatie/ssh/issues",
-                "source": "https://github.com/spatie/ssh/tree/1.12.0"
+                "source": "https://github.com/pierrelemee/ssh/tree/feature/105-local-ssh"
             },
-            "funding": [
-                {
-                    "url": "https://spatie.be/open-source/support-us",
-                    "type": "custom"
-                }
-            ],
-            "time": "2024-11-06T22:10:55+00:00"
+            "time": "2024-11-08T19:58:57+00:00"
         },
         {
             "name": "symfony/cache",
@@ -4755,7 +4760,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "spatie/ssh": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Runner/SshRunner.php
+++ b/src/Runner/SshRunner.php
@@ -102,6 +102,10 @@ final class SshRunner
     ): Ssh {
         $ssh = Ssh::create($user, $host, $sshOptions['port'] ?? null);
 
+        if ($sshOptions['no_bash'] ?? false) {
+            $ssh->removeBash();
+        }
+
         if ($sshOptions['path_private_key'] ?? false) {
             $ssh->usePrivateKey($sshOptions['path_private_key']);
         }
@@ -111,11 +115,15 @@ final class SshRunner
         if ($sshOptions['multiplexing_control_path'] ?? false) {
             $ssh->useMultiplexing($sshOptions['multiplexing_control_path'], $sshOptions['multiplexing_control_persist'] ?? '10m');
         }
-        if ($sshOptions['enable_strict_check'] ?? false) {
+        if (isset($sshOptions['enable_strict_check'])) {
             $sshOptions['enable_strict_check'] ? $ssh->enableStrictHostKeyChecking() : $ssh->disableStrictHostKeyChecking();
         }
-        if ($sshOptions['password_authentication'] ?? false) {
+        if (isset($sshOptions['password_authentication'])) {
             $sshOptions['password_authentication'] ? $ssh->enablePasswordAuthentication() : $ssh->disablePasswordAuthentication();
+        }
+
+        if ($sshOptions['allow_local_connection'] ?? false) {
+            $ssh->allowLocalConnection();
         }
 
         return $ssh;


### PR DESCRIPTION
# Allow to run ssh commands to localhost

See #532 : my wish here is to allow anyone who, like me, would like to test a set of SSH commands over a local Docker container. For this reason, it's handy to explicitly declare an `allow_local_connection` to the SSH options. Under the hood, this takes advantage of [the _spatie_ `Ssh` option I'm currently suggesting there](https://github.com/spatie/ssh/pull/108).

> [!NOTE]  
> I also included a fix to the `buildSssh()` function so that boolean options `enable_strict_check` and `password_authentication` can be defined but set to `false` or any _falsy_ value (I personally rely on URLs and query params)