### PR TITLE
Rework the releasing

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -3,8 +3,6 @@ name: Artifacts
 on:
   push:
     branches: [ "main" ]
-  release:
-      types: [ "created" ]
 
 permissions:
   contents: write
@@ -31,7 +29,7 @@ jobs:
           path: tools/phar/build/castor.linux-amd64.phar
           if-no-files-found: error
 
-      - name: Upload the Linux ARM64 phar
+      - name: Upload the Linux amr64 phar
         uses: actions/upload-artifact@v4
         with:
           name: 'castor.linux-arm64.phar'
@@ -45,7 +43,7 @@ jobs:
           path: tools/phar/build/castor.darwin-amd64.phar
           if-no-files-found: error
 
-      - name: Upload the Darwin ARM64 phar
+      - name: Upload the Darwin amr64 phar
         uses: actions/upload-artifact@v4
         with:
           name: 'castor.darwin-arm64.phar'
@@ -157,31 +155,3 @@ jobs:
           name: "castor.darwin-arm64"
           path: ./castor.darwin-arm64
           if-no-files-found: error
-
-  release:
-    name: Upload artifacts to the release
-    if: github.event_name == 'release'
-    needs: [phars, static-linux-amd64, static-darwin-amd64, static-darwin-arm64]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: retrieve artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: build
-          merge-multiple: true
-
-      - name: Upload files
-        run: |
-          gh release upload ${{ github.ref_name }} ./build/castor.darwin-amd64
-          gh release upload ${{ github.ref_name }} ./build/castor.darwin-amd64.phar
-          gh release upload ${{ github.ref_name }} ./build/castor.darwin-arm64
-          gh release upload ${{ github.ref_name }} ./build/castor.darwin-arm64.phar
-          gh release upload ${{ github.ref_name }} ./build/castor.linux-amd64
-          gh release upload ${{ github.ref_name }} ./build/castor.linux-amd64.phar
-          gh release upload ${{ github.ref_name }} ./build/castor.linux-arm64.phar
-          gh release upload ${{ github.ref_name }} ./build/castor.windows-amd64.phar
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 !/castor.composer.json
 !/castor.composer.lock
 site/
+/tools/release/artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released yet
 
