### PR TITLE
Renamed `Context::__debugInfo()` to `Context::getDebugInfo()`

### DIFF
--- a/src/Console/Command/DebugCommand.php
+++ b/src/Console/Command/DebugCommand.php
@@ -37,7 +37,7 @@ final class DebugCommand extends Command
             'Root directory' => $this->rootDir,
             'Cache directory' => $this->cacheDir,
             'Current context name' => $this->contextRegistry->getCurrentContext()->name,
-            'Current context data' => json_encode($this->contextRegistry->getCurrentContext()->__debugInfo(), \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES),
+            'Current context data' => json_encode($this->contextRegistry->getCurrentContext()->getDebugInfo(), \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES),
         ];
 
         $io->horizontalTable(array_keys($table), [array_values($table)]);

--- a/src/Context.php
+++ b/src/Context.php
@@ -40,7 +40,8 @@ class Context implements \ArrayAccess
         $this->workingDirectory = $workingDirectory ?? PathHelper::getRoot();
     }
 
-    public function __debugInfo()
+    // @phpstan-ignore missingType.iterableValue
+    public function getDebugInfo(): array
     {
         return [
             'name' => $this->name,


### PR DESCRIPTION
This prevents Symfony var dumper to dump twice the context
