### PR TITLE
Fix command return value and import statement

### DIFF
--- a/doc/going-further/interacting-with-castor/symfony-task.md
+++ b/doc/going-further/interacting-with-castor/symfony-task.md
@@ -11,10 +11,13 @@ command class.
 >  on your vendor directory - unless you installed Castor with Composer).
 
 ```php
+<?php
+
+namespace App\Command;
 
 use Castor\Attribute\AsSymfonyTask;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Commhearand\Command;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -26,7 +29,7 @@ class HelloCommand extends Command
     {
         $output->writeln('Hello');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }
 ```


### PR DESCRIPTION
Even fixing the use statement and adding the namespace, this command works in Symfony but it's not getting picked up in castor.

I've also tried adding originalName: per the docs, but that didn't help.  

This PR is more about the documentation, I can also submit an issue if necessary.