### PR TITLE
chore(test): disable xdebug when generating tests

### DIFF
--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -234,6 +234,7 @@ function add_test(array $args, string $class, ?string $cwd = null, bool $needRem
             'CASTOR_NO_REMOTE' => $needRemote ? 0 : 1,
             'CASTOR_TEST' => 'true',
             'CASTOR_CACHE_DIR' => $_SERVER['CASTOR_CACHE_DIR'],
+            'XDEBUG_MODE' => 'off',
         ],
         input: $inputStream,
         timeout: null,


### PR DESCRIPTION
See https://github.com/jolicode/castor/pull/625

I test it without and with it, and it correctly disable xdebug when generating a test (without that i was having a different output for the test with composer)