### PR TITLE
Revert "Do not boot the kernel when using composer command"

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -2,12 +2,10 @@
 
 namespace Castor\Console;
 
-use Castor\Console\Command\ComposerCommand;
 use Castor\Container;
 use Castor\Kernel;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -45,9 +43,7 @@ class Application extends SymfonyApplication
         // @phpstan-ignore-next-line
         Container::set($this->containerBuilder->get(Container::class));
 
-        if ($this->shouldBootKernel($input)) {
-            $this->kernel->boot($input, $output);
-        }
+        $this->kernel->boot($input, $output);
 
         return parent::doRun($input, $output);
     }
@@ -87,26 +83,6 @@ class Application extends SymfonyApplication
         );
 
         return $definition;
-    }
-
-    private function shouldBootKernel(InputInterface $input): bool
-    {
-        $name = $input->getFirstArgument();
-        if (!$name) {
-            return true;
-        }
-
-        try {
-            $command = $this->find($name);
-        } catch (CommandNotFoundException) {
-            return true;
-        }
-
-        if ($command instanceof ComposerCommand) {
-            return false;
-        }
-
-        return true;
     }
 
     private function getLogo(): string


### PR DESCRIPTION
This reverts commit b5a2093ac81cb5b829eefce3b34d8d47411a08df.

We need to boot the kernel, because one could create a custom composer
task.

fix https://github.com/jolicode/castor/issues/562
