### PR TITLE
fix(composer): fix raw token, fix self command for composer

### DIFF
--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -210,6 +210,8 @@ add_test(['unknown:task'], 'NoConfigUnknown', '/tmp');
 add_test([], 'NewProject', '/tmp');
 // remote special test
 add_test(['remote-import:remote-task-class'], 'RemoteImportClassWithVendorReset', needRemote: true, needResetVendor: true);
+// composer help test
+add_test(['composer', 'list', '--', '--help'], 'ComposerHelp');
 
 echo "\nDone.\n";
 

--- a/src/Console/Input/GetRawTokenTrait.php
+++ b/src/Console/Input/GetRawTokenTrait.php
@@ -28,6 +28,11 @@ trait GetRawTokenTrait
 
                 continue;
             }
+
+            if ($value === '--') {
+                continue;
+            }
+
             if ($keep) {
                 $parameters[] = $value;
             }

--- a/src/Import/Remote/Composer.php
+++ b/src/Import/Remote/Composer.php
@@ -160,9 +160,12 @@ class Composer
             $args[] = '--no-interaction';
         }
 
+        $self = $_SERVER['PHP_SELF'] ?? '';
+
         putenv('COMPOSER=' . $composerJsonFilePath);
         $_ENV['COMPOSER'] = $composerJsonFilePath;
         $_SERVER['COMPOSER'] = $composerJsonFilePath;
+        $_SERVER['PHP_SELF'] = $self . ' composer';
 
         if ($binDir) {
             putenv('COMPOSER_BIN_DIR=' . $binDir);
@@ -204,6 +207,8 @@ class Composer
         } finally {
             putenv('COMPOSER=');
             putenv('SHELL_VERBOSITY=');
+            $_SERVER['PHP_SELF'] = $self;
+
             unset($_ENV['COMPOSER'], $_SERVER['COMPOSER'], $_ENV['SHELL_VERBOSITY'], $_SERVER['SHELL_VERBOSITY']);
         }
 

--- a/tests/Generated/ComposerHelpTest.php
+++ b/tests/Generated/ComposerHelpTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class ComposerHelpTest extends TaskTestCase
+{
+    // composer
+    public function test(): void
+    {
+        $process = $this->runTask(['composer', 'list', '--', '--help']);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertSame('', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/ComposerHelpTest.php.output.txt
+++ b/tests/Generated/ComposerHelpTest.php.output.txt
@@ -1,0 +1,42 @@
+Description:
+  List commands
+
+Usage:
+  list [options] [--] [<namespace>]
+
+Arguments:
+  namespace                      The namespace name
+
+Options:
+      --raw                      To output raw command list
+      --format=FORMAT            The output format (txt, xml, json, or md) [default: "txt"]
+      --short                    To skip describing commands' arguments
+  -h, --help                     Display help for the given command. When no command is given display help for the list command
+      --silent                   Do not output any message
+  -q, --quiet                    Only errors are displayed. All other output is suppressed
+  -V, --version                  Display this application version
+      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction           Do not ask any interactive question
+      --profile                  Display timing and memory usage information
+      --no-plugins               Whether to disable plugins.
+      --no-scripts               Skips the execution of all scripts defined in composer.json file.
+  -d, --working-dir=WORKING-DIR  If specified, use the given directory as working directory.
+      --no-cache                 Prevent use of the cache
+  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+Help:
+  The list command lists all commands:
+
+    castor composer list
+
+  You can also display the commands for a specific namespace:
+
+    castor composer list test
+
+  You can also output the information in other formats by using the --format option:
+
+    castor composer list --format=xml
+
+  It's also possible to get raw list of commands (useful for embedding command runner):
+
+    castor composer list --raw

--- a/tests/Generated/RunExceptionVerboseTest.php.err.txt
+++ b/tests/Generated/RunExceptionVerboseTest.php.err.txt
@@ -28,7 +28,7 @@ Exception trace:
  Castor\Console\Application->doRunCommand() at .../vendor/symfony/console/Application.php:XXXX
  Symfony\Component\Console\Application->doRun() at .../src/Console/Application.php:XXXX
  Castor\Console\Application->doRun() at .../vendor/symfony/console/Application.php:XXXX
- Symfony\Component\Console\Application->run() at .../bin/castor:XXXX
+ Symfony\Component\Console\Application->run() at castor:XXXX
 
 run:exception [--repeat [REPEAT]]
 

--- a/tests/Helper/OutputCleaner.php
+++ b/tests/Helper/OutputCleaner.php
@@ -56,6 +56,12 @@ final class OutputCleaner
         // castor version
         $string = preg_replace('{you are using v\d+.\d+.\d+.}m', 'you are using vX.Y.Z.', $string);
 
+        // binary
+        $string = str_replace('tests/../', '', $string);
+        $string = str_replace('.../bin/castor', 'castor', $string);
+        $string = str_replace('.../castor', 'castor', $string);
+        $string = preg_replace('#\S+?tools/phar/build/castor\S*#', 'castor', $string);
+
         return preg_replace('{castor v\d+.\d+.\d+}m', 'castor v.X.Y.Z', $string);
     }
 }


### PR DESCRIPTION
Fix https://github.com/jolicode/castor/issues/664

This allow to use "--" with get raw tokens to avoid options to be used in first command.

It also modify the "PHP_SELF" env var for composer to display correct help command in sub command