### PR TITLE
Upgrade supported version of SPC > 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Internal
 
 * Update all PHP vendor
+* Upgrade supported version of SPC > 2.5.0
 
 ## 0.27.0 (2025-09-02)
 

--- a/src/Console/Command/CompileCommand.php
+++ b/src/Console/Command/CompileCommand.php
@@ -19,8 +19,8 @@ class CompileCommand extends Command
 {
     // When something **important** related to the compilation changed, increase
     // this version to invalide the cache
-    private const CACHE_VERSION = '2';
-    private const DEFAULT_SPC_VERSION = '2.3.5';
+    private const CACHE_VERSION = '3';
+    private const DEFAULT_SPC_VERSION = '2.7.4';
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
@@ -87,8 +87,7 @@ class CompileCommand extends Command
             $this->buildPHP(
                 $spcBinaryPath,
                 $phpExtensions,
-                $os = $input->getOption('os'),
-                ('macos' === $os && 'aarch64' === $arch) ? 'arm64' : $arch,
+                $os,
                 $spcBinaryDir,
                 $io,
                 $output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG,
@@ -190,13 +189,12 @@ class CompileCommand extends Command
         $downloadProcess->mustRun(fn ($type, $buffer) => print $buffer);
     }
 
-    private function buildPHP(string $spcBinaryPath, mixed $phpExtensions, mixed $os, mixed $arch, string $spcBinaryDir, SymfonyStyle $io, bool $debug = false): void
+    private function buildPHP(string $spcBinaryPath, mixed $phpExtensions, mixed $os, string $spcBinaryDir, SymfonyStyle $io, bool $debug = false): void
     {
         $command = [
             $spcBinaryPath, 'build', $phpExtensions,
             '--build-micro',
             '--with-micro-fake-cli',
-            '--arch=' . $arch,
         ];
 
         if ($debug) {


### PR DESCRIPTION
Here I take the shortcut to deprecate old SPC version (it may be a BC break if someone use the cli option with --spc-version < `2.5.0` ) so if we don't wan't to increase a major semver version I can update to support both with a version check ?

Fix #687 