### PR TITLE
Add input option to Context for passing data to process stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * Add `directory` and `filter` parameters to `#[AsPathArgument]` and `#[AsPathOption]` attributes to improve autocomplete
+* Add `input` option to Context to pass data to process stdin (useful for sensitive data like passwords)
 
 ### Fixes
 

--- a/doc/docs/getting-started/run.md
+++ b/doc/docs/getting-started/run.md
@@ -96,3 +96,16 @@ the process:
 ```php
 {% include "/examples/basic/run/pty.php" start="<?php\n\nnamespace run;\n\n" %}
 ```
+
+## Providing input to a process
+
+You can provide input to a process via stdin using the `input` option on the
+context. This is useful for commands that require input but you don't want to
+expose sensitive data (like passwords) in command line arguments:
+
+```php
+{% include "/examples/basic/run/input.php" start="<?php\n\nnamespace run;\n\n" %}
+```
+
+The `input` option accepts a string, a `\Stringable`, a resource, or an
+`\Iterator<string>`.

--- a/examples/basic/run/input.php
+++ b/examples/basic/run/input.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace run;
+
+use Castor\Attribute\AsTask;
+
+use function Castor\context;
+use function Castor\io;
+use function Castor\run;
+
+#[AsTask(description: 'Run a sub-process with stdin input')]
+function run_with_input(): void
+{
+    $result = run(
+        ['cat'],
+        context: context()->withInput("Hello from stdin!\n"),
+    );
+    io()->writeln('Output: ' . $result->getOutput());
+}

--- a/src/Context.php
+++ b/src/Context.php
@@ -12,8 +12,9 @@ class Context implements \ArrayAccess
     public readonly string $workingDirectory;
 
     /**
-     * @param array<string, string|\Stringable|int> $environment      A list of environment variables to add to the task
-     * @param string[]                              $verboseArguments A list of arguments to pass to the command to enable verbose output
+     * @param array<string, string|\Stringable|int>              $environment      A list of environment variables to add to the task
+     * @param string[]                                           $verboseArguments A list of arguments to pass to the command to enable verbose output
+     * @param string|\Stringable|resource|\Iterator<string>|null $input            The input to send to the process stdin
      *
      * @phpstan-param ContextData $data The input parameter accepts an array or an Object
      */
@@ -35,6 +36,7 @@ class Context implements \ArrayAccess
         public readonly string $name = '',
         public readonly string $notificationTitle = '',
         public readonly array $verboseArguments = [],
+        public readonly mixed $input = null,
     ) {
         $this->workingDirectory = $workingDirectory ?? PathHelper::getRoot(false);
     }
@@ -91,6 +93,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -111,6 +114,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -130,6 +134,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -149,6 +154,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -168,6 +174,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -187,6 +194,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -206,6 +214,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -225,6 +234,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -244,6 +254,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -263,6 +274,7 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -286,6 +298,7 @@ class Context implements \ArrayAccess
             $name,
             $this->notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -305,6 +318,7 @@ class Context implements \ArrayAccess
             $this->name,
             $notificationTitle,
             $this->verboseArguments,
+            $this->input,
         );
     }
 
@@ -325,6 +339,28 @@ class Context implements \ArrayAccess
             $this->name,
             $this->notificationTitle,
             $arguments,
+            $this->input,
+        );
+    }
+
+    /** @param string|\Stringable|resource|\Iterator<string>|null $input */
+    public function withInput(mixed $input): self
+    {
+        return new self(
+            $this->data,
+            $this->environment,
+            $this->workingDirectory,
+            $this->tty,
+            $this->pty,
+            $this->timeout,
+            $this->quiet,
+            $this->allowFailure,
+            $this->notify,
+            $this->verbosityLevel,
+            $this->name,
+            $this->notificationTitle,
+            $this->verboseArguments,
+            $input,
         );
     }
 

--- a/src/Runner/ProcessRunner.php
+++ b/src/Runner/ProcessRunner.php
@@ -76,8 +76,11 @@ class ProcessRunner
             ;
         }
 
-        // TTY does not work on windows, and PTY is a mess, so let's skip everything!
-        if (!OsHelper::isWindows()) {
+        // When input is provided, we need to disable TTY and PTY because they require interactive terminal
+        if (null !== $context->input) {
+            $process->setInput($context->input);
+        } elseif (!OsHelper::isWindows()) {
+            // TTY does not work on windows, and PTY is a mess, so let's skip everything!
             if ($context->tty) {
                 $process->setTty(true);
                 $process->setInput(\STDIN);

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -115,6 +115,7 @@ run:process-helper                                       Run a sub-process and d
 run:pty                                                  Run a command with PTY disabled
 run:quiet                                                Executes something but does not output anything
 run:run                                                  Run a sub-process
+run:run-with-input                                       Run a sub-process with stdin input
 run:tty                                                  Run a command with TTY enabled
 run:variables                                            Run a sub-process with environment variables and display information about it
 run:verbose-arguments                                    A failing task that will suggest to re-run with verbose arguments

--- a/tests/Generated/RunRunWithInputTest.php
+++ b/tests/Generated/RunRunWithInputTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class RunRunWithInputTest extends TaskTestCase
+{
+    // run:run-with-input
+    public function test(): void
+    {
+        $process = $this->runTask(['run:run-with-input']);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFileWithCleaning(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertSame('', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/RunRunWithInputTest.php.output.txt
+++ b/tests/Generated/RunRunWithInputTest.php.output.txt
@@ -1,0 +1,3 @@
+Hello from stdin!
+Output: Hello from stdin!
+


### PR DESCRIPTION
Closes #627

## Description

This PR adds an `input` option to the `Context` class, allowing users to pass data to a process via stdin. This is useful for commands that require sensitive input (like passwords) without exposing them in command line arguments.

## Usage

```php
use function Castor\context;
use function Castor\run;

// Pass sensitive data via stdin instead of command arguments
run(
    ['zip', '-e', 'archive.zip', 'files/'],
    context: context()->withInput("mypassword\nmypassword\n"),
);
```

## Changes

- Add `input` property to `Context` class
- Add `withInput()` method to `Context` class
- Update `ProcessRunner::run()` to use the input when provided
- Add example and documentation