### PR TITLE
Fix context name when getting it from the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released yet
 
+### Fixes
+
+* Fix context name when getting it from the registry
+
 ## 0.22.0 (2024-12-30)
 
 ### Features

--- a/src/Context.php
+++ b/src/Context.php
@@ -29,7 +29,10 @@ class Context implements \ArrayAccess
         public readonly bool $allowFailure = false,
         public readonly ?bool $notify = null,
         public readonly VerbosityLevel|LegacyVerbosityLevel $verbosityLevel = VerbosityLevel::NOT_CONFIGURED,
-        // Do not use this argument, it is only used internally by the application
+        /**
+         * @internal
+         * Do not use this argument, it is only used internally by the application
+         */
         public readonly string $name = '',
         public readonly string $notificationTitle = '',
         public readonly array $verboseArguments = [],
@@ -270,6 +273,10 @@ class Context implements \ArrayAccess
         );
     }
 
+    /**
+     * @internal
+     * Do not use this method, it is only used internally by the application
+     */
     public function withName(string $name): self
     {
         return new self(

--- a/src/ContextRegistry.php
+++ b/src/ContextRegistry.php
@@ -99,6 +99,8 @@ class ContextRegistry
             throw new FunctionConfigurationException(\sprintf('The context generator must return an instance of "%s", "%s" returned.', Context::class, get_debug_type($context)), $this->descriptors[$name]->function);
         }
 
+        $context = $context->withName($name);
+
         $event = new ContextCreatedEvent($name, $context);
         $this->eventDispatcher->dispatch($event);
 


### PR DESCRIPTION
fix #592
