### PR TITLE
Speedup CI by fixing cache for binary builds

### DIFF
--- a/.github/actions/static/action.yaml
+++ b/.github/actions/static/action.yaml
@@ -5,7 +5,6 @@ inputs:
   os:
     description: 'The operating system to build for'
     required: true
-    default: 'linux-amd64'
 
 runs:
   using: "composite"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,11 @@ jobs:
         with:
           target: 'test'
 
+      - uses: ./.github/actions/cache
+        with:
+          target: 'linux-amd64'
+        if: matrix.castor.method == 'static'
+
       - name: Build Castor phar for Linux
         run: bin/castor castor:phar:linux
         if: matrix.castor.method == 'phar' || matrix.castor.method == 'static'
@@ -134,8 +139,10 @@ jobs:
           composer-flags: "--no-dev"
       - uses: ./.github/actions/cache
         with:
-          target: 'test'
+          target: 'linux-amd64'
       - uses: ./.github/actions/phar
       - uses: ./.github/actions/static
+        with:
+          os: 'linux-amd64'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Compile steps are back to almost instant on `PHPUnit on 8.2 / Castor from static` and `Ensure artifacts are OK` jobs 