### PR TITLE
Detect interactive environment on Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add `directory` and `filter` parameters to `#[AsPathArgument]` and `#[AsPathOption]` attributes to improve autocomplete
 * Add `input` option to Context to pass data to process stdin (useful for sensitive data like passwords)
+* Add `Context::supportsInteraction()` / `Context::withSupportsInteraction()` to expose whether the surrounding environment supports interactive commands (auto-detected from `CI` env var and STDIN being a TTY); `Context::toInteractive()` now throws a `LogicException` when called in a non-interactive environment, with `toInteractive(throwOnNonInteractiveEnv: false)` to bypass
 
 ### Fixes
 

--- a/doc/docs/getting-started/context.md
+++ b/doc/docs/getting-started/context.md
@@ -339,6 +339,51 @@ function foo(): void
 }
 ```
 
+### Interactive environment
+
+Some commands (a shell, `vim`, an interactive prompt, ...) only make sense
+when Castor runs in an interactive environment. Castor auto-detects this and
+exposes it via `supportsInteraction()`:
+
+```php
+use Castor\Attribute\AsTask;
+
+use function Castor\context;
+use function Castor\run;
+
+#[AsTask()]
+function shell(): void
+{
+    $c = context();
+
+    if ($c->supportsInteraction()) {
+        $c = $c->toInteractive();
+    }
+
+    run('bash', context: $c);
+}
+```
+
+Auto-detection considers the environment **non-interactive** when:
+
+* the `CI` environment variable is set, or
+* `STDIN` is not attached to a TTY (piped input, AI agent runners, ...).
+
+You can also force the value yourself with `withSupportsInteraction()`, for
+example to flag your own AI agent runner:
+
+```php
+$c = context()->withSupportsInteraction(false);
+```
+
+Calling `toInteractive()` in a non-interactive environment throws a
+`LogicException` to prevent silent hangs. If you really want to force
+interactive flags anyway, pass `throwOnNonInteractiveEnv: false`:
+
+```php
+$c = context()->toInteractive(throwOnNonInteractiveEnv: false);
+```
+
 ### Passing verbose arguments
 
 Castor allow you to pass verbose arguments (like the universal `-v` option) to

--- a/src/Context.php
+++ b/src/Context.php
@@ -11,10 +11,15 @@ class Context implements \ArrayAccess
 {
     public readonly string $workingDirectory;
 
+    public readonly bool $supportsInteraction;
+
     /**
-     * @param array<string, string|\Stringable|int>              $environment      A list of environment variables to add to the task
-     * @param string[]                                           $verboseArguments A list of arguments to pass to the command to enable verbose output
-     * @param string|\Stringable|resource|\Iterator<string>|null $input            The input to send to the process stdin
+     * @param array<string, string|\Stringable|int>              $environment         A list of environment variables to add to the task
+     * @param string[]                                           $verboseArguments    A list of arguments to pass to the command to enable verbose output
+     * @param string|\Stringable|resource|\Iterator<string>|null $input               The input to send to the process stdin
+     * @param ?bool                                              $supportsInteraction Whether the surrounding environment supports interactive
+     *                                                                                commands. When null (default), it is auto-detected from
+     *                                                                                well-known signals (CI env var, STDIN being a TTY).
      *
      * @phpstan-param ContextData $data The input parameter accepts an array or an Object
      */
@@ -37,8 +42,10 @@ class Context implements \ArrayAccess
         public readonly string $notificationTitle = '',
         public readonly array $verboseArguments = [],
         public readonly mixed $input = null,
+        ?bool $supportsInteraction = null,
     ) {
         $this->workingDirectory = $workingDirectory ?? PathHelper::getRoot(false);
+        $this->supportsInteraction = $supportsInteraction ?? self::detectSupportsInteraction();
     }
 
     // @phpstan-ignore missingType.iterableValue
@@ -57,6 +64,7 @@ class Context implements \ArrayAccess
             'notify' => $this->notify,
             'verbosityLevel' => $this->verbosityLevel,
             'notificationTitle' => $this->notificationTitle,
+            'supportsInteraction' => $this->supportsInteraction,
         ];
     }
 
@@ -182,8 +190,33 @@ class Context implements \ArrayAccess
         ]);
     }
 
-    public function toInteractive(): self
+    public function withSupportsInteraction(bool $supportsInteraction = true): self
     {
+        return $this->clone([
+            'supportsInteraction' => $supportsInteraction,
+        ]);
+    }
+
+    public function supportsInteraction(): bool
+    {
+        return $this->supportsInteraction;
+    }
+
+    /**
+     * Switches the context to interactive mode (TTY enabled, no timeout, allow
+     * failure) so that commands like a shell can be run.
+     *
+     * When the surrounding environment is not interactive (CI, AI agent, piped
+     * stdin, ...) this throws a {@see \LogicException} to prevent silent hangs.
+     * Pass {@code $throwOnNonInteractiveEnv: false} to bypass this check and
+     * force interactive flags anyway.
+     */
+    public function toInteractive(bool $throwOnNonInteractiveEnv = true): self
+    {
+        if ($throwOnNonInteractiveEnv && !$this->supportsInteraction) {
+            throw new \LogicException('Cannot switch context to interactive mode: the surrounding environment is not interactive (CI, agent, or non-TTY stdin). Call toInteractive(throwOnNonInteractiveEnv: false) to force it, or guard the call with Context::supportsInteraction().');
+        }
+
         return $this
             ->withTimeout(null)
             ->withTty()
@@ -248,5 +281,18 @@ class Context implements \ArrayAccess
         $vars = array_merge(get_object_vars($this), $args);
 
         return new self(...$vars);
+    }
+
+    private static function detectSupportsInteraction(): bool
+    {
+        if (false !== getenv('CI')) {
+            return false;
+        }
+
+        if (\defined('STDIN') && \function_exists('stream_isatty') && !@stream_isatty(\STDIN)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Castor\Tests;
+
+use Castor\Context;
+use PHPUnit\Framework\TestCase;
+
+class ContextTest extends TestCase
+{
+    public function testSupportsInteractionDefaultsToTrueWhenExplicitlySet(): void
+    {
+        $context = new Context(supportsInteraction: true);
+
+        $this->assertTrue($context->supportsInteraction());
+    }
+
+    public function testWithSupportsInteractionReturnsNewInstance(): void
+    {
+        $context = new Context(supportsInteraction: true);
+        $nonInteractive = $context->withSupportsInteraction(false);
+
+        $this->assertNotSame($context, $nonInteractive);
+        $this->assertTrue($context->supportsInteraction());
+        $this->assertFalse($nonInteractive->supportsInteraction());
+    }
+
+    public function testSupportsInteractionIsPreservedAcrossOtherWithers(): void
+    {
+        $context = (new Context(supportsInteraction: false))
+            ->withWorkingDirectory('/tmp')
+            ->withQuiet()
+            ->withAllowFailure()
+            ->withEnvironment(['FOO' => 'bar'])
+        ;
+
+        $this->assertFalse($context->supportsInteraction());
+    }
+
+    public function testToInteractiveSwitchesFlagsWhenEnvSupportsInteraction(): void
+    {
+        $context = (new Context(supportsInteraction: true))->toInteractive();
+
+        $this->assertTrue($context->tty);
+        $this->assertNull($context->timeout);
+        $this->assertTrue($context->allowFailure);
+    }
+
+    public function testToInteractiveThrowsWhenEnvDoesNotSupportInteraction(): void
+    {
+        $context = new Context(supportsInteraction: false);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/not interactive/');
+
+        $context->toInteractive();
+    }
+
+    public function testToInteractiveCanBypassTheCheck(): void
+    {
+        $context = (new Context(supportsInteraction: false))->toInteractive(throwOnNonInteractiveEnv: false);
+
+        $this->assertTrue($context->tty);
+        $this->assertNull($context->timeout);
+        $this->assertTrue($context->allowFailure);
+        $this->assertFalse($context->supportsInteraction());
+    }
+}


### PR DESCRIPTION
## Summary

First stab at #803: let `Context` know whether the surrounding environment supports interactive commands, and prevent `toInteractive()` from silently hanging in CI / under AI agent runners.

- New `Context::isEnvInteractive()` / `withEnvInteractive()`
- Auto-detection from `CI` env var + STDIN being a TTY (override with `withEnvInteractive(false)`)
- `Context::toInteractive()` now throws a `LogicException` when the environment is not interactive, with `toInteractive(throwOnNonInteractiveEnv: false)` as an escape hatch
- Tests, CHANGELOG and docs updated

Opening as **draft** because two design points really benefit from your input before going further:

### 1. Auto-detection scope

I went conservative on purpose: only `CI` + `!stream_isatty(STDIN)`. The issue mentioned `CURSOR_AGENT` / `AI_AGENT` / etc., but that ecosystem is fragmented and there's no real standard yet — I'd rather let users declare their own runner with `withEnvInteractive(false)` than hardcode a list that goes stale fast. Happy to expand the list if you'd prefer broader detection out of the box.

### 2. BC break on `toInteractive()`

As suggested by @joelwurtz in the issue, `toInteractive()` now throws when the env is not interactive. This is technically a BC break for anyone calling `toInteractive()` from CI today (even if such a call was almost certainly already broken in practice). The bypass param is there for the rare legitimate use case. Let me know if you'd rather have it opt-in via a separate method instead.

### Out of scope

The "automatically hide commands when env is not interactive" idea from the issue thread isn't in this PR — it's a bigger change touching command discovery, and felt better as a follow-up once the foundation is agreed on.

Refs #803

## Test plan

- [x] `vendor/bin/phpunit tests/ContextTest.php` (6 new tests)
- [x] `tools/phpstan/vendor/bin/phpstan` clean
- [x] `tools/php-cs-fixer/vendor/bin/php-cs-fixer fix` clean
- [x] Full suite: only pre-existing unrelated failures remain (locale-dependent `RunVerboseArguments*` tests + network-dependent `RemoteImportRemoteTasks`)

Thanks a lot for maintaining Castor — happy to iterate on this based on your feedback! 🙌