### PR TITLE
fix(run-phar): fix running phar that may reexecute himself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixes
 
 * Ignore `null` env variable when running process
+* Use an env var when using `run_php()` to avoid conflict with php script reexecution
+* Rename `run_phar()` to `run_php()` to express better that it can run any PHP file
 
 ### Internal
 

--- a/bin/castor
+++ b/bin/castor
@@ -3,24 +3,10 @@
 
 use Castor\Console\ApplicationFactory;
 
-$argv = $_SERVER['argv'];
+$runPhar = getenv('CASTOR_RUN_PHAR');
 
-if (count($argv) > 2 && $argv[1] === 'run-phar') {
-    $phar = $argv[2];
-
-    if (!file_exists($phar)) {
-        echo "Phar file not found: $phar\n";
-        exit(1);
-    }
-
-    // override the argv
-    $_SERVER['argv'] = array_merge(
-        array($argv[0]),
-        array_slice($argv, 3)
-    );
-    $_SERVER['argc'] = count($_SERVER['argv']);
-
-    require $phar;
+if ($runPhar) {
+    require $runPhar;
 
     exit(0);
 }

--- a/bin/castor
+++ b/bin/castor
@@ -3,10 +3,10 @@
 
 use Castor\Console\ApplicationFactory;
 
-$runPhar = getenv('CASTOR_RUN_PHAR');
+$phpFile = $_SERVER['CASTOR_PHP_REPLACE'] ?? false;
 
-if ($runPhar) {
-    require $runPhar;
+if ($phpFile) {
+    require $phpFile;
 
     exit(0);
 }

--- a/doc/going-further/helpers/run-php.md
+++ b/doc/going-further/helpers/run-php.md
@@ -1,15 +1,15 @@
 # Executing a phar file
 
-## The `run_phar()` function
+## The `run_php()` function
 
-The `run_phar()` function provides a way to execute a phar file in all scenarios,
+The `run_php()` function provides a way to execute a php or phar file in all scenarios,
 whether castor is executed as a phar, as a static binary, or as a script.
 
 ```php
 #[AsTask()]
 function exec_something()
 {
-    run_phar('path/to/my.phar', ['arg1', 'arg2']);
+    run_php('path/to/my.phar', ['arg1', 'arg2']);
 }
 ```
 
@@ -17,4 +17,4 @@ This allow to execute external php script even if you don't have PHP when using
 the static binary and without conflicts between the external script and internal
 php code of Castor.
 
-The `run_phar()` takes exactly the same options as the `run()` function.
+The `run_php()` takes exactly the same options as the `run()` function.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -39,7 +39,7 @@ Castor provides the following built-in functions:
 - [`output`](going-further/helpers/console-and-io.md#the-output-function)
 - [`parallel`](going-further/helpers/parallel.md#the-parallel-function)
 - [`run`](getting-started/run.md#the-run-function)
-- [`run_phar`](going-further/helpers/run-phar.md)
+- [`run_php`](going-further/helpers/run-php.md)
 - [`ssh_download`](going-further/helpers/ssh.md#the-ssh_download-function)
 - [`ssh_run`](going-further/helpers/ssh.md#the-ssh_run-function)
 - [`ssh_upload`](going-further/helpers/ssh.md#the-ssh_upload-function)

--- a/examples/run-phar.php
+++ b/examples/run-phar.php
@@ -4,10 +4,10 @@ namespace run;
 
 use Castor\Attribute\AsTask;
 
-use function Castor\run_phar;
+use function Castor\run_php;
 
 #[AsTask(description: 'Run a phar in a sub process')]
 function phar(): void
 {
-    run_phar('examples/run.phar', ['a', 'list', 'of', 'arguments']);
+    run_php('examples/run.phar', ['a', 'list', 'of', 'arguments']);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -928,13 +928,25 @@ function open(string ...$urls): void
 /**
  * @param array<string|\Stringable> $arguments
  */
-function run_phar(string $pharPath, array $arguments = [], ?Context $context = null): Process
+function run_php(string $pharPath, array $arguments = [], ?Context $context = null): Process
 {
     // get program path
     $castorPath = $_SERVER['argv'][0];
-    $context = $context ?? context();
+    $context ??= context();
 
     return run([$castorPath, ...$arguments], context: $context->withEnvironment([
-        'CASTOR_RUN_PHAR' => $pharPath,
+        'CASTOR_PHP_REPLACE' => $pharPath,
     ]));
+}
+
+/**
+ * @param array<string|\Stringable> $arguments
+ *
+ * @deprecated
+ */
+function run_phar(string $pharPath, array $arguments = [], ?Context $context = null): Process
+{
+    trigger_deprecation('jolicode/castor', '0.23', 'The "%s()" function is deprecated, use "Castor\%s()" instead.', __FUNCTION__, 'run_php');
+
+    return run_php($pharPath, $arguments, $context);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -932,6 +932,9 @@ function run_phar(string $pharPath, array $arguments = [], ?Context $context = n
 {
     // get program path
     $castorPath = $_SERVER['argv'][0];
+    $context = $context ?? context();
 
-    return run([$castorPath, 'run-phar', $pharPath, ...$arguments], context: $context);
+    return run([$castorPath, ...$arguments], context: $context->withEnvironment([
+        'CASTOR_RUN_PHAR' => $pharPath,
+    ]));
 }


### PR DESCRIPTION
When running a phar, if the phar would reexecute himself (like phpstan do for parallel analyze) it may attempt to look at args to do that.

Since we hijacked those parameters to make it work it may not work as intended.

So instead of using argc / argv we rather use an environnement variable to require the correct phar if needed.

This should work as long as sub process launched by the phar will not remove env var (but it should not otherwise there may be other bugs happening)