### PR TITLE
Allow to set `memory_limit` dynamically via `CASTOR_MEMORY_LIMIT` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add `iconv` extension to the static binary
 * Support having `--` option with raw tokens which avoid interpretation of the next arguments
+* Allow to set `memory_limit` dynamically via `CASTOR_MEMORY_LIMIT` environment variable
 
 ## 0.25.0 (2025-07-11)
 

--- a/bin/castor
+++ b/bin/castor
@@ -4,15 +4,13 @@
 use Castor\Console\Application;
 use Castor\Console\ApplicationFactory;
 
+$memoryLimit = $_SERVER['CASTOR_MEMORY_LIMIT'] ?? false;
+if ($memoryLimit && function_exists('ini_set')) {
+    ini_set('memory_limit', $memoryLimit);
+}
+
 $phpFile = $_SERVER['CASTOR_PHP_REPLACE'] ?? false;
-
 if ($phpFile) {
-    $memoryLimit = $_SERVER['CASTOR_MEMORY_LIMIT'] ?? false;
-
-    if ($memoryLimit && function_exists('ini_set')) {
-        ini_set('memory_limit', $memoryLimit);
-    }
-
     require $phpFile;
 
     exit(0);

--- a/doc/getting-started/remote.md
+++ b/doc/getting-started/remote.md
@@ -42,3 +42,16 @@ phpstan with extensions, you can do this by running the following command:
 ```bash
 castor execute --deps phpstan/phpstan-symfony phpstan/phpstan
 ```
+
+## More memory
+
+If the script requires more memory than the default provided by PHP or castor static binary,
+you can use the `CASTOR_MEMORY_LIMIT` environment variable to increase the memory limit within the
+context:
+
+```bash
+CASTOR_MEMORY_LIMIT=512M castor execute friendsofphp/php-cs-fixer fix
+```
+
+`CASTOR_MEMORY_LIMIT` supports the same values as the [`memory_limit` directive
+in PHP](https://www.php.net/manual/en/ini.core.php#ini.memory-limit).

--- a/doc/going-further/helpers/run-php.md
+++ b/doc/going-further/helpers/run-php.md
@@ -1,9 +1,9 @@
-# Executing a phar file
+# Executing a PHP script
 
 ## The `run_php()` function
 
-The `run_php()` function provides a way to execute a php or phar file in all scenarios,
-whether castor is executed as a phar, as a static binary, or as a script.
+The `run_php()` function provides a way to execute a PHP or phar file in all scenarios,
+whether castor is executed as a phar, as a static binary, or as a script:
 
 ```php
 #[AsTask()]
@@ -22,8 +22,8 @@ The `run_php()` takes exactly the same options as the `run()` function.
 ### Script requiring more memory
 
 If you need to execute a script that requires more memory than the default
-provided by PHP or castor static binary, you can use the `CASTOR_MEMORY_LIMIT` 
-environment variable to increase the memory limit within the context: 
+provided by PHP or castor static binary, you can use the `CASTOR_MEMORY_LIMIT`
+environment variable to increase the memory limit within the context:
 
 ```php
 #[AsTask()]
@@ -33,4 +33,5 @@ function exec_something()
 }
 ```
 
-`CASTOR_MEMORY_LIMIT` supports the same values as the [`memory_limit` directive in PHP](https://www.php.net/manual/fr/ini.core.php#ini.memory-limit).
+`CASTOR_MEMORY_LIMIT` supports the same values as the [`memory_limit` directive
+in PHP](https://www.php.net/manual/en/ini.core.php#ini.memory-limit).

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -94,5 +94,9 @@ Castor supports the following environment variables:
 - [`CASTOR_CACHE_DIR`](going-further/helpers/cache.md#cache-location-on-the-filesystem)
 - [`CASTOR_CONTEXT`](getting-started/context.md#setting-a-default-context)
 - [`CASTOR_GENERATE_STUBS`](installation.md#stubs)
+- [`CASTOR_MEMORY_LIMIT`](going-further/helpers/run-php.md#script-requiring-more-memory)
+  in context of running PHP script, and
+  [`CASTOR_MEMORY_LIMIT`](getting-started/remote.md#more-memory) in context of
+  remote execution
 - [`CASTOR_NO_REMOTE`](going-further/extending-castor/remote-imports.md#preventing-remote-imports)
 - [`CASTOR_USE_SECTION`](going-further/helpers/console-and-io.md#experimental-section-output)

--- a/src/Console/Input/GetRawTokenTrait.php
+++ b/src/Console/Input/GetRawTokenTrait.php
@@ -29,7 +29,7 @@ trait GetRawTokenTrait
                 continue;
             }
 
-            if ($value === '--') {
+            if ('--' === $value) {
                 continue;
             }
 


### PR DESCRIPTION
fix #662
