### PR TITLE
Display a nice message when the user is using an unsupported PHP version (8.2 or 8.3) and suggest to use the static binary instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Not released yet
 
+## 1.6.1 (2026-07-02)
+
+### Features
+
+* Display a nice message when the user is using an unsupported PHP version (8.2 or 8.3) and suggest to use the static binary instead
+
 ## 1.6.0 (2026-06-30)
 
 ### Features

--- a/bin/castor
+++ b/bin/castor
@@ -1,6 +1,13 @@
 #!/usr/bin/env php
 <?php
 
+if (!isset($_SERVER['CASTOR_TEST']) && PHP_VERSION_ID < 80400) {
+    fwrite(STDERR, sprintf("Castor requires PHP >= 8.4.0, but you are running PHP %s.\n", PHP_VERSION));
+    fwrite(STDERR, "You can still use castor, but you must install the static version of castor.\n");
+    fwrite(STDERR, "Read more at https://castor.jolicode.com/installation/installer/static\n");
+    exit(1);
+}
+
 use Castor\Console\Application;
 use Castor\Console\ApplicationFactory;
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -24,7 +24,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 class Application extends SymfonyApplication
 {
     public const NAME = 'castor';
-    public const VERSION = 'v1.6.0';
+    public const VERSION = 'v1.6.1';
     public const HIDE_LOGO = false;
     public const EXTERNAL_LOGO = '';
 


### PR DESCRIPTION
Example:
```
>…me/gregoire/dev/github.com/jolicode/castor(php-version) tools/phar/build/castor.linux-amd64.phar 
Castor requires PHP >= 8.4.0, but you are running PHP 8.3.31.
You can still use castor, but you must install the static version of castor.
Read more at https://castor.jolicode.com/installation/installer/static
```

