### PR TITLE
feat: add CASTOR_DISABLE_AGENT_DETECTION env var to bypass AI agent detection

### DIFF
--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -20,6 +20,7 @@ $_SERVER['CASTOR_CACHE_DIR'] ??= '/tmp/castor-tests/cache';
 if (!$_SERVER['CASTOR_CACHE_DIR']) {
     throw new RuntimeException('CASTOR_CACHE_DIR is not set or empty.');
 }
+$_SERVER['CASTOR_DISABLE_AGENT_DETECTION'] = 'true';
 
 WebServerHelper::start();
 

--- a/doc/docs/going-further/helpers/version-check.md
+++ b/doc/docs/going-further/helpers/version-check.md
@@ -45,3 +45,18 @@ update the tool once in a day.
 
 This behavior can be disabled by setting the `CASTOR_DISABLE_VERSION_CHECK`
 environment variable to `1` or `true`.
+
+## AI agent context
+
+Castor automatically detects when it is running inside an AI agent (e.g. Claude
+Code, GitHub Copilot Workspace, or any environment where `STDIN` is not a TTY).
+In that context, Castor reduces its output to avoid polluting the agent's
+context window: the ASCII logo is hidden and update reminders are suppressed.
+
+If the detection produces a false positive — for instance in a CI pipeline that
+looks like an agent — you can disable it by setting the
+`CASTOR_DISABLE_AGENT_DETECTION` environment variable to any non-empty value:
+
+```bash
+CASTOR_DISABLE_AGENT_DETECTION=true castor my-task
+```

--- a/doc/docs/reference.md
+++ b/doc/docs/reference.md
@@ -102,6 +102,7 @@ Castor supports the following environment variables:
 
 - [`CASTOR_CACHE_DIR`](going-further/helpers/cache.md#cache-location-on-the-filesystem)
 - [`CASTOR_CONTEXT`](getting-started/context.md#setting-a-default-context)
+- [`CASTOR_DISABLE_AGENT_DETECTION`](going-further/helpers/version-check.md#ai-agent-context)
 - [`CASTOR_DISABLE_VERSION_CHECK`](going-further/helpers/version-check.md#update-reminder)
 - [`CASTOR_GENERATE_STUBS`](../installation/index.md#stubs)
 - [`CASTOR_MEMORY_LIMIT`](going-further/helpers/run-php.md#script-requiring-more-memory)

--- a/src/Helper/PlatformHelper.php
+++ b/src/Helper/PlatformHelper.php
@@ -31,6 +31,10 @@ final class PlatformHelper
 
     public static function isRunningInAgentContext(): bool
     {
+        if (self::getEnv('CASTOR_DISABLE_AGENT_DETECTION')) {
+            return false;
+        }
+
         static $result = null;
 
         return $result ??= AgentDetector::detect()->isAgent;

--- a/tests/TaskTestCase.php
+++ b/tests/TaskTestCase.php
@@ -35,6 +35,7 @@ abstract class TaskTestCase extends TestCase
             'ENDPOINT' => $_SERVER['ENDPOINT'],
             'CASTOR_CACHE_DIR' => self::$castorCacheDir,
             'CASTOR_TEST' => 'true',
+            'CASTOR_DISABLE_AGENT_DETECTION' => 'true',
         ];
 
         if (!$needRemote) {


### PR DESCRIPTION
Allow users to opt out of the agent context detection introduced in #824,
which suppresses the logo and update reminders. Useful when the heuristic
produces a false positive (e.g. CI pipelines without a TTY). The test
harness and the test-generation script also set the variable so tests always
run in non-agent mode.