+### Internal
+
+* Rework the releasing
+
 ## 0.20.0 (2024-11-13)
 
 ### Features

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -63,6 +63,7 @@ $taskFilterList = [
     'watch:stop',
     'open:documentation',
     'open:multiple',
+    'release',
     // Not examples
     'castor:compile',
     'castor:phar:build',

--- a/castor.php
+++ b/castor.php
@@ -11,6 +11,7 @@ import(__DIR__ . '/tools/phpstan/castor.php');
 import(__DIR__ . '/tools/static/castor.php');
 
 mount(__DIR__ . '/tools/phar');
+mount(__DIR__ . '/tools/release');
 mount(__DIR__ . '/tools/watcher');
 
 #[AsTask(description: 'hello')]

--- a/src/Exception/ProblemException.php
+++ b/src/Exception/ProblemException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Castor\Exception;
+
+class ProblemException extends \RuntimeException
+{
+    public function __construct(string $message, int $code = 1, ?\Throwable $previous = null)
+    {
+        if ($code < 1) {
+            throw new \InvalidArgumentException('The code must be greater than 0.');
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Runner/ProcessRunner.php
+++ b/src/Runner/ProcessRunner.php
@@ -18,7 +18,6 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 use function Castor\context;
-use function Castor\Internal\fix_exception;
 
 /** @internal */
 class ProcessRunner
@@ -218,7 +217,7 @@ class ProcessRunner
                     throw new ProcessFailedException($process);
                 }
 
-                throw fix_exception(new \Exception("The command \"{$process->getCommandLine()}\" failed."), 1);
+                throw new \RuntimeException("The command \"{$process->getCommandLine()}\" failed.");
             }
 
             return $process;

--- a/src/functions-internal.php
+++ b/src/functions-internal.php
@@ -23,7 +23,7 @@ function castor_require(string $file): void
  *
  * @internal
  */
-function fix_exception(\Exception $exception, int $depth = 0): \Exception
+function fix_exception(\Throwable $exception, int $depth = 0): \Throwable
 {
     $lastFrame = $exception->getTrace()[$depth];
     foreach (['file', 'line'] as $key) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -71,19 +71,26 @@ function run(
         $workingDirectory = $path;
     }
 
-    return Container::get()->processRunner->run(
-        $command,
-        $environment,
-        $workingDirectory,
-        $tty,
-        $pty,
-        $timeout,
-        $quiet,
-        $allowFailure,
-        $notify,
-        $callback,
-        $context,
-    );
+    try {
+        return Container::get()
+            ->processRunner
+            ->run(
+                $command,
+                $environment,
+                $workingDirectory,
+                $tty,
+                $pty,
+                $timeout,
+                $quiet,
+                $allowFailure,
+                $notify,
+                $callback,
+                $context,
+            )
+        ;
+    } catch (\Throwable $e) {
+        throw fix_exception($e, 1);
+    }
 }
 
 /**
@@ -101,7 +108,7 @@ function capture(
     ?string $path = null,
 ): string {
     if ($workingDirectory && $path) {
-        throw new \LogicException('You cannot use both the "path" and "workingDirectory" arguments at the same time.');
+        throw fix_exception(new \LogicException('You cannot use both the "path" and "workingDirectory" arguments at the same time.'), 1);
     }
     if ($path) {
         trigger_deprecation('jolicode/castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
@@ -109,15 +116,22 @@ function capture(
         $workingDirectory = $path;
     }
 
-    return Container::get()->processRunner->capture(
-        $command,
-        $environment,
-        $workingDirectory,
-        $timeout,
-        $allowFailure,
-        $onFailure,
-        $context,
-    );
+    try {
+        return Container::get()
+            ->processRunner
+            ->capture(
+                $command,
+                $environment,
+                $workingDirectory,
+                $timeout,
+                $allowFailure,
+                $onFailure,
+                $context,
+            )
+        ;
+    } catch (\Throwable $e) {
+        throw fix_exception($e, 2);
+    }
 }
 
 /**
@@ -134,7 +148,7 @@ function exit_code(
     ?string $path = null,
 ): int {
     if ($workingDirectory && $path) {
-        throw new \LogicException('You cannot use both the "path" and "workingDirectory" arguments at the same time.');
+        throw fix_exception(new \LogicException('You cannot use both the "path" and "workingDirectory" arguments at the same time.'));
     }
     if ($path) {
         trigger_deprecation('jolicode/castor', '0.15', 'The "path" argument is deprecated, use "workingDirectory" instead.');
@@ -142,14 +156,21 @@ function exit_code(
         $workingDirectory = $path;
     }
 
-    return Container::get()->processRunner->exitCode(
-        $command,
-        $environment,
-        $workingDirectory,
-        $timeout,
-        $quiet,
-        $context,
-    );
+    try {
+        return Container::get()
+            ->processRunner
+            ->exitCode(
+                $command,
+                $environment,
+                $workingDirectory,
+                $timeout,
+                $quiet,
+                $context,
+            )
+        ;
+    } catch (\Throwable $e) {
+        throw fix_exception($e, 2);
+    }
 }
 
 /**

--- a/tests/Generated/FailureVerboseArgumentsTrueTest.php.err.txt
+++ b/tests/Generated/FailureVerboseArgumentsTrueTest.php.err.txt
@@ -1,4 +1,4 @@
-In ProcessRunner.php line XXXX:
+In functions.php line XXXX:
 
   The command "bash -c i_do_not_exist -x -e" failed.
 

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -3,6 +3,7 @@ hello                                                             hello
 help                                                              Display help for a command
 list                                                              List commands
 no-namespace                                                      Task without a namespace
+release                                                           Release a new version of castor
 args:another-args                                                 Dumps all arguments and options, without configuration
 args:args                                                         Dumps all arguments and options, with custom configuration
 args:autocomplete-argument                                        Provides autocomplete for an argument

--- a/tests/Generated/RunExceptionVerboseTest.php.err.txt
+++ b/tests/Generated/RunExceptionVerboseTest.php.err.txt
@@ -1,4 +1,4 @@
-In ProcessRunner.php line XXXX:
+In run.php line 64:
 
   [Symfony\Component\Process\Exception\ProcessFailedException]
   The command "echo foo; echo bar>&2; exit 1" failed.
@@ -18,7 +18,7 @@ In ProcessRunner.php line XXXX:
 
 
 Exception trace:
-  at .../src/Runner/ProcessRunner.php:XXXX
+  at .../examples/run.php:XXXX
  Castor\Runner\ProcessRunner->run() at .../src/functions.php:XXXX
  Castor\run() at .../examples/run.php:XXXX
  run\exception() at .../src/Console/Command/TaskCommand.php:XXXX

--- a/tests/Generated/ShellBashTest.php.err.txt
+++ b/tests/Generated/ShellBashTest.php.err.txt
@@ -1,4 +1,4 @@
-In Process.php line XXXX:
+In functions.php line XXXX:
 
   TTY mode requires /dev/tty to be read/writable.
 

--- a/tests/Generated/ShellShTest.php.err.txt
+++ b/tests/Generated/ShellShTest.php.err.txt
@@ -1,4 +1,4 @@
-In Process.php line XXXX:
+In functions.php line XXXX:
 
   TTY mode requires /dev/tty to be read/writable.
 

--- a/tests/Generated/SshDownloadTest.php.err.txt
+++ b/tests/Generated/SshDownloadTest.php.err.txt
@@ -1,6 +1,6 @@
 ssh: Could not resolve hostname server-1.example.com: Name or service not known
 
-In SshRunner.php line XXXX:
+In ProcessRunner.php line XXXX:
 
   The command "scp -r debian@server-1.example.com:/tmp/test.html /var/www/index.html" failed.
 

--- a/tests/Generated/SshLsTest.php.err.txt
+++ b/tests/Generated/SshLsTest.php.err.txt
@@ -1,6 +1,6 @@
 ssh: Could not resolve hostname server-1.example.com: Name or service not known
 
-In SshRunner.php line XXXX:
+In ProcessRunner.php line XXXX:
 
   The command "ssh -p 2222 debian@server-1.example.com 'bash -se' << \EOF-SPATIE-SSH
   cd /var/www && ls -alh

--- a/tests/Generated/SshRealTimeOutputTest.php.err.txt
+++ b/tests/Generated/SshRealTimeOutputTest.php.err.txt
@@ -1,4 +1,4 @@
-In SshRunner.php line XXXX:
+In ProcessRunner.php line XXXX:
 
   The command "ssh  debian@server-1.example.com 'bash -se' << \EOF-SPATIE-SSH
   ls -alh

--- a/tests/Generated/SshUploadTest.php.err.txt
+++ b/tests/Generated/SshUploadTest.php.err.txt
@@ -1,6 +1,6 @@
 ssh: Could not resolve hostname server-1.example.com: Name or service not known
 
-In SshRunner.php line XXXX:
+In ProcessRunner.php line XXXX:
 
   The command "scp -r .../examples/ssh.php debian@server-1.example.com:/var/www/index.html" failed.
 

--- a/tests/Generated/SshWhoamiTest.php.err.txt
+++ b/tests/Generated/SshWhoamiTest.php.err.txt
@@ -1,6 +1,6 @@
 ssh: Could not resolve hostname server-1.example.com: Name or service not known
 
-In SshRunner.php line XXXX:
+In ProcessRunner.php line XXXX:
 
   The command "ssh -p 2222 server-1.example.com 'bash -se' << \EOF-SPATIE-SSH
   cd /var/www && whoami

--- a/tools/release/castor.php
+++ b/tools/release/castor.php
@@ -1,0 +1,172 @@
+<?php
+
+use Castor\Attribute\AsTask;
+use Castor\Console\Application;
+use Castor\Exception\ProblemException;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Process\ExecutableFinder;
+
+use function Castor\capture;
+use function Castor\context;
+use function Castor\finder;
+use function Castor\fs;
+use function Castor\io;
+use function Castor\run;
+
+const REPO = 'jolicode/castor';
+const EXPECTED_ARTIFACTS = 8;
+
+#[AsTask(description: 'Release a new version of castor')]
+function release(): int
+{
+    io()->title('Release a new version of Castor');
+
+    io()->section('Check requirements');
+
+    check(
+        'Check if Git is installed',
+        'Git is not installed. Please install it before.',
+        fn () => (new ExecutableFinder())->find('git'),
+    );
+
+    check(
+        'Check if GitHub CLI is installed',
+        'GitHub CLI is not installed. Please install it before.',
+        fn () => (new ExecutableFinder())->find('gh'),
+    );
+
+    check(
+        'Check if there are uncommitted changes',
+        'You have uncommitted changes. Please commit or stash them before.',
+        fn () => !capture(['git', 'status', '--porcelain']),
+    );
+
+    $currentSha = capture('git rev-parse HEAD');
+    io()->comment("Commit: <comment>{$currentSha}</comment>");
+
+    check(
+        'Check current commit exist on remote',
+        'You are not up to date with origin/main. Please push the latest changes before.',
+        fn () => $currentSha === capture('git ls-remote git@github.com:' . REPO . ' refs/heads/main | cut -f 1'),
+    );
+
+    $version = Application::VERSION;
+    io()->comment("Version: <comment>{$version}</comment>");
+
+    check(
+        'Check if a tag already exists for this version',
+        "Version {$version} already exists. Change the version in `src/Console/Application.php`.",
+        fn () => !capture('git ls-remote git@github.com:' . REPO . " refs/tags/{$version}", context: context()->withAllowFailure()),
+    );
+
+    io()->section('Check GitHub Actions requirements');
+
+    $response = capture(['gh', 'run', 'list', '--commit', $currentSha, '--json', 'name,databaseId,status,conclusion']);
+    if (!$response) {
+        throw new ProblemException('Could not found a GitHub Actions run for this commit. Please wait for the CI to start.');
+    }
+
+    $runs = json_decode($response, true);
+    $runTest = null;
+    $runArtifacts = null;
+    foreach ($runs as $run) {
+        if ('Continuous Integration' === $run['name']) {
+            $runTest = $run;
+        }
+        if ('Artifacts' === $run['name']) {
+            $runArtifacts = $run;
+        }
+    }
+    if (!$runTest || !$runArtifacts) {
+        throw new ProblemException('Could not found a GitHub Actions run for this commit. Please wait for the CI to start.');
+    }
+
+    checkCi($runArtifacts);
+    checkCi($runTest);
+
+    io()->section("Releasing version {$version}");
+
+    $artifactsDir = __DIR__ . '/artifacts';
+    fs()->remove($artifactsDir);
+    fs()->mkdir($artifactsDir);
+
+    check(
+        'Download artifacts',
+        'Failed to download artifacts.',
+        fn () => run(['gh', 'run', 'download', $runArtifacts['databaseId'], '--dir', $artifactsDir], context: context()->withQuiet())->isSuccessful(),
+    );
+
+    $files = finder()
+        ->in($artifactsDir)
+        ->files()
+    ;
+
+    check(
+        'Check the number of artifacts',
+        'There are not enough files in the artifacts directory.',
+        fn () => EXPECTED_ARTIFACTS === count($files),
+    );
+
+    check(
+        'Check if artifacts are not empty',
+        'Some artifacts are empty.',
+        fn () => !array_filter(
+            iterator_to_array($files),
+            // A least 3MB
+            fn (SplFileInfo $file) => 3_000_000 > $file->getSize()
+        ),
+    );
+
+    io()->write('Publishing the release');
+
+    $process = run(
+        [
+            'gh', 'release', 'create', $version,
+            '--title', "Release {$version}",
+            ...array_keys(iterator_to_array($files)),
+        ],
+        context: context()->toInteractive()
+    );
+
+    if (!$process->isSuccessful()) {
+        throw new ProblemException('Failed to publish the release.');
+    }
+
+    io()->success('Release published!');
+
+    return 0;
+}
+
+function check(string $title, string $failureMessage, callable $check): void
+{
+    io()->write($title);
+
+    if (!$check()) {
+        io()->writeln(' ❌');
+
+        throw new ProblemException($failureMessage);
+    }
+
+    io()->writeln(' ✅');
+}
+
+function checkCi(array $run): void
+{
+    io()->comment("{$run['name']}'s run id <comment>{$run['databaseId']}</comment>");
+
+    if ('completed' === $run['status']) {
+        if ('failure' === $run['conclusion']) {
+            run(['gh', 'run', 'view', $run['databaseId']]);
+
+            throw new ProblemException("The CI {$run['name']} has failed. Please fix it before releasing.");
+        }
+    } else {
+        $process = run(['gh', 'run', 'watch', $run['databaseId'], '--exit-status'], context: context()->toInteractive());
+
+        if (!$process->isSuccessful()) {
+            throw new ProblemException("The CI {$run['name']} has failed. Please fix it before releasing.");
+        }
+    }
+
+    io()->comment("{$run['name']}'s run is <info>okay</info>!");
+}


### PR DESCRIPTION
Our current process has some issues. For example, we publish the release, and then
we build all artifacts in GHA. But this build took some time, and during the build
we broke all CI. Indeed, CI wants to download castor, it tooks the last release, but 
artifacts are not yet there.

And for the v0.20.0, we had another issue: the release.created event was NOT fired :/ 

And we had other issues in the past, for example when a build fails, none files were uploaded.

E_TOO_MANY_PIT_FALL...

So we rewrote everything. Now the releasing is managed locally. We still use GHA to build all our artefacts.
But now we are able to publish a release with all artifacts at once 🎉

And we added tons of checks to ensure everything is okay.

---

Side notes:

* This patch add support for ProblemeException => it display an error message, but simpler than a regular exception
* We better display origin file/line when an exception occurs

---

fixes https://github.com/jolicode/castor/issues/520