### PR TITLE
Fix ssh boolean options being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released yet
 
+### Fixes
+
+* Fix `enable_strict_check` and `password_authentication` ssh options being ignored
+
 ## 1.6.1 (2026-07-02)
 
 ### Features

--- a/src/Runner/SshRunner.php
+++ b/src/Runner/SshRunner.php
@@ -113,10 +113,10 @@ final readonly class SshRunner
         if ($sshOptions['multiplexing_control_path'] ?? false) {
             $ssh->useMultiplexing($sshOptions['multiplexing_control_path'], $sshOptions['multiplexing_control_persist'] ?? '10m');
         }
-        if ($sshOptions['enable_strict_check'] ?? false) {
+        if (isset($sshOptions['enable_strict_check'])) {
             $sshOptions['enable_strict_check'] ? $ssh->enableStrictHostKeyChecking() : $ssh->disableStrictHostKeyChecking();
         }
-        if ($sshOptions['password_authentication'] ?? false) {
+        if (isset($sshOptions['password_authentication'])) {
             $sshOptions['password_authentication'] ? $ssh->enablePasswordAuthentication() : $ssh->disablePasswordAuthentication();
         }
 

--- a/tests/SshRunnerTest.php
+++ b/tests/SshRunnerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Castor\Tests;
+
+use Castor\Runner\SshRunner;
+use PHPUnit\Framework\TestCase;
+use Spatie\Ssh\Ssh;
+
+class SshRunnerTest extends TestCase
+{
+    public function testPasswordAuthenticationIsDisabledWhenFalse(): void
+    {
+        $this->assertStringContainsString('-o PasswordAuthentication=no', $this->buildSshCommand([
+            'password_authentication' => false,
+        ]));
+    }
+
+    public function testStrictHostKeyCheckingIsDisabledWhenFalse(): void
+    {
+        $this->assertStringContainsString('-o StrictHostKeyChecking=no', $this->buildSshCommand([
+            'enable_strict_check' => false,
+        ]));
+    }
+
+    /**
+     * Enabling either option means letting OpenSSH use its own default, so no
+     * explicit "-o" is added to the command.
+     */
+    public function testNoOptionIsAddedWhenEnabled(): void
+    {
+        $command = $this->buildSshCommand([
+            'password_authentication' => true,
+            'enable_strict_check' => true,
+        ]);
+
+        $this->assertStringNotContainsString('PasswordAuthentication', $command);
+        $this->assertStringNotContainsString('StrictHostKeyChecking', $command);
+    }
+
+    public function testNoOptionIsAddedWhenOmitted(): void
+    {
+        $command = $this->buildSshCommand([]);
+
+        $this->assertStringNotContainsString('PasswordAuthentication', $command);
+        $this->assertStringNotContainsString('StrictHostKeyChecking', $command);
+    }
+
+    /**
+     * @param array{
+     *     'enable_strict_check'?: bool,
+     *     'password_authentication'?: bool,
+     * } $sshOptions
+     */
+    private function buildSshCommand(array $sshOptions): string
+    {
+        // buildSsh() does not use the constructor dependencies, so we can skip them.
+        $runner = new \ReflectionClass(SshRunner::class)->newInstanceWithoutConstructor();
+        $ssh = new \ReflectionMethod(SshRunner::class, 'buildSsh')->invoke($runner, 'server-1.example.com', 'debian', $sshOptions);
+
+        $this->assertInstanceOf(Ssh::class, $ssh);
+
+        return $ssh->getExecuteCommand('ls');
+    }
+}


### PR DESCRIPTION
## Bug

`SshRunner::buildSsh()` guards both boolean options with a truthiness check, so passing `false` never enters the block and `disable*()` is dead code:

```php
if ($sshOptions['password_authentication'] ?? false) {
    $sshOptions['password_authentication'] ? $ssh->enablePasswordAuthentication() : $ssh->disablePasswordAuthentication();
}
```

In `spatie/ssh`, the `enable*()` methods only `unset()` the option to fall back on OpenSSH's default, while the `disable*()` ones actually add `-o PasswordAuthentication=no` / `-o StrictHostKeyChecking=no`. The only branch with an effect is the unreachable one, so both options are no-op today whatever the value passed.

## Fix

Use `isset()`, so an explicit `false` reaches `disable*()`. Omitting the option still adds nothing.

Tests in `tests/SshRunnerTest.php` — the two `false` cases fail on `main`. They reach the private `buildSsh()` by reflection; happy to restructure if you prefer.

---

Unrelated: `$sshOptions` is a closed shape, so an arbitrary `-o` (e.g. `BatchMode=yes`) can't be passed. `spatie/ssh` has `addExtraOption()` — Should we add an `extra_options` key Castor's side?