### PR TITLE
fix(stubs): do not generate stub if no castor file, also check for completion command name

### DIFF
--- a/src/Listener/GenerateStubsListener.php
+++ b/src/Listener/GenerateStubsListener.php
@@ -16,6 +16,7 @@ class GenerateStubsListener
         private readonly bool $repacked,
         #[Autowire('%generate_stubs%')]
         private readonly bool $generateStubs,
+        private readonly bool $hasCastorFile,
     ) {
     }
 
@@ -32,11 +33,15 @@ class GenerateStubsListener
             return;
         }
 
+        if (!$this->hasCastorFile) {
+            return;
+        }
+
         $command = $event->getCommand();
         if (!$command) {
             return;
         }
-        if ('_complete' === $command->getName()) {
+        if ('_complete' === $command->getName() || 'completion' === $command->getName()) {
             return;
         }
 


### PR DESCRIPTION
Actually the stub is generated everytime i launch a terminal (because the command name is completion not _complete, not sure why it has change ?

I also think that we should not generate stubs when we don't are in path where there are no castor file.

It avoid generating a stub on execute / missplaced command execution