### PR TITLE
Better update instructions with the installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Use correct working directory when using the `castor execute` command.
 * Fix infinite loop when executing `castor` with `castor execute jolicode/castor@castor`
 * Fix `--castor-file` option parsing
+* Fix the update instructions when using static binaries
 
 ### Internal
 
@@ -21,6 +22,10 @@
 * Update all PHP vendor
 * Upgrade SPC version to v2.7.5
 * Use a `PhpRunner` service instead of static functions to run PHP files
+
+### Documentation
+
+* Rework the installation methods documentation
 
 ## 1.0.0 (2025-10-10)
 

--- a/installer/bash-installer
+++ b/installer/bash-installer
@@ -179,7 +179,7 @@ download_url=$CASTOR_DOWNLOAD_URL_PATTERN
 download_url=${download_url/~platform~/${platform}}
 download_url=${download_url/~versionPath~/${versionPath}}
 
-output "  Downloading ${download_url}...";
+output "  Downloading ${download_url}.";
 case $downloader in
     "curl")
         http_code=$(curl -s -o "${CASTOR_TMPDIR}/${CASTOR_TMP_NAME}" -w "%{http_code}" --location "${download_url}")
@@ -207,20 +207,20 @@ if [ ! -d "${binary_dest}" ]; then
 fi
 
 if [ "${custom_dir}" == "true" ]; then
-    output "  Installing the phar into ${binary_dest} ..."
+    output "  Installing castor into ${binary_dest}."
 else
-    output "  Installing the phar into your home directory..."
+    output "  Installing castor into your home directory."
 fi
 
 if mv "${CASTOR_TMPDIR}/${CASTOR_TMP_NAME}" "${binary_dest}/${CASTOR_EXECUTABLE}"; then
-    output "  The phar was saved to: ${binary_dest}/${CASTOR_EXECUTABLE}"
+    output "  Castor executable was moved to: ${binary_dest}/${CASTOR_EXECUTABLE}."
 else
-    output "  Failed to move the phar to ${binary_dest}." "error"
+    output "  Failed to move the executable to ${binary_dest}." "error"
     rm "${CASTOR_TMPDIR}/${CASTOR_EXECUTABLE}"
     exit 1
 fi
 
-output "  Fixing the phar permissions."
+output "  Fixing the executable permissions."
 chmod u+x "${binary_dest}/${CASTOR_EXECUTABLE}"
 
 output "\n🦫  $("${binary_dest}/${CASTOR_EXECUTABLE}" --version) was installed successfully!" "success"

--- a/src/Console/Command/CompileCommand.php
+++ b/src/Console/Command/CompileCommand.php
@@ -224,6 +224,7 @@ class CompileCommand extends Command
             $spcBinaryPath,
             'micro:combine', $pharFilePath,
             '--output=' . $appBinaryFilePath,
+            '--with-ini-set', 'castor.static=1',
         ];
         if ($iniFile) {
             if (!file_exists($iniFile)) {

--- a/src/Helper/Architecture.php
+++ b/src/Helper/Architecture.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Castor\Helper;
+
+enum Architecture: string
+{
+    case Amd64 = 'amd64';
+    case Arm64 = 'arm64';
+}

--- a/src/Helper/PlatformHelper.php
+++ b/src/Helper/PlatformHelper.php
@@ -28,6 +28,14 @@ final class PlatformHelper
         return getenv($name);
     }
 
+    public static function getArchitecture(): Architecture
+    {
+        return match (php_uname('m')) {
+            'arm64' => Architecture::Arm64,
+            default => Architecture::Amd64,
+        };
+    }
+
     public static function getDefaultCacheDirectory(): string
     {
         try {

--- a/src/Runner/WatchRunner.php
+++ b/src/Runner/WatchRunner.php
@@ -5,6 +5,8 @@ namespace Castor\Runner;
 use Castor\Console\Output\SectionOutput;
 use Castor\Context;
 use Castor\ContextRegistry;
+use Castor\Helper\Architecture;
+use Castor\Helper\PlatformHelper;
 use JoliCode\PhpOsHelper\OsHelper;
 use Symfony\Component\Process\Process;
 
@@ -39,15 +41,17 @@ final readonly class WatchRunner
             return;
         }
 
+        $architecture = PlatformHelper::getArchitecture();
+
         $binary = match (true) {
-            OsHelper::isMacOS() => match (php_uname('m')) {
-                'arm64' => 'watcher-darwin-arm64',
-                default => 'watcher-darwin-amd64',
+            OsHelper::isMacOS() => match ($architecture) {
+                Architecture::Arm64 => 'watcher-darwin-arm64',
+                Architecture::Amd64 => 'watcher-darwin-amd64',
             },
             OsHelper::isWindows() => 'watcher-windows.exe',
-            default => match (php_uname('m')) {
-                'arm64' => 'watcher-linux-arm64',
-                default => 'watcher-linux-amd64',
+            default => match ($architecture) {
+                Architecture::Arm64 => 'watcher-darwin-arm64',
+                Architecture::Amd64 => 'watcher-linux-amd64',
             },
         };
 


### PR DESCRIPTION
When using the static binary, update instructions will now suggest the "--static" option of the installer.