### PR TITLE
feat(archive): add zip archive functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Improve `decrypt_file_with_password()` with smart `.enc` extension handling
   and file overwrite protection
+* Add `zip()`, `zip_binary()`, and `zip_php()` functions to create password-protected
+  zip archives with various compression methods and configurable compression levels
 
 ### Fixes
 

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -92,6 +92,9 @@ $taskFilterList = [
     'qa:phpstan:update',
     'update',
     // Customized tests
+    'archive:zip',
+    'archive:zip-binary',
+    'archive:zip-php',
     'crypto:decrypt',
     'crypto:encrypt',
     'crypto:decrypt-file',

--- a/doc/going-further/helpers/archive.md
+++ b/doc/going-further/helpers/archive.md
@@ -1,0 +1,90 @@
+# Archive
+
+## The `zip()` function
+
+Castor provides a `zip()` function to compress files or directories into a password-protected ZIP archive:
+
+```php
+use Castor\Attribute\AsArgument;
+use Castor\Attribute\AsTask;
+use Castor\Helper\CompressionMethod;
+
+use function Castor\zip;
+use function Castor\io;
+
+#[AsTask(description: 'Compress a file into a zip archive')]
+function compress_file(string $file, string $destination): void
+{
+    zip($file, $destination, 'my super secret password', CompressionMethod::DEFLATE, 6);
+    io()->success('File compressed successfully!');
+}
+```
+
+> [!NOTE]
+> The `zip()` function automatically selects the best available method (binary or PHP) based on your system configuration.
+> 
+> The `source` parameter can be either a file path or a directory path. Both are fully supported.
+
+> [!WARNING]
+> If you're using the binary version of Castor, you must compile it with the ZIP extension enabled using the `--php-extensions=...,zip` option. Otherwise, the ZIP functionality will not be available.
+
+## The `zip_binary()` function
+
+Castor provides a `zip_binary()` function to compress files using the native zip binary:
+
+```php
+use Castor\Attribute\AsArgument;
+use Castor\Attribute\AsTask;
+use Castor\Helper\ZipArchiver;
+
+use function Castor\zip_binary;
+use function Castor\io;
+
+#[AsTask(description: 'Compress a directory into a zip archive using native binary')]
+function compress_dir_binary(string $directory, string $destination): void
+{
+    zip_binary($directory, $destination, 'my super secret password', CompressionMethod::BZIP2, 9);
+    io()->success('Directory compressed successfully!');
+}
+```
+
+## The `zip_php()` function
+
+Castor provides a `zip_php()` function to compress files using PHP's ZipArchive class:
+
+```php
+use Castor\Attribute\AsArgument;
+use Castor\Attribute\AsTask;
+use Castor\Helper\ZipArchiver;
+
+use function Castor\zip_php;
+use function Castor\io;
+
+#[AsTask(description: 'Compress a directory into a zip archive using PHP')]
+function compress_dir_php(string $directory, string $destination): void
+{
+    zip_php($directory, $destination, 'my super secret password', CompressionMethod::ZSTD, 9);
+    io()->success('Directory compressed successfully!');
+}
+```
+
+## Compression methods
+
+Castor supports various compression methods:
+
+- `CompressionMethod::STORE`: No compression, just storage (fastest)
+- `CompressionMethod::DEFLATE`: Standard ZIP compression (good balance)
+- `CompressionMethod::BZIP2`: Better compression ratio but slower
+- `CompressionMethod::ZSTD`: Modern compression algorithm (best ratio, requires PHP ZipArchive with libzip ≥ 1.8.0)
+
+## Overwriting existing archives
+
+All zip functions accept an `overwrite` parameter to control whether existing archives should be replaced:
+
+```php
+// Will throw an exception if destination.zip already exists
+zip($source, 'destination.zip', 'password');
+
+// Will overwrite destination.zip if it already exists
+zip($source, 'destination.zip', 'password', overwrite: true);
+```

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -55,6 +55,9 @@ Castor provides the following built-in functions:
 - [`with`](going-further/interacting-with-castor/advanced-context.md#the-with-function)
 - [`yaml_dump`](going-further/helpers/yaml.md)
 - [`yaml_parse`](going-further/helpers/yaml.md)
+- [`zip`](going-further/helpers/archive.md)
+- [`zip_binary`](going-further/helpers/archive.md)
+- [`zip_php`](going-further/helpers/archive.md)
 
 ## Vendor helpers
 

--- a/examples/archive.php
+++ b/examples/archive.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace archive;
+
+use Castor\Attribute\AsTask;
+use Castor\Helper\CompressionMethod;
+
+use function Castor\io;
+use function Castor\zip;
+use function Castor\zip_binary;
+use function Castor\zip_php;
+
+const SAMPLE_FILE_BASE = __DIR__ . '/fixtures/archive/sample';
+const SAMPLE_FILE = SAMPLE_FILE_BASE . '.txt';
+const SAMPLE_FILE_ZIP = SAMPLE_FILE_BASE . '.zip';
+
+const SAMPLE_DIR = __DIR__ . '/fixtures/archive/sample_dir';
+const SAMPLE_DIR_ZIP = SAMPLE_DIR . '.zip';
+
+#[AsTask(description: 'Compress files into a zip archive using native binary or fallback to ZipArchive php class', name: 'zip')]
+function zip_archive(): void
+{
+    zip(SAMPLE_FILE, SAMPLE_FILE_ZIP, 'secret', CompressionMethod::BZIP2, 9, overwrite: true);
+    io()->success('File ' . SAMPLE_FILE . ' compressed into ' . SAMPLE_FILE_ZIP);
+
+    zip(SAMPLE_DIR, SAMPLE_DIR_ZIP, 'secret', CompressionMethod::BZIP2, 9, overwrite: true);
+    io()->success('Directory ' . SAMPLE_DIR . ' compressed into ' . SAMPLE_DIR_ZIP);
+}
+
+#[AsTask(description: 'Compress files into a zip archive using native binary', name: 'zip-binary')]
+function zip_binary_archive(): void
+{
+    zip_binary(SAMPLE_FILE, SAMPLE_FILE_ZIP, 'secret', CompressionMethod::BZIP2, 9, overwrite: true);
+    io()->success('File ' . SAMPLE_FILE . ' compressed into ' . SAMPLE_FILE_ZIP);
+
+    zip_binary(SAMPLE_DIR, SAMPLE_DIR_ZIP, 'secret', CompressionMethod::BZIP2, 9, overwrite: true);
+    io()->success('Directory ' . SAMPLE_DIR . ' compressed into ' . SAMPLE_DIR_ZIP);
+}
+
+#[AsTask(description: 'Compress files into a zip archive using ZipArchive php class', name: 'zip-php')]
+function zip_php_archive(): void
+{
+    zip_php(SAMPLE_FILE, SAMPLE_FILE_ZIP, 'secret', CompressionMethod::BZIP2, 9, overwrite: true);
+    io()->success('File ' . SAMPLE_FILE . ' compressed into ' . SAMPLE_FILE_ZIP);
+
+    zip_php(SAMPLE_DIR, SAMPLE_DIR_ZIP, 'secret', CompressionMethod::BZIP2, 9, overwrite: true);
+    io()->success('Directory ' . SAMPLE_DIR . ' compressed into ' . SAMPLE_DIR_ZIP);
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -8,6 +8,7 @@ use Castor\Fingerprint\FingerprintHelper;
 use Castor\Helper\Notifier;
 use Castor\Helper\SymmetricCrypto;
 use Castor\Helper\Waiter;
+use Castor\Helper\ZipArchiver;
 use Castor\Http\HttpDownloader;
 use Castor\Import\Importer;
 use Castor\Runner\ParallelRunner;
@@ -54,6 +55,7 @@ final class Container
         public readonly Waiter $waiter,
         public readonly WatchRunner $watchRunner,
         public readonly SymmetricCrypto $symmetricCrypto,
+        public readonly ZipArchiver $zipArchiver,
     ) {
     }
 

--- a/src/Helper/CompressionMethod.php
+++ b/src/Helper/CompressionMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Castor\Helper;
+
+enum CompressionMethod: string
+{
+    case STORE = 'store';
+    case BZIP2 = 'bzip2';
+    case ZSTD = 'zstd';
+    case DEFLATE = 'deflate';
+
+    public function toZipArchiveMethod(): int
+    {
+        return match ($this) {
+            self::BZIP2 => \ZipArchive::CM_BZIP2,
+            self::STORE => \ZipArchive::CM_STORE,
+            self::DEFLATE => \ZipArchive::CM_DEFLATE,
+            self::ZSTD => \ZipArchive::CM_ZSTD,
+        };
+    }
+}

--- a/src/Helper/ZipArchiver.php
+++ b/src/Helper/ZipArchiver.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Castor\Helper;
+
+use Castor\Context;
+use Castor\Runner\ProcessRunner;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ZipArchiver
+{
+    public function __construct(
+        private readonly ProcessRunner $processRunner,
+        private readonly LoggerInterface $logger,
+        private readonly Filesystem $filesystem,
+    ) {
+    }
+
+    public function zip(
+        string $source,
+        string $destination,
+        #[\SensitiveParameter] ?string $password = null,
+        CompressionMethod $compressionMethod = CompressionMethod::DEFLATE,
+        int $compressionLevel = 6,
+        bool $overwrite = false,
+    ): void {
+        if ($this->isZipBinaryAvailable() && CompressionMethod::ZSTD !== $compressionMethod) {
+            $this->zipWithBinary($source, $destination, $password, $compressionMethod, $compressionLevel, $overwrite);
+
+            return;
+        }
+
+        $this->logger->notice('Native zip binary not available or ZSTD compression method is requested, falling back to PHP ZipArchive');
+
+        if (class_exists(\ZipArchive::class)) {
+            $this->zipWithPhp($source, $destination, $password, $compressionMethod, $compressionLevel, $overwrite);
+
+            return;
+        }
+
+        throw new \RuntimeException('No ZIP compression method available. Install zip binary or PHP zip extension.');
+    }
+
+    public function zipWithBinary(
+        string $source,
+        string $destination,
+        #[\SensitiveParameter] ?string $password = null,
+        CompressionMethod $compressionMethod = CompressionMethod::DEFLATE,
+        int $compressionLevel = 6,
+        bool $overwrite = false,
+    ): void {
+        if (!$overwrite && $this->filesystem->exists($destination)) {
+            throw new \RuntimeException(\sprintf('Destination file already exists: %s. Use overwrite=true to force overwrite.', $destination));
+        }
+
+        $zipCommand = ['zip', '-r', $destination, '-Z', $compressionMethod->value, '-' . $compressionLevel];
+
+        if (null !== $password) {
+            // @todo improve security by using -e instead, when run() will allow input to be set before running the command
+            $zipCommand = [...$zipCommand, '-P', $password];
+        }
+
+        // There's no equivalent to an overwrite mode in zip binary, use php to remove existing archive
+        if ($overwrite) {
+            $this->filesystem->remove($destination);
+        }
+
+        // basename($source) and setting the working directory to the parent directory of the source prevents
+        // the full path structure from being included in the zip file
+        $this->processRunner->run(
+            [...$zipCommand, basename($source)],
+            context: new Context(workingDirectory: \dirname($source), quiet: true)
+        );
+    }
+
+    public function zipWithPhp(
+        string $source,
+        string $destination,
+        #[\SensitiveParameter] ?string $password = null,
+        CompressionMethod $compressionMethod = CompressionMethod::DEFLATE,
+        int $compressionLevel = 6,
+        bool $overwrite = false,
+    ): void {
+        $zip = new \ZipArchive();
+
+        if (true !== $zip->open($destination, \ZipArchive::CREATE | ($overwrite ? \ZipArchive::OVERWRITE : \ZipArchive::EXCL))) {
+            throw new \RuntimeException(\sprintf('Failed to open zip file for writing: %s. Error: %s', $destination, $zip->getStatusString()));
+        }
+
+        if (null !== $password) {
+            $zip->setPassword($password);
+        }
+
+        if (is_dir($source)) {
+            // For directories, we need to manually add each file
+            $baseDir = rtrim($source, '/\\');
+            $baseName = basename($baseDir);
+
+            $zip->addEmptyDir($baseName);
+
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($baseDir, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::LEAVES_ONLY
+            );
+
+            foreach ($iterator as $file) {
+                if (!$file->isDir()) {
+                    $filePath = $file->getRealPath();
+                    $relativePath = $baseName . '/' . substr($filePath, \strlen($baseDir) + 1);
+
+                    $zip->addFile($filePath, $relativePath);
+                }
+            }
+        } else {
+            $fileName = basename($source);
+            $zip->addFile($source, $fileName);
+        }
+
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $stat = $zip->statIndex($i);
+
+            if (false === $stat) {
+                throw new \RuntimeException(\sprintf('Failed to get stat for index "%d"', $i));
+            }
+
+            $fileName = $stat['name'];
+
+            // Skip compression and encryption for directories (names ending with '/')
+            // match zip binary behavior
+            if (str_ends_with($fileName, '/')) {
+                continue;
+            }
+
+            $zip->setCompressionName($fileName, $compressionMethod->toZipArchiveMethod(), $compressionLevel);
+
+            if (null !== $password) {
+                // Use AES-256 encryption for maximum security
+                $zip->setEncryptionName($fileName, \ZipArchive::EM_AES_256);
+            }
+        }
+
+        if (!$zip->close()) {
+            throw new \RuntimeException(\sprintf('Failed to close zip file for writing: %s. Error: %s', $destination, $zip->getStatusString()));
+        }
+    }
+
+    private function isZipBinaryAvailable(): bool
+    {
+        return 0 === $this->processRunner->exitCode(['which', 'zip'], context: new Context(quiet: true));
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -10,6 +10,7 @@ use Castor\Exception\MinimumVersionRequirementNotMetException;
 use Castor\Exception\ProblemException;
 use Castor\Exception\WaitFor\ExitedBeforeTimeoutException;
 use Castor\Exception\WaitFor\TimeoutReachedException;
+use Castor\Helper\CompressionMethod;
 use Castor\Helper\HasherHelper;
 use Castor\Helper\PathHelper;
 use Castor\Import\Mount;
@@ -936,6 +937,39 @@ function open(string ...$urls): void
     }
 
     parallel(...$parallelCallbacks);
+}
+
+function zip(
+    string $source,
+    string $destination,
+    #[\SensitiveParameter] ?string $password = null,
+    CompressionMethod $compressionMethod = CompressionMethod::DEFLATE,
+    int $compressionLevel = 6,
+    bool $overwrite = false,
+): void {
+    Container::get()->zipArchiver->zip($source, $destination, $password, $compressionMethod, $compressionLevel, $overwrite);
+}
+
+function zip_binary(
+    string $source,
+    string $destination,
+    #[\SensitiveParameter] ?string $password = null,
+    CompressionMethod $compressionMethod = CompressionMethod::DEFLATE,
+    int $compressionLevel = 6,
+    bool $overwrite = false,
+): void {
+    Container::get()->zipArchiver->zipWithBinary($source, $destination, $password, $compressionMethod, $compressionLevel, $overwrite);
+}
+
+function zip_php(
+    string $source,
+    string $destination,
+    #[\SensitiveParameter] ?string $password = null,
+    CompressionMethod $compressionMethod = CompressionMethod::DEFLATE,
+    int $compressionLevel = 6,
+    bool $overwrite = false,
+): void {
+    Container::get()->zipArchiver->zipWithPhp($source, $destination, $password, $compressionMethod, $compressionLevel, $overwrite);
 }
 
 /**

--- a/tests/Examples/ArchiveZipTest.php
+++ b/tests/Examples/ArchiveZipTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Castor\Tests\Examples;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+/**
+ * @test test
+ */
+class ArchiveZipTest extends TaskTestCase
+{
+    private const FIXTURES_DIR = __DIR__ . '/../../examples/fixtures/archive';
+    private const SAMPLE_FILE_PATH = self::FIXTURES_DIR . '/sample.txt';
+    private const SAMPLE_FILE_ZIP_PATH = self::FIXTURES_DIR . '/sample.zip';
+    private const SAMPLE_DIR_PATH = self::FIXTURES_DIR . '/sample_dir';
+    private const SAMPLE_DIR_ZIP_PATH = self::FIXTURES_DIR . '/sample_dir.zip';
+
+    private Filesystem $filesystem;
+    private string $sampleFileContent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->filesystem = new Filesystem();
+
+        // Use longer content to ensure zip binary actually applies compression.
+        // With very short content, zip may determine compression is unnecessary and leave the file uncompressed.
+        $this->sampleFileContent = str_repeat('This is a sample text file for testing zip functionality.', 20);
+
+        if (!$this->filesystem->exists(self::FIXTURES_DIR)) {
+            $this->filesystem->mkdir(self::FIXTURES_DIR);
+        }
+
+        $this->filesystem->dumpFile(self::SAMPLE_FILE_PATH, $this->sampleFileContent);
+
+        if (!$this->filesystem->exists(self::SAMPLE_DIR_PATH)) {
+            $this->filesystem->mkdir(self::SAMPLE_DIR_PATH);
+        }
+
+        $this->filesystem->dumpFile(self::SAMPLE_DIR_PATH . '/sample.txt', $this->sampleFileContent);
+
+        // Create a subdirectory with another text file to test recursivity
+        if (!$this->filesystem->exists(self::SAMPLE_DIR_PATH . '/subdir')) {
+            $this->filesystem->mkdir(self::SAMPLE_DIR_PATH . '/subdir');
+        }
+
+        $this->filesystem->dumpFile(self::SAMPLE_DIR_PATH . '/subdir/nested.txt', $this->sampleFileContent);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove([
+            self::SAMPLE_FILE_PATH,
+            self::SAMPLE_FILE_ZIP_PATH,
+            self::SAMPLE_DIR_PATH,
+            self::SAMPLE_DIR_ZIP_PATH,
+        ]);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider archiveTaskProvider
+     */
+    public function testArchiveTask(string $taskName): void
+    {
+        $process = $this->runTask([$taskName]);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertFileExists(self::SAMPLE_FILE_ZIP_PATH);
+        $this->assertFileExists(self::SAMPLE_DIR_ZIP_PATH);
+
+        $this->assertZipIsPasswordProtected(self::SAMPLE_FILE_ZIP_PATH, 'sample.txt');
+        $this->assertZipCompressionMethod(self::SAMPLE_FILE_ZIP_PATH);
+
+        $this->assertZipIsPasswordProtected(self::SAMPLE_DIR_ZIP_PATH, 'sample_dir/sample.txt');
+        $this->assertZipIsPasswordProtected(self::SAMPLE_DIR_ZIP_PATH, 'sample_dir/subdir/nested.txt');
+
+        $this->assertZipCompressionMethod(self::SAMPLE_DIR_ZIP_PATH);
+    }
+
+    public function archiveTaskProvider(): \Generator
+    {
+        yield 'archive:zip' => ['archive:zip'];
+        yield 'archive:zip-binary' => ['archive:zip-binary'];
+        yield 'archive:zip-php' => ['archive:zip-php'];
+    }
+
+    private function assertZipIsPasswordProtected(string $zipPath, string $filePath): void
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            $this->markTestSkipped('ZipArchive class not available');
+        }
+
+        $zip = new \ZipArchive();
+        $zip->open($zipPath);
+        $extracted = $zip->getFromName($filePath);
+        $this->assertFalse($extracted);
+
+        $zip->setPassword('secret');
+
+        $extracted = $zip->getFromName($filePath);
+        $this->assertSame($this->sampleFileContent, $extracted);
+
+        $zip->close();
+    }
+
+    private function assertZipCompressionMethod(string $zipPath): void
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            $this->markTestSkipped('ZipArchive class not available');
+        }
+
+        $zip = new \ZipArchive();
+        $zip->open($zipPath);
+        $zip->setPassword('secret');
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            ['comp_method' => $compressionMethod, 'name' => $filePath] = $zip->statIndex($i);
+
+            if (str_ends_with($filePath, '/')) {
+                $this->assertEquals(\ZipArchive::CM_STORE, $compressionMethod, \sprintf('Compression method is "%d" for directory "%s", should be "%d"', $compressionMethod, $filePath, \ZipArchive::CM_STORE));
+
+                continue;
+            }
+
+            $this->assertEquals(\ZipArchive::CM_BZIP2, $compressionMethod, \sprintf('Compression method is "%d" for file "%s", should be "%d"', $compressionMethod, $filePath, \ZipArchive::CM_BZIP2));
+        }
+
+        $zip->close();
+    }
+}

--- a/tests/Generated/FilesystemFindTest.php.output.txt
+++ b/tests/Generated/FilesystemFindTest.php.output.txt
@@ -1,1 +1,1 @@
-Number of PHP files: 35
+Number of PHP files: 36

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -4,6 +4,9 @@ help                                                              Display help f
 list                                                              List commands
 no-namespace                                                      Task without a namespace
 update                                                            Update all dependencies
+archive:zip                                                       Compress files into a zip archive using native binary or fallback to ZipArchive php class
+archive:zip-binary                                                Compress files into a zip archive using native binary
+archive:zip-php                                                   Compress files into a zip archive using ZipArchive php class
 args:another-args                                                 Dumps all arguments and options, without configuration
 args:args                                                         Dumps all arguments and options, with custom configuration
 args:autocomplete-argument                                        Provides autocomplete for an argument

--- a/tools/static/castor.php
+++ b/tools/static/castor.php
@@ -11,17 +11,17 @@ use function Castor\run;
 #[AsTask(description: 'Build static binary for Linux system')]
 function linux()
 {
-    run('bin/castor compile tools/phar/build/castor.linux-amd64.phar --os=linux --arch=x86_64 --binary-path=castor.linux-amd64 --php-extensions=mbstring,phar,posix,tokenizer,pcntl,curl,filter,openssl,sodium,ctype', timeout: 0);
+    run('bin/castor compile tools/phar/build/castor.linux-amd64.phar --os=linux --arch=x86_64 --binary-path=castor.linux-amd64 --php-extensions=mbstring,phar,posix,tokenizer,pcntl,curl,filter,openssl,sodium,ctype,zip,bz2', timeout: 0);
 }
 
 #[AsTask(description: 'Build static binary for MacOS (amd64) system')]
 function darwinAmd64()
 {
-    run('bin/castor compile tools/phar/build/castor.darwin-amd64.phar --os=macos --arch=x86_64 --binary-path=castor.darwin-amd64 --php-extensions=mbstring,phar,posix,tokenizer,pcntl,curl,filter,openssl,sodium,ctype', timeout: 0);
+    run('bin/castor compile tools/phar/build/castor.darwin-amd64.phar --os=macos --arch=x86_64 --binary-path=castor.darwin-amd64 --php-extensions=mbstring,phar,posix,tokenizer,pcntl,curl,filter,openssl,sodium,ctype,zip,bz2', timeout: 0);
 }
 
 #[AsTask(description: 'Build static binary for MacOS (arm64) system')]
 function darwinArm64()
 {
-    run('bin/castor compile tools/phar/build/castor.darwin-arm64.phar --os=macos --arch=aarch64 --binary-path=castor.darwin-arm64 --php-extensions=mbstring,phar,posix,tokenizer,pcntl,curl,filter,openssl,sodium,ctype', timeout: 0);
+    run('bin/castor compile tools/phar/build/castor.darwin-arm64.phar --os=macos --arch=aarch64 --binary-path=castor.darwin-arm64 --php-extensions=mbstring,phar,posix,tokenizer,pcntl,curl,filter,openssl,sodium,ctype,zip,bz2', timeout: 0);
 }


### PR DESCRIPTION
### Main features:
- Support for password-protected ZIP files  
- Different compression methods: `store`, `deflate`, `bzip2`, `zstd`  
- Compression level can be changed  
- Two ways to create ZIP files:
  - Using the system’s `zip` command (faster)
  - Using PHP’s `ZipArchive` class (fallback if no binary)  
- Automatic switch from binary to PHP if needed

### Public functions:
- `zip()`: Picks the best method available  
- `zip_binary()`: Always uses the system’s `zip` command  
- `zip_php()`: Always uses PHP’s `ZipArchive`  

### Notes from development:
- At first, I only wanted to expose `zip()`, but testing the fallback logic was hard. So I exposed the other two functions to make testing easier.
- I first used the word “Compression” in names, but I learned that compression and archiving are not the same. ZIP does both, so I chose the name `Archiver` to match what PHP uses.
- I worked hard to make sure both implementations (binary and PHP) give similar results.
- I chose not to overwrite by default to prevent data loss, same as encryption functions.
- This version supports the most common cases. Later, I would like to:
  - Add files to an existing ZIP  
  - Let users choose exactly which files to zip throught a callable (now you can only pass a single path that zip everything in it)

I thought this task would take one evening, but it took almost two full days 😅 I had a lot of back and forth.

### Next steps (if the design looks good):
- Add unzip support  
- Add support for `.tar` and `.gz` formats  
- Add compression-only functions
