### PR TITLE
feat: auto-detect tty/pty from supportsInteraction context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Features
 
 * Drop support for PHP 8.2 and 8.3, minimum supported version is now PHP 8.4
-* Remove castor header and upgrade output when running inside an ai agent
 * Add support for `.castor.context` file to set the default context (lowest precedence after `--context` flag and `CASTOR_CONTEXT` env var)
+* Use best of TTY/PTY according to the surrounding environment capabilities
+* Remove castor header and upgrade output when running inside an ai agent
 
 ## Security
 

--- a/src/Context.php
+++ b/src/Context.php
@@ -10,8 +10,9 @@ use Symfony\Component\DependencyInjection\Attribute\Exclude;
 class Context implements \ArrayAccess
 {
     public readonly string $workingDirectory;
-
     public readonly bool $supportsInteraction;
+    public readonly bool $tty;
+    public readonly bool $pty;
 
     /**
      * @param array<string, string|\Stringable|int>              $environment         A list of environment variables to add to the task
@@ -27,8 +28,8 @@ class Context implements \ArrayAccess
         public readonly array $data = [],
         public readonly array $environment = [],
         ?string $workingDirectory = null,
-        public readonly bool $tty = false,
-        public readonly bool $pty = true,
+        ?bool $tty = null,
+        ?bool $pty = null,
         public readonly ?float $timeout = null,
         public readonly bool $quiet = false,
         public readonly bool $allowFailure = false,
@@ -46,6 +47,18 @@ class Context implements \ArrayAccess
     ) {
         $this->workingDirectory = $workingDirectory ?? PathHelper::getRoot(false);
         $this->supportsInteraction = $supportsInteraction ?? self::detectSupportsInteraction();
+        if (null === $tty && null === $pty) {
+            if ($this->supportsInteraction) {
+                $this->tty = true;
+                $this->pty = false;
+            } else {
+                $this->tty = false;
+                $this->pty = true;
+            }
+        } else {
+            $this->tty = $tty ?? false;
+            $this->pty = $pty ?? false;
+        }
     }
 
     // @phpstan-ignore missingType.iterableValue

--- a/tools/docker/castor.php
+++ b/tools/docker/castor.php
@@ -22,7 +22,7 @@ function docker_run(string $imageName, array $runCommand, ?string $workDir = nul
         '--network=host',
     ];
 
-    if (!$context->quiet && false !== $context->tty && false !== $context->pty) {
+    if (!$context->quiet && $context->tty) {
         $command[] = '-i';
     }
 


### PR DESCRIPTION
Previously, `tty` and `pty` had fixed defaults (`tty=false`, `pty=true`)
regardless of the runtime environment. This meant that on an interactive
terminal, Castor would still use PTY mode (fake terminal) rather than full
TTY mode, even though a real TTY is available and more appropriate.

This commit makes `tty` and `pty` computed from `supportsInteraction` when
neither is explicitly set by the caller:

- interactive environment (supportsInteraction=true) → tty=true, pty=false
- non-interactive environment (supportsInteraction=false, e.g. CI, agent) → tty=false, pty=true

`tty` and `pty` are mutually exclusive alternatives: ProcessRunner gives
precedence to TTY > PTY > nothing. Providing only one of them explicitly
forces the other to false, which is intentional.

Also fix the docker helper: the `-i` flag condition previously required
both `tty` and `pty` to be non-false simultaneously, which can never
happen since they are now mutually exclusive. The correct condition is
simply `$context->tty` (TTY mode implies interactive stdin passthrough).

---

<img width="1484" height="981" alt="image" src="https://github.com/user-attachments/assets/0d1d06a7-d8bc-4770-8c68-72ecc3985a69" />
