### PR TITLE
Update wait_for_docker_container example

### DIFF
--- a/doc/docs/going-further/helpers/wait-for.md
+++ b/doc/docs/going-further/helpers/wait-for.md
@@ -137,8 +137,7 @@ wait_for_http_status(
 ### The `wait_for_docker_container()` function
 
 The `wait_for_docker_container()` function waits for a Docker container to be
-ready. It checks if the container is running and if the specified port is
-accessible within the specified timeout.
+ready. It checks if the container is running.
 It can also wait for a specific check to be successful, by providing a
 `$containerChecker` callback function.
 
@@ -146,14 +145,13 @@ Example:
 
 ```php
 wait_for_docker_container(
-    container: 'mysql-container',
-    containerChecker: function ($containerId) {
-        return run("docker exec $containerId mysql -uroot -proot -e 'SELECT 1'", context: context()->withAllowFailure()))->isSuccessful();
-    },
-    portsToCheck: [3306]
+    containerName: 'mysql-container',
     timeout: 30,
     quiet: false,
     intervalMs: 100,
     message: 'Waiting for my-container to be ready...',
+    containerChecker: function ($containerId) {
+        return run("docker exec $containerId mysql -uroot -proot -e 'SELECT 1'", context: context()->withAllowFailure())->isSuccessful();
+    },
 );
 ```


### PR DESCRIPTION
I guess the interface of the method got changed, but not the docs.