### PR TITLE
fix(composer): use COMPOSER_VENDOR_DIR instead of working directory, to use correct relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix infinite loop when executing `castor` with `castor execute jolicode/castor@castor`
 * Fix `--castor-file` option parsing
 * Fix the update instructions when using static binaries
+* Fix remote composer working directory, forcing relative paths to have "../" prefix
 
 ### Internal
 

--- a/castor.composer.json
+++ b/castor.composer.json
@@ -28,5 +28,10 @@
                 }
             }
         }
-    ]
+    ],
+    "autoload": {
+        "files": [
+            "tests\/autoload\/loadme.php"
+        ]
+    }
 }

--- a/examples/advanced/remote_import/remote_tasks.php
+++ b/examples/advanced/remote_import/remote_tasks.php
@@ -5,6 +5,7 @@ namespace remote_import;
 use Castor\Attribute\AsTask;
 
 use function Castor\import;
+use function Castor\Tests\autoload\loadme;
 
 // Importing tasks from a Composer package
 import('composer://pyrech/castor-example');
@@ -19,4 +20,10 @@ function remote_tasks(): void
 {
     \pyrech\helloExample(); // from composer://pyrech/castor-example
     \pyrech\foobar(); // from package://pyrech/foobar
+}
+
+#[AsTask(description: 'Can invoke autoloaded files from castor.composer.json')]
+function autoload(): void
+{
+    loadme();
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ parameters:
         - src
         - examples
         - tools/phpstan/src
+        - tests/autoload/loadme.php
     tmpDir: 'var/phpstan/tmp'
     inferPrivatePropertyTypeFromConstructor: true
     excludePaths:

--- a/src/Import/Remote/Composer.php
+++ b/src/Import/Remote/Composer.php
@@ -153,9 +153,6 @@ class Composer
     {
         $this->filesystem->mkdir($vendorDirectory);
 
-        $args[] = '--working-dir';
-        $args[] = \dirname($vendorDirectory);
-
         if (!$interactive) {
             $args[] = '--no-interaction';
         }
@@ -165,6 +162,9 @@ class Composer
         putenv('COMPOSER=' . $composerJsonFilePath);
         $_ENV['COMPOSER'] = $composerJsonFilePath;
         $_SERVER['COMPOSER'] = $composerJsonFilePath;
+        putenv('COMPOSER_VENDOR_DIR=' . $vendorDirectory);
+        $_ENV['COMPOSER_VENDOR_DIR'] = $vendorDirectory;
+        $_SERVER['COMPOSER_VENDOR_DIR'] = $vendorDirectory;
         $_SERVER['PHP_SELF'] = $self . ' composer';
 
         if ($binDir) {
@@ -206,9 +206,10 @@ class Composer
             $exitCode = $composerApplication->run($argvInput, $output);
         } finally {
             putenv('COMPOSER=');
+            putenv("COMPOSER_VENDOR_DIR=");
             $_SERVER['PHP_SELF'] = $self;
 
-            unset($_ENV['COMPOSER'], $_SERVER['COMPOSER']);
+            unset($_ENV['COMPOSER'], $_SERVER['COMPOSER'], $_ENV['COMPOSER_VENDOR_DIR'], $_SERVER['COMPOSER_VENDOR_DIR']);
         }
 
         if ($binDir) {

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -84,6 +84,7 @@ qa:cs:update                                             Update dependencies
 qa:phpstan:install                                       install dependencies
 qa:phpstan:phpstan                                       Run PHPStan
 qa:phpstan:update                                        update dependencies
+remote-import:autoload                                   Can invoke autoloaded files from castor.composer.json
 remote-import:import-class                               Use a class that extends a class imported from a remote package
 remote-import:remote-tasks                               Use functions imported from remote packages
 run:allow-failure                                        A failing task authorized to fail

--- a/tests/Generated/RemoteImportAutoloadTest.php
+++ b/tests/Generated/RemoteImportAutoloadTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class RemoteImportAutoloadTest extends TaskTestCase
+{
+    // remote-import:autoload
+    public function test(): void
+    {
+        $process = $this->runTask(['remote-import:autoload']);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFile(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertSame('', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/RemoteImportAutoloadTest.php.output.txt
+++ b/tests/Generated/RemoteImportAutoloadTest.php.output.txt
@@ -1,0 +1,1 @@
+autoload/loadme.php loaded

--- a/tests/autoload/loadme.php
+++ b/tests/autoload/loadme.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Castor\Tests\autoload;
+
+function loadme(): void
+{
+    echo "autoload/loadme.php loaded\n";
+}


### PR DESCRIPTION
Before this change all relative path in `castor.composer.json` would need to have "../" to be working.

It may be a BC break if people are using "../" not sure what to do for that since it will be hard to test for all possibilities