### PR TITLE
feat(init): do not ask confirmation when using 'castor init'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * Allow to specify directory where to output repacked phar
+* Do not ask confirmation when explicitly using `castor init` command
 
 ### Internal
 

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -209,7 +209,6 @@ add_test(['symfony:greet', 'World', '--french', 'COUCOU', '--punctuation', '!'],
 add_test(['symfony:hello'], 'SymfonyHello', skipOnBinary: true);
 // In /tmp
 add_test(['completion', 'bash'], 'NoConfigCompletion', '/tmp');
-add_test(['init'], 'NewProjectInit', '/tmp');
 add_test(['unknown:task', 'toto', '--foo', 1], 'NoConfigUnknownWithArgs', '/tmp');
 add_test(['unknown:task'], 'NoConfigUnknown', '/tmp');
 add_test([], 'NewProject', '/tmp');

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -20,7 +20,8 @@ class InitCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        if (!$io->confirm('Do you want to initialize current directory with castor?', false)) {
+        // Only ask for confirmation if not running "castor init" explicitly
+        if ($this->getName() !== $input->getFirstArgument() && !$io->confirm('Do you want to initialize current directory with castor?', false)) {
             $io->note('Doing nothing.');
 
             return Command::SUCCESS;

--- a/tests/Examples/NewProjectInitTest.php
+++ b/tests/Examples/NewProjectInitTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Castor\Tests\Generated;
+namespace Castor\Tests\Examples;
 
 use Castor\Tests\TaskTestCase;
 use Symfony\Component\Process\Exception\ProcessFailedException;
@@ -10,7 +10,15 @@ class NewProjectInitTest extends TaskTestCase
     // init
     public function test(): void
     {
-        $process = $this->runTask(['init'], '/tmp');
+        $tmpDirectory = tempnam(sys_get_temp_dir(),'');
+
+        if (file_exists($tmpDirectory)) {
+            unlink($tmpDirectory);
+        }
+
+        mkdir($tmpDirectory);
+
+        $process = $this->runTask(['init'], $tmpDirectory);
 
         if (0 !== $process->getExitCode()) {
             throw new ProcessFailedException($process);

--- a/tests/Examples/NewProjectInitTest.php.output.txt
+++ b/tests/Examples/NewProjectInitTest.php.output.txt
@@ -1,0 +1,4 @@
+ [OK] Project created. You can edit "castor.php" and write your own tasks.
+
+ ! [NOTE] Run "castor" to see the available tasks.
+

--- a/tests/Generated/NewProjectInitTest.php.output.txt
+++ b/tests/Generated/NewProjectInitTest.php.output.txt
@@ -1,5 +1,0 @@
- Do you want to initialize current directory with castor? (yes/no) [no]:
- >
-
- ! [NOTE] Doing nothing.
-


### PR DESCRIPTION
Ref https://github.com/jolicode/castor/issues/699

The point behind this is when an user write `castor init` his intent is clear, there is no need for confirmation.

However it needs a confirmation when he only write `castor` because maybe in this case this is an error and the user wanted to do something else