### PR TITLE
fix(phpstan): prefer type alias in class instead of phpstan files, document ContextData type alias override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Fix `AsArgsAfterOptionEnd` not validating arguments properly: extra arguments given without a `--` were silently dropped instead of raising an error, and required arguments given after `--` were not detected as missing
 * Fix `-c`/`--context` being wrongly parsed from arguments passed after `--`, causing an unrelated `Context "..." not found` error
 * Prevent the `AsArgsAfterOptionEnd` attribute from being used on more than one parameter of the same task
+* Turn the `SshOptions` type alias into a `@phpstan-type` declared on `SshRunner`, so it resolves without any PHPStan configuration
+* Ship a default `ContextData: 'array<string, mixed>'` PHPStan type alias in `extension.neon`, so projects that do not declare their own context data shape no longer get `class.notFound` errors on `Context::$data` and `variable()`. Declaring the alias in your own `phpstan.neon` still takes precedence, and is now documented in the [context documentation](https://castor.jolicode.com/getting-started/context/#typing-the-context-data)
 
 ## 1.6.1 (2026-07-02)
 

--- a/composer.json
+++ b/composer.json
@@ -73,5 +73,12 @@
             "php": "8.4.1"
         },
         "sort-packages": true
+    },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20f60f884363ee925175d7b668c36fc6",
+    "content-hash": "73083b7badbbb4e7e20cfb26ca1ef5b6",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/doc/docs/getting-started/context.md
+++ b/doc/docs/getting-started/context.md
@@ -68,6 +68,55 @@ function foo(): void
 }
 ```
 
+### Typing the context data
+
+Castor cannot know the shape of your context data, so `Context::$data` and
+`variable()` are described by a PHPStan [type
+alias](https://phpstan.org/writing-php-code/phpdoc-types#global-type-aliases)
+named `ContextData`. It defaults to `array<string, mixed>`, which means
+`variable()` returns `mixed` out of the box.
+
+If you use PHPStan, you can redeclare that alias in your own `phpstan.neon` to
+describe your own variables:
+
+```neon
+parameters:
+    typeAliases:
+        ContextData: '''
+            array{
+                name: string,
+                production: bool,
+                foo?: string,
+            }
+        '''
+```
+
+`variable()` then returns precise types instead of `mixed`:
+
+```php
+$name = variable('name');                // string
+$production = variable('production');    // bool
+$unknown = variable('unknown', 42);      // int, inferred from the default value
+```
+
+Your declaration takes precedence over the default one, so there is nothing
+else to remove or disable.
+
+> [!NOTE]
+> The default alias lives in `extension.neon` at the root of the Castor
+> package. It is registered automatically if you use
+> [phpstan/extension-installer](https://github.com/phpstan/extension-installer).
+> Otherwise, include it by hand:
+>
+> ```neon
+> includes:
+>     - vendor/jolicode/castor/extension.neon
+> ```
+>
+> When you run Castor as a phar or as a standalone binary there is no
+> `vendor/jolicode/castor` directory: declare the alias yourself, either with your
+> own shape or with the permissive default `ContextData: 'array<string, mixed>'`.
+
 ## Creating a new context
 
 You can create a new context by declaring a function with

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,3 @@
+parameters:
+    typeAliases:
+        ContextData: 'array<string, mixed>'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+    - extension.neon
     - phpstan-baseline.neon
 
 parameters:
@@ -20,24 +21,6 @@ parameters:
                 foo?: string,
             }
         '''
-        ImportSource: '''
-            array{
-                url?: string,
-                type?: "git" | "svn",
-                reference?: string,
-            }
-        '''
-        SshOptions: '''
-            array{
-               'port'?: int,
-               'path_private_key'?: string,
-               'jump_host'?: string,
-               'multiplexing_control_path'?: string,
-               'multiplexing_control_persist'?: string,
-               'enable_strict_check'?: bool,
-               'password_authentication'?: bool,
-           }
-       '''
     ignoreErrors:
         -
             message: "#^Function pyrech\\\\.* not found\\.$#"

--- a/src/Runner/SshRunner.php
+++ b/src/Runner/SshRunner.php
@@ -6,7 +6,19 @@ use Castor\ContextRegistry;
 use Spatie\Ssh\Ssh;
 use Symfony\Component\Process\Process;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @phpstan-type SshOptions array{
+ *     'port'?: int,
+ *     'path_private_key'?: string,
+ *     'jump_host'?: string,
+ *     'multiplexing_control_path'?: string,
+ *     'multiplexing_control_persist'?: string,
+ *     'enable_strict_check'?: bool,
+ *     'password_authentication'?: bool,
+ * }
+ */
 final readonly class SshRunner
 {
     public function __construct(


### PR DESCRIPTION
* ImportSource was not used anymore -> removed
* SshRunner options can be done in the class instead -> moved to class so the stub has it (better for ide)
* ContextData keeped and documented, also added an extension so plugin author don't have to repeat this