### PR TITLE
fix: don't forward STDIN to PTY subprocess when STDIN is not a TTY

### DIFF
--- a/src/Runner/ProcessRunner.php
+++ b/src/Runner/ProcessRunner.php
@@ -88,7 +88,13 @@ class ProcessRunner
                 $process->setInput(\STDIN);
             } elseif ($context->pty) {
                 $process->setPty(true);
-                $process->setInput(\STDIN);
+                // Only forward STDIN to the subprocess when it is an actual terminal.
+                // When STDIN is a pipe (CI, tests, scripts), forwarding it would allow the
+                // PTY I/O loop to consume data meant for castor's own interactive prompts
+                // (e.g. the "retry with verbose arguments?" confirmation question).
+                if (stream_isatty(\STDIN)) {
+                    $process->setInput(\STDIN);
+                }
             }
         }
 


### PR DESCRIPTION
When running a subprocess in PTY mode, Castor previously always called
`$process->setInput(\STDIN)`, which instructed Symfony's PTY I/O loop
to read from Castor's own stdin and pipe the data into the PTY master
(and from there, into the subprocess's stdin).

This caused a subtle race condition when Castor's stdin is a pipe (e.g.
in automated tests, CI scripts, or any non-interactive invocation):

1. The caller writes data into Castor's stdin pipe before Castor
   reaches a point where it needs to read from stdin itself.
2. Castor starts the subprocess with setPty(true) + setInput(\STDIN).
3. Symfony's AbstractPipes::unblock() immediately sets \STDIN to
   non-blocking mode (via stream_set_blocking(\STDIN, false)).
4. The PTY I/O loop runs and — finding data already buffered in the
   non-blocking \STDIN — reads and forwards it to the PTY master.
5. The PTY master echoes the data back as output (terminal echo).
6. When the subprocess eventually exits and Castor needs to ask an
   interactive question (e.g. "Do you want to retry with verbose
   arguments?"), \STDIN is empty: the data was already consumed by
   step 4. The confirmation question defaults to "no".

This was the root cause of RunVerboseArgumentsTrueTest failing locally
with PHP 8.5 while passing in CI (PHP 8.4): Castor's startup time
(~1.18 s) exceeded the 500 ms delay used by the test infrastructure
before writing the "yes\n" answer into the InputStream. On the test
runner side, `wait()` delivers the data to Castor's stdin pipe while
Castor is still initialising and the PTY I/O loop for the bash
subprocess is active, so the data is consumed before the confirmation
question is ever reached.

The fix is semantically correct: in a real interactive terminal,
stream_isatty(\STDIN) is true, so keystrokes still flow from the user
through Castor into the PTY subprocess as before. When Castor's stdin
is a pipe (script, test, CI), there is no interactive terminal to
forward, so \STDIN is now left untouched, preserving its contents for
Castor's own prompts.
