### PR TITLE
Fix passing `null` to `escapeshellarg()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released yet
 
+### Fixes
+
+* Ignore `null` env variable when running process
+
 ## 0.22.1 (2025-01-31)
 
 ### Fixes

--- a/castor.composer.lock
+++ b/castor.composer.lock
@@ -94,29 +94,27 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
+                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/31610dbb31faa98e6b5447b62340826f54fbc4e9",
+                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
+                "doctrine/coding-standard": "^9 || ^12",
+                "phpstan/phpstan": "1.4.10 || 2.0.3",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -124,7 +122,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                    "Doctrine\\Deprecations\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -135,9 +133,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.4"
             },
-            "time": "2024-01-30T19:34:25+00:00"
+            "time": "2024-12-07T21:18:45+00:00"
         },
         {
             "name": "pyrech/castor-example",

--- a/src/Runner/ProcessRunner.php
+++ b/src/Runner/ProcessRunner.php
@@ -294,7 +294,7 @@ class ProcessRunner
         $runnable = $process->getCommandLine();
 
         foreach ($process->getEnv() as $key => $value) {
-            if ('argv' === $key || 'argc' === $key) {
+            if (null === $value || 'argv' === $key || 'argc' === $key) {
                 continue;
             }
             $runnable = \sprintf('%s=%s %s ', $key, escapeshellarg($value), $runnable);

--- a/tests/Monolog/Processor/ProcessProcessorTest.php
+++ b/tests/Monolog/Processor/ProcessProcessorTest.php
@@ -17,6 +17,7 @@ class ProcessProcessorTest extends TestCase
             'foo' => 'b\'"`\ar',
             'argc' => 3,
             'argv' => ['/home/foo/.local/bin//castor', 'builder', '-vvv'],
+            'null' => null,
         ]);
         $log = new LogRecord(
             datetime: new \DateTimeImmutable(),
@@ -25,12 +26,7 @@ class ProcessProcessorTest extends TestCase
             message: 'new process',
             context: ['process' => $process],
         );
-        $mock = $this->getMockBuilder(ProcessRunner::class)
-            ->onlyMethods(['buildRunnableCommand'])
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
+        $mock = $this->createPartialMock(ProcessRunner::class, []);
         $processor = new ProcessProcessor($mock);
 
         $this->assertEquals(
@@ -40,8 +36,11 @@ class ProcessProcessorTest extends TestCase
                     'foo' => 'b\'"`\ar',
                     'argc' => 3,
                     'argv' => ['/home/foo/.local/bin//castor', 'builder', '-vvv'],
+                    'null' => null,
                 ],
-                'runnable' => '',
+                'runnable' => <<<'TXT'
+                    foo='b'\''"`\ar' 'ls' '-alh'
+                    TXT,
             ],
             $processor($log)->context['process'],
         );


### PR DESCRIPTION
This fixes `WARNING [castor] Deprecated: escapeshellarg(): Passing null to parameter #1 ($arg) of type string is deprecated`, see https://github.com/jolicode/orpi/pull/6623 for a full example.

If the env var is `null`, I chose to ignore it, but it can also be transformed into `''`, what do you prefer?