### PR TITLE
Fix typos in remote.md documentation

### DIFF
--- a/doc/getting-started/remote.md
+++ b/doc/getting-started/remote.md
@@ -1,7 +1,7 @@
 # Remote execution
 
 Castor allows you to run any php package without installing it on your machine or
-adding them to your dependencies. This is done by using the `castor execute` command
+adding them to your dependencies. This is done by using the `castor execute` command.
 
 As an example, let's say you want to run the `friendsofphp/php-cs-fixer` package
 to fix your code style. You can do this by running the following command:


### PR DESCRIPTION
withing is a typo, but not sure if this is the best alternative.