### PR TITLE
feat(event): add details about mount in the functions resolved event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * Add `dispatch()` and `event_dispatcher()` functions to dispatch events and access the event dispatcher
+* Add `mountPath` and `isRootMount` properties to `FunctionsResolvedEvent`, so listeners can tell the root application apart from mounted ones (the event is dispatched once per mount)
 
 ### Fixes
 

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -198,6 +198,7 @@ displayTitle('Generating tests for valid fixtures');
 add_test(['hello'], 'ContextFile', '{{ base }}/tests/fixtures/valid/context-file');
 add_test(['hello', '--context', 'foo'], 'ContextFileOverriddenByCli', '{{ base }}/tests/fixtures/valid/context-file');
 add_test(['hello'], 'ContextFileInvalid', '{{ base }}/tests/fixtures/valid/context-file-invalid');
+add_test(['hello'], 'FunctionsResolvedMount', '{{ base }}/tests/fixtures/valid/functions-resolved-mount');
 add_test(['list'], 'LayoutWithFolder', '{{ base }}/tests/fixtures/valid/layout-with-folder');
 add_test([], 'ImportSamePackageWithDefaultVersion', '{{ base }}/tests/fixtures/valid/import-same-package-with-default-version', needRemote: true, needResetVendor: true);
 add_test(['fs-watch'], 'WatchWithForcedTimeout', '{{ base }}/tests/fixtures/valid/watch-with-forced-timeout');

--- a/doc/docs/going-further/extending-castor/events.md
+++ b/doc/docs/going-further/extending-castor/events.md
@@ -74,7 +74,10 @@ Here is the built-in events triggered by Castor:
 
 * `Castor\Event\FunctionsResolvedEvent`: This event is triggered after the
   functions has been resolved. It provides access to an array of
-  `TaskDescriptor` and `SymfonyTaskDescriptor` objects;
+  `TaskDescriptor` and `SymfonyTaskDescriptor` objects. It also exposes the
+  `mountPath` (the path of the mount being resolved) and `isRootMount` (whether
+  it is the root application or a mounted one) properties. See
+  [Functions resolved and mounts](#functions-resolved-and-mounts) below;
 
 * `Castor\Event\AfterBootEvent`: This event is triggered when the application is
   ready to execute task
@@ -100,6 +103,39 @@ Here is the built-in events triggered by Castor:
 * `Castor\Event\ContextCreatedEvent`: This event is triggered after a context
   has been created. It allows to update the `Context` that will be used by the
   application.
+
+## Functions resolved and mounts
+
+The `FunctionsResolvedEvent` is dispatched **once per mount**, not once per
+application. When you [mount another application](mount.md), Castor resolves the
+functions of the root application and then of each mounted application
+separately, dispatching a `FunctionsResolvedEvent` for each of them.
+
+This means a listener attached to `FunctionsResolvedEvent` runs several times
+when mounts are involved: once for the root application and once for every
+mount. Each dispatch only carries the `TaskDescriptor` and
+`SymfonyTaskDescriptor` objects resolved for that specific mount, so a listener
+that performs a global, one-time side effect could run more than once.
+
+To only act once, for the root application, guard your listener with the
+`isRootMount` property. The `mountPath` property gives you the filesystem path
+of the mount currently being resolved:
+
+```php
+use Castor\Attribute\AsListener;
+use Castor\Event\FunctionsResolvedEvent;
+
+#[AsListener(event: FunctionsResolvedEvent::class)]
+function on_functions_resolved(FunctionsResolvedEvent $event): void
+{
+    if (!$event->isRootMount) {
+        // Skip mounted applications, only run for the root application
+        return;
+    }
+
+    // Custom logic that must run only once
+}
+```
 
 ## Console events
 

--- a/src/Event/FunctionsResolvedEvent.php
+++ b/src/Event/FunctionsResolvedEvent.php
@@ -11,10 +11,14 @@ class FunctionsResolvedEvent extends Event
     /**
      * @param list<TaskDescriptor>        $taskDescriptors
      * @param list<SymfonyTaskDescriptor> $symfonyTaskDescriptors
+     * @param string                      $mountPath              the filesystem path of the mount currently being resolved
+     * @param bool                        $isRootMount            whether this is the root application (true) or a mounted one (false)
      */
     public function __construct(
         public array $taskDescriptors,
         public array $symfonyTaskDescriptors,
+        public readonly string $mountPath = '',
+        public readonly bool $isRootMount = true,
     ) {
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -131,7 +131,9 @@ final class Kernel
 
         $event = new FunctionsResolvedEvent(
             $descriptorsCollection->taskDescriptors,
-            $descriptorsCollection->symfonyTaskDescriptors
+            $descriptorsCollection->symfonyTaskDescriptors,
+            $mount->path,
+            $mount->path === $this->rootDir,
         );
         $this->eventDispatcher->dispatch($event);
 

--- a/tests/Generated/FunctionsResolvedMountTest.php
+++ b/tests/Generated/FunctionsResolvedMountTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class FunctionsResolvedMountTest extends TaskTestCase
+{
+    // hello
+    public function test(): void
+    {
+        $process = $this->runTask(['hello'], '{{ base }}/tests/fixtures/valid/functions-resolved-mount');
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFileWithCleaning(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertSame('', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/FunctionsResolvedMountTest.php.output.txt
+++ b/tests/Generated/FunctionsResolvedMountTest.php.output.txt
@@ -1,0 +1,3 @@
+FunctionsResolvedEvent dispatched (mountPath: functions-resolved-mount, isRootMount: true) with 1 task(s)
+FunctionsResolvedEvent dispatched (mountPath: mounted, isRootMount: false) with 1 task(s)
+Hello from root

--- a/tests/fixtures/valid/functions-resolved-mount/castor.php
+++ b/tests/fixtures/valid/functions-resolved-mount/castor.php
@@ -1,0 +1,27 @@
+<?php
+
+use Castor\Attribute\AsListener;
+use Castor\Attribute\AsTask;
+use Castor\Event\FunctionsResolvedEvent;
+
+use function Castor\io;
+use function Castor\mount;
+
+mount(__DIR__ . '/mounted');
+
+#[AsTask(description: 'A task in the root application')]
+function hello(): void
+{
+    io()->writeln('Hello from root');
+}
+
+#[AsListener(event: FunctionsResolvedEvent::class)]
+function on_functions_resolved(FunctionsResolvedEvent $event): void
+{
+    io()->writeln(\sprintf(
+        'FunctionsResolvedEvent dispatched (mountPath: %s, isRootMount: %s) with %d task(s)',
+        basename($event->mountPath),
+        $event->isRootMount ? 'true' : 'false',
+        \count($event->taskDescriptors),
+    ));
+}

--- a/tests/fixtures/valid/functions-resolved-mount/mounted/castor.php
+++ b/tests/fixtures/valid/functions-resolved-mount/mounted/castor.php
@@ -1,0 +1,11 @@
+<?php
+
+use Castor\Attribute\AsTask;
+
+use function Castor\io;
+
+#[AsTask(description: 'A task in the mounted application')]
+function world(): void
+{
+    io()->writeln('Hello from mounted');
+}


### PR DESCRIPTION
FunctionsResolvedEvent is fired after each mount which means that if we have a listener in the root castor it will fire multiples times

This PR add 2 fields that allow to know if the event is run on root or on a specific mount path.

Not sure if this is useful, because it is hard to know that this is running on our specific listener. The best way to know that is to have a `static $first = true; if ($!first) return; // ...; $first = false` pattern since the first run on our listener is always the one that is linked to our mount.

Another option would be to "removed" the listener once it has been executed