### PR TITLE
Add `AsPathArgument` and `AsPathOption` attributes for paths autocompletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Add `encrypt_with_password()`, `decrypt_with_password()`,
   `encrypt_file_with_password()`, and `decrypt_file_with_password()` functions to
   encrypt and decrypt data
+* Add `AsPathArgument` and `AsPathOption` attributes to handle autocompletion of
+paths in arguments and options
 
 ### Fixes
 

--- a/doc/getting-started/arguments.md
+++ b/doc/getting-started/arguments.md
@@ -166,3 +166,32 @@ command has been forced
 Please refer to the [Symfony
 documentation](https://symfony.com/doc/current/console/input.html#using-command-options)
 for more information.
+
+## Path arguments and options
+
+In some cases, you may want the user to provide a path in an argument or an option.
+In order to ease the use of paths for users, Castor provides the `AsPathArgument`
+and `AsPathOption` attributes alternatives to `AsArgument` and `AsOption`.
+
+When using `AsPathArgument` or `AsPathOption`, the argument or option will be
+autocompleted with suggestions of paths.
+
+```php
+use Castor\Attribute\AsOption;
+use Castor\Attribute\AsTask;
+
+use function Castor\run;
+#[AsTask()]
+function command(
+    #[AsPathArgument()]
+    string $argument,
+): void {
+}
+```
+
+```bash
+$ castor command /var/www/[TAB]
+/var/www/foo  /var/www/bar  /var/www/baz
+```
+
+See the [autocompletion documentation](../going-further/interacting-with-castor/autocomplete.md) for more information about completion.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -78,6 +78,8 @@ Castor provides the following attributes to register tasks, listener, etc:
 - [`AsContextGenerator`](going-further/interacting-with-castor/advanced-context.md#the-ascontextgenerator-attribute)
 - [`AsListener`](going-further/extending-castor/events.md#registering-a-listener)
 - [`AsOption`](getting-started/arguments.md#overriding-the-option-name-and-description)
+- [`AsPathArgument`](getting-started/arguments.md#path-arguments-and-options)
+- [`AsPathOption`](getting-started/arguments.md#path-arguments-and-options)
 - [`AsRawTokens`](getting-started/arguments.md#arguments-without-configuration-nor-validation)
 - [`AsSymfonyTask`](going-further/interacting-with-castor/symfony-task.md)
 - [`AsTask`](getting-started/basic-usage.md)

--- a/examples/args.php
+++ b/examples/args.php
@@ -4,6 +4,7 @@ namespace args;
 
 use Castor\Attribute\AsArgument;
 use Castor\Attribute\AsOption;
+use Castor\Attribute\AsPathArgument;
 use Castor\Attribute\AsRawTokens;
 use Castor\Attribute\AsTask;
 use Symfony\Component\Console\Completion\CompletionInput;
@@ -62,4 +63,12 @@ function get_argument_autocompletion(CompletionInput $input): array
         'bar',
         'baz',
     ];
+}
+
+#[AsTask(description: 'Provides autocomplete for a path argument')]
+function autocomplete_path(
+    #[AsPathArgument(name: 'argument', description: 'This is a path argument with autocompletion')]
+    string $argument,
+): void {
+    var_dump(\func_get_args());
 }

--- a/src/Attribute/AsPathArgument.php
+++ b/src/Attribute/AsPathArgument.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Castor\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class AsPathArgument extends AsArgument
+{
+    public function __construct(
+        ?string $name = null,
+        string $description = '',
+    ) {
+        parent::__construct($name, $description);
+    }
+}

--- a/src/Attribute/AsPathOption.php
+++ b/src/Attribute/AsPathOption.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Castor\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class AsPathOption extends AsOption
+{
+    /**
+     * @param string|array<string>|null $shortcut
+     */
+    public function __construct(
+        ?string $name = null,
+        string|array|null $shortcut = null,
+        ?int $mode = null,
+        string $description = '',
+    ) {
+        parent::__construct($name, $shortcut, $mode, $description);
+    }
+}

--- a/src/Factory/TaskCommandFactory.php
+++ b/src/Factory/TaskCommandFactory.php
@@ -8,6 +8,7 @@ use Castor\Descriptor\TaskDescriptor;
 use Castor\ExpressionLanguage;
 use Castor\Helper\Slugger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 class TaskCommandFactory
 {
@@ -16,6 +17,7 @@ class TaskCommandFactory
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ContextRegistry $contextRegistry,
         private readonly Slugger $slugger,
+        private readonly Filesystem $fs,
     ) {
     }
 
@@ -27,6 +29,7 @@ class TaskCommandFactory
             $this->eventDispatcher,
             $this->contextRegistry,
             $this->slugger,
+            $this->fs,
         );
     }
 }

--- a/tests/AutocompleteTest.php
+++ b/tests/AutocompleteTest.php
@@ -3,6 +3,8 @@
 namespace Castor\Tests;
 
 use Castor\Attribute\AsArgument;
+use Castor\Attribute\AsPathArgument;
+use Castor\Attribute\AsPathOption;
 use Castor\Attribute\AsTask;
 use Castor\Console\Command\TaskCommand;
 use Castor\ContextRegistry;
@@ -12,6 +14,7 @@ use Castor\Helper\Slugger;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
 class AutocompleteTest extends TaskTestCase
@@ -27,6 +30,7 @@ class AutocompleteTest extends TaskTestCase
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(ContextRegistry::class),
             new Slugger(new AsciiSlugger()),
+            new Filesystem(),
         );
 
         $tester = new CommandCompletionTester($command);
@@ -41,6 +45,79 @@ class AutocompleteTest extends TaskTestCase
         yield [task_with_autocomplete(...), ['d', 'e', 'f']];
         yield [task_with_autocomplete_filtered(...), ['foo', 'bar', 'baz']];
         yield [task_with_autocomplete_filtered(...), ['bar', 'baz'], 'ba'];
+    }
+
+    /** @dataProvider providePathCompletionTests */
+    public function testPathCompletion(\Closure $function, array $input, array $expectedItems, bool $exactExpectations = false)
+    {
+        $descriptor = new TaskDescriptor(new AsTask('task'), new \ReflectionFunction($function));
+
+        $fs = new Filesystem();
+
+        $command = new TaskCommand(
+            $descriptor,
+            $this->createMock(ExpressionLanguage::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(ContextRegistry::class),
+            new Slugger(new AsciiSlugger()),
+            $fs,
+        );
+
+        $tester = new CommandCompletionTester($command);
+
+        $suggestions = $tester->complete($input);
+
+        $message = sprintf('%s - Suggestions: %s',
+            (new \ReflectionFunction($function))->getName(),
+            implode(', ', $suggestions)
+        );
+
+        if ($exactExpectations) {
+            $this->assertCount(count($expectedItems), $suggestions, $message);
+            $this->assertSame($expectedItems, $suggestions, $message);
+
+            return;
+        }
+
+        $this->assertCount(count($expectedItems), array_intersect($suggestions, $expectedItems), $message);
+    }
+
+    public function providePathCompletionTests(): \Generator
+    {
+        $fs = new Filesystem();
+
+        $tmpDir = sys_get_temp_dir() . '/castor-test';
+        $fs->mkdir($tmpDir . '/foo');
+        $fs->mkdir($tmpDir . '/bar');
+        $fs->touch($tmpDir . '/foo/baz.txt');
+
+        yield [task_with_path_argument(...), [''], ['bin', 'doc', 'src', 'tools']];
+        yield [task_with_path_argument(...), ['.'], ['bin', 'doc', 'src', 'tools']];
+        yield [task_with_path_argument(...), ['./'], ['./bin', './doc', './src', './tools']];
+        yield [task_with_path_argument(...), ['b'], ['bin', 'doc', 'src', 'tools']];
+        yield [task_with_path_argument(...), ['bin'], ['bin/castor']];
+        yield [task_with_path_argument(...), ['bin/'], ['bin/castor']];
+        yield [task_with_path_argument(...), ['yolooooooooo'], []];
+        yield [task_with_path_argument(...), ['yolooooooooo/'], []];
+        yield [task_with_path_argument(...), [$tmpDir], [$tmpDir . '/bar', $tmpDir . '/foo'], true];
+        yield [task_with_path_argument(...), [$tmpDir . '/'], [$tmpDir . '/bar', $tmpDir . '/foo'], true];
+        yield [task_with_path_argument(...), [$tmpDir . '/.'], [$tmpDir . '/bar', $tmpDir . '/foo'], true];
+        yield [task_with_path_argument(...), [$tmpDir . '/./'], [$tmpDir . '/./bar', $tmpDir . '/./foo'], true];
+        yield [task_with_path_argument(...), [$tmpDir . '/f'], [$tmpDir . '/bar', $tmpDir . '/foo'], true];
+
+        yield [task_with_path_option(...), ['--option'], ['bin', 'doc', 'src', 'tools']];
+        yield [task_with_path_option(...), ['--option', '.'], ['bin', 'doc', 'src', 'tools']];
+        yield [task_with_path_option(...), ['--option', './'], ['./bin', './doc', './src', './tools']];
+        yield [task_with_path_option(...), ['--option', 'b'], ['bin', 'doc', 'src', 'tools']];
+        yield [task_with_path_option(...), ['--option', 'bin'], ['bin/castor']];
+        yield [task_with_path_option(...), ['--option', 'bin/'], ['bin/castor']];
+        yield [task_with_path_option(...), ['--option', 'yolooooooooo'], []];
+        yield [task_with_path_option(...), ['--option', 'yolooooooooo/'], []];
+        yield [task_with_path_option(...), ['--option', $tmpDir], [$tmpDir . '/bar', $tmpDir . '/foo'], true];
+        yield [task_with_path_option(...), ['--option', $tmpDir . '/'], [$tmpDir . '/bar', $tmpDir . '/foo'], true];
+        yield [task_with_path_option(...), ['--option', $tmpDir . '/.'], [$tmpDir . '/bar', $tmpDir . '/foo'], true];
+        yield [task_with_path_option(...), ['--option', $tmpDir . '/./'], [$tmpDir . '/./bar', $tmpDir . '/./foo'], true];
+        yield [task_with_path_option(...), ['--option', $tmpDir . '/f'], [$tmpDir . '/bar', $tmpDir . '/foo'], true];
     }
 }
 
@@ -80,4 +157,16 @@ function complete_filtered(CompletionInput $input): array
         'bar',
         'baz',
     ], fn (string $value) => str_starts_with($value, $input->getCompletionValue()));
+}
+
+function task_with_path_argument(
+    #[AsPathArgument(name: 'argument')]
+    string $path,
+): void {
+}
+
+function task_with_path_option(
+    #[AsPathOption(name: 'option')]
+    string $path,
+): void {
 }

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -6,6 +6,7 @@ no-namespace                                                      Task without a
 args:another-args                                                 Dumps all arguments and options, without configuration
 args:args                                                         Dumps all arguments and options, with custom configuration
 args:autocomplete-argument                                        Provides autocomplete for an argument
+args:autocomplete-path                                            Provides autocomplete for a path argument
 args:passthru                                                     Dumps all arguments and options, without configuration nor validation
 assertion:ensure-we-are-in-the-future                             Ensure we are in the future
 assertion:throw-an-exception                                      Throws a Problem exception


### PR DESCRIPTION
Fixes https://github.com/jolicode/castor/issues/582

Example:
![image](https://github.com/user-attachments/assets/b564555c-f70d-421a-84c0-8b09bfa4ea4a)
