### PR TITLE
Try MacOS 14 for the build step of MacOS static binary

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -126,7 +126,7 @@ jobs:
   static-darwin-amd64:
     needs: phars
     name: Create MacOs amd64 static binary and upload
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Internal
 
 * Upgrade supported version of SPC > 2.5.0
+* Upgrade GitHub action runner to MacOS 14
 
 ## 0.28.0 (2025-09-24)
 


### PR DESCRIPTION
Trying to avoid this:

<img width="1828" height="525" alt="image" src="https://github.com/user-attachments/assets/e8ceff4f-08c7-4324-8040-1bfd0b4e90b5" />
