### PR TITLE
Fix installer to workaround over wrong update instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released yet
 
+### Fixes
+
+* Fix installer to better handle invalid --install-dir option
+
 ## 1.3.0 (2026-03-06)
 
 ### Features
@@ -21,7 +25,7 @@
 * Add a `terminal()` function to get terminal properties
 * Add a `#[AsArgsAfterOptionEnd]` attribute to get all arguments after `--` delimiter
 
-### Fixed
+### Fixes
 
 * Do not generate stub if no castor file, also check for completion command name
 

--- a/installer/bash-installer
+++ b/installer/bash-installer
@@ -201,7 +201,21 @@ if [ $http_code != 200 ]; then
 fi
 
 if [ ! -d "${binary_dest}" ]; then
+    # Backward-compatible quick fix: if --install-dir points to the castor binary path,
+    # install into its parent directory.
+    # There was a bug fixed in https://github.com/jolicode/castor/pull/786
+    if [ "$(basename "${binary_dest}")" = "${CASTOR_EXECUTABLE}" ]; then
+        binary_dest="$(dirname "${binary_dest}")"
+    fi
+fi
+
+if [ ! -d "${binary_dest}" ]; then
     if ! mkdir -p "${binary_dest}"; then
+        if [ "${custom_dir}" = "true" ]; then
+            output "[castor-installer] Error: invalid value for --install-dir: '${binary_dest}'. Expected a directory, or a full path ending with '/${CASTOR_EXECUTABLE}'." "error"
+            exit 1
+        fi
+
         binary_dest="."
     fi
 fi


### PR DESCRIPTION
Follow up of #786
Fix #796 

With an `--install-dir` matching an executable named `castor` :

<img width="1037" height="307" alt="image" src="https://github.com/user-attachments/assets/23579978-639c-454f-bbe7-1472bc1ece7b" />


With a wrong `--install-dir` matching a file existing :

<img width="1039" height="266" alt="image" src="https://github.com/user-attachments/assets/66154544-38fd-4236-b8ea-fc87711547e0" />


