### PR TITLE
Fix implementation of Context::supportsInteraction()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 * Fix usage of `#[AsArgsAfterOptionEnd]`, CLI arguments are not mandatory anymore, and PHP parameters can be optional with default value
+* Fix implementation of `Context::supportsInteraction()`
 
 ### Security
 

--- a/src/Context.php
+++ b/src/Context.php
@@ -214,7 +214,7 @@ class Context implements \ArrayAccess
     public function toInteractive(bool $throwOnNonInteractiveEnv = true): self
     {
         if ($throwOnNonInteractiveEnv && !$this->supportsInteraction) {
-            throw new \LogicException('Cannot switch context to interactive mode: the surrounding environment is not interactive (CI, agent, or non-TTY stdin). Call toInteractive(throwOnNonInteractiveEnv: false) to force it, or guard the call with Context::supportsInteraction().');
+            throw new \LogicException('Cannot switch context to interactive mode: the surrounding environment is not interactive (CI, agent, or non-TTY stdin/stdout). Call Context::toInteractive(throwOnNonInteractiveEnv: false) to force it, or guard the call with Context::supportsInteraction().');
         }
 
         return $this
@@ -291,7 +291,15 @@ class Context implements \ArrayAccess
             return false;
         }
 
-        if (\defined('STDIN') && \function_exists('stream_isatty') && !@stream_isatty(\STDIN)) {
+        if (!\function_exists('stream_isatty')) {
+            return false;
+        }
+
+        if (!stream_isatty(\STDIN) || !stream_isatty(\STDOUT)) {
+            return false;
+        }
+
+        if (!@is_writable('/dev/tty')) {
             return false;
         }
 


### PR DESCRIPTION
Implementation was partially broken.

If you use `$c->toInteractive()`, it will call `$c->withTty()`.
Then if you execute a process, well do this:
```
if ($context->tty) {
    $process->setTty(true);
```

And in Symfony Process: https://github.com/symfony/symfony/blob/c8078f63a7a4f9ef3200f9eca1583abf6f7ae832/src/Symfony/Component/Process/Process.php#L1294

So we must check at least the same way!


cc @Amoifr
