### PR TITLE
feat(context): allow to pass an array for context

### DIFF
--- a/examples/env.php
+++ b/examples/env.php
@@ -4,13 +4,10 @@ namespace env;
 
 use Castor\Attribute\AsTask;
 
-use function Castor\context;
 use function Castor\run;
 
 #[AsTask(description: 'Display environment variables')]
 function env(): void
 {
-    run('echo \"$FOO\"', context: context()->withEnvironment([
-        'FOO' => 'toto',
-    ]));
+    run('echo \"$FOO\"', context: ['environment' => ['FOO' => 'toto']]);
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -7,6 +7,20 @@ use Castor\Helper\PathHelper;
 use Castor\VerbosityLevel as LegacyVerbosityLevel;
 use Symfony\Component\DependencyInjection\Attribute\Exclude;
 
+/**
+ * Context for running commands.
+ *
+ * @phpstan-type ContextArray array{
+ *   "environment"?: array<string, string>,
+ *   "workingDirectory"?: string,
+ *   "tty"?: bool,
+ *   "pty"?: bool,
+ *   "timeout"?: float,
+ *   "quiet"?: bool,
+ *   "allowFailure"?: bool,
+ *   "notify"?: bool,
+ * }
+ */
 #[Exclude]
 class Context implements \ArrayAccess
 {
@@ -56,6 +70,48 @@ class Context implements \ArrayAccess
             'verbosityLevel' => $this->verbosityLevel,
             'notificationTitle' => $this->notificationTitle,
         ];
+    }
+
+    /**
+     * @param ContextArray $contextData
+     */
+    public function with(array $contextData): self
+    {
+        $context = $this;
+
+        if (\array_key_exists('environment', $contextData)) {
+            $context = $context->withEnvironment($contextData['environment']);
+        }
+
+        if (\array_key_exists('workingDirectory', $contextData)) {
+            $context = $context->withWorkingDirectory($contextData['workingDirectory']);
+        }
+
+        if (\array_key_exists('tty', $contextData)) {
+            $context = $context->withTty($contextData['tty']);
+        }
+
+        if (\array_key_exists('pty', $contextData)) {
+            $context = $context->withPty($contextData['pty']);
+        }
+
+        if (\array_key_exists('timeout', $contextData)) {
+            $context = $context->withTimeout($contextData['timeout']);
+        }
+
+        if (\array_key_exists('quiet', $contextData)) {
+            $context = $context->withQuiet($contextData['quiet']);
+        }
+
+        if (\array_key_exists('allowFailure', $contextData)) {
+            $context = $context->withAllowFailure($contextData['allowFailure']);
+        }
+
+        if (\array_key_exists('notify', $contextData)) {
+            $context = $context->withNotify($contextData['notify']);
+        }
+
+        return $context;
     }
 
     /**

--- a/src/Runner/ProcessRunner.php
+++ b/src/Runner/ProcessRunner.php
@@ -22,7 +22,11 @@ use Symfony\Component\Process\Process;
 use function Castor\context;
 use function Symfony\Component\String\u;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @phpstan-import-type ContextArray from Context
+ */
 class ProcessRunner
 {
     public function __construct(
@@ -39,6 +43,7 @@ class ProcessRunner
      * @param string|array<string|\Stringable|int>|CommandBuilderInterface $command
      * @param array<string, string|\Stringable|int>|null                   $environment
      * @param (callable(string, string, Process) :void)|null               $callback
+     * @param Context|ContextArray|null                                    $context
      */
     public function run(
         string|array|CommandBuilderInterface $command,
@@ -51,9 +56,13 @@ class ProcessRunner
         ?bool $allowFailure = null,
         ?bool $notify = null,
         ?callable $callback = null,
-        ?Context $context = null,
+        Context|array|null $context = null,
     ): Process {
         $context ??= $this->contextRegistry->getCurrentContext();
+
+        if (\is_array($context)) {
+            $context = $this->contextRegistry->getCurrentContext()->with($context);
+        }
 
         if (null !== $environment) {
             trigger_deprecation('jolicode/castor', '0.18', 'The "environment" argument is deprecated, use the "Context" object instead.');

--- a/src/functions.php
+++ b/src/functions.php
@@ -49,6 +49,16 @@ function parallel(callable ...$callbacks): array
  * @param string|array<string|\Stringable|int>|CommandBuilderInterface $command
  * @param array<string, string|\Stringable|int>|null                   $environment
  * @param (callable(string, string, Process) :void)|null               $callback
+ * @param Context|array{
+ *    "environment"?: array<string, string>,
+ *    "workingDirectory"?: string,
+ *    "tty"?: bool,
+ *    "pty"?: bool,
+ *    "timeout"?: float,
+ *    "quiet"?: bool,
+ *    "allowFailure"?: bool,
+ *    "notify"?: bool,
+ *  }|null                                                              $context
  */
 function run(
     string|array|CommandBuilderInterface $command,
@@ -61,7 +71,7 @@ function run(
     ?bool $allowFailure = null,
     ?bool $notify = null,
     ?callable $callback = null,
-    ?Context $context = null,
+    Context|array|null $context = null,
     ?string $path = null,
 ): Process {
     if ($workingDirectory && $path) {


### PR DESCRIPTION
Not sure if it's better, but i know people prefer to have this, mainly this allow to pass an array for context which will allow to do the following : 

```php
run('command', context: [
  'pty' => true,
  'environment' => ['FOO' => 'BAR'],
  'tty' => false,
  'quiet' => true,
]);
```

This mainly "reallow" the deprecated way of passing those parameters in the run fonction without having to get the context (but avoid maintenance problem with context growing)