### PR TITLE
fix: replace fixed sleep with prompt-aware wait to fix race condition in RunVerboseArgumentsTrueTest

### DIFF
--- a/tests/TaskTestCase.php
+++ b/tests/TaskTestCase.php
@@ -74,8 +74,20 @@ abstract class TaskTestCase extends TestCase
 
         if ($inputStream) {
             $process->start();
-            usleep(500_000);
-            $inputStream->write($input);
+
+            // Wait for the interactive prompt to appear before writing input, to
+            // avoid the race condition where the PTY I/O loop for the subprocess
+            // would consume the input from STDIN before the question is asked.
+            $outputBuffer = '';
+            if ($process->waitUntil(static function (string $type, string $data) use (&$outputBuffer): bool {
+                if (Process::OUT === $type) {
+                    $outputBuffer .= $data;
+                }
+
+                return str_contains($outputBuffer, ' > ');
+            })) {
+                $inputStream->write($input);
+            }
             $inputStream->close();
             $process->wait();
         } else {


### PR DESCRIPTION
The test RunVerboseArgumentsTrueTest was failing locally (PHP 8.5) while
passing in CI (PHP 8.4). This commit documents the full investigation and
applies the correct fix.

## Root cause

The test infrastructure wrote `yes\n` to the subprocess InputStream after
a hardcoded usleep(500_000) delay, then called wait() which flushed the
data into Castor's stdin pipe.

Castor's startup time on PHP 8.5 without a warm cache is ~1.18 s. The
500 ms delay was therefore too short: `yes\n` arrived in Castor's stdin
pipe while Castor was still initialising and before it reached the confirm
question. At that point, Castor had already launched the bash subprocess
with setPty(true) + setInput(\STDIN). Symfony's AbstractPipes::unblock()
put \STDIN into non-blocking mode, and the PTY I/O loop read `yes\n` from
the non-blocking \STDIN and forwarded it to the PTY master, which echoed
it back to stdout. By the time the bash subprocess failed and Castor called
SymfonyStyle::confirm(), \STDIN was empty — so QuestionHelper defaulted to
'no' and no retry happened.

In CI the test passed because the machines are faster (or the PHP 8.4
runtime starts sooner), so the 500 ms window was sufficient — the `yes\n`
arrived after bash had already exited and the PTY loop was done.

## Why the obvious production fix does not work

A first attempt introduced a stream_isatty(\STDIN) guard in ProcessRunner
to skip setInput(\STDIN) when stdin is not a TTY. That prevented the PTY
loop from consuming the input, fixing RunVerboseArgumentsTrueTest — but it
broke RunVerboseArgumentsTest (the no-input variant) in a subtle way:

When the PTY loop does NOT read \STDIN, PHP's feof() flag is never
advanced. PHP's feof() only returns true after an actual read attempt that
returns empty/false. With the old code the PTY loop inadvertently triggered
that read (getting an empty string on the closed pipe), so feof() returned
true when QuestionHelper later called while (!feof(\STDIN)) — the loop was
skipped, doReadInput() returned '', no MissingInputException was raised, and
$input->isInteractive() stayed true. SymfonyStyle::askQuestion() then called
$this->newLine(), producing the expected trailing newline in the output.

Without the PTY read the feof state was never triggered: QuestionHelper
entered the while loop, the first fread() returned '' on the closed pipe,
and MissingInputException('Aborted.') was thrown. The catch block in
QuestionHelper::ask() called $input->setInteractive(false), which caused
askQuestion() to skip the $this->newLine() call. The result was that the
error message appeared on the same line as the ' > ' prompt instead of on
the next line — changing the expected test output.

## The correct fix

The race condition is fundamentally a test-infrastructure problem: the test
was guessing how long Castor would take to reach the confirm question and
sleeping for that duration. The correct fix is to wait for evidence that
the question has actually been asked before sending the answer.

Process::waitUntil() runs the I/O loop and calls a user callback on each
chunk of output. The callback accumulates stdout and returns true as soon
as ' > ' (the Symfony question prompt) appears. Only then is `yes\n`
written to the InputStream. By the time the prompt is visible:

  - Castor has fully initialised.
  - The bash subprocess has run and exited.
  - The PTY I/O loop for bash is finished.
  - \STDIN is free for QuestionHelper to read.

QuestionHelper then reads `yes\n`, returns true, Castor retries the
command with verbose arguments (-x -e), fails again as expected, and the
test assertions pass.

If the subprocess exits before showing a prompt (unexpected path), the
waitUntil() call returns false, the InputStream is closed without writing
anything, and wait() collects the exit status normally.
