### PR TITLE
Do not use 💩 in namespace

### DIFF
--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -12,7 +12,7 @@ use Castor\Container;
 use Castor\Helper\PathHelper;
 use Castor\Helper\PlatformHelper;
 use Castor\Monolog\Processor\ProcessProcessor;
-use Castor\💩\FixLazyServicePass;
+use Castor\👾\FixLazyServicePass;
 use Joli\JoliNotif\DefaultNotifier;
 use Monolog\Logger;
 use Psr\Cache\CacheItemPoolInterface;

--- a/src/👾/FixLazyServicePass.php
+++ b/src/👾/FixLazyServicePass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Castor\💩;
+namespace Castor\👾;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;


### PR DESCRIPTION
does not work well on macos
