### PR TITLE
Allow watch() to be called with an array of paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Turn the `SshOptions` type alias into a `@phpstan-type` declared on `SshRunner`, so it resolves without any PHPStan configuration
 * Ship a default `ContextData: 'array<string, mixed>'` PHPStan type alias in `extension.neon`, so projects that do not declare their own context data shape no longer get `class.notFound` errors on `Context::$data` and `variable()`. Declaring the alias in your own `phpstan.neon` still takes precedence, and is now documented in the [context documentation](https://castor.jolicode.com/getting-started/context/#typing-the-context-data)
 * Fix watcher to use correct binary on Linux ARM64
+* Fix `watch()` failing when given an array of paths
 
 ## 1.6.1 (2026-07-02)
 

--- a/src/Runner/WatchRunner.php
+++ b/src/Runner/WatchRunner.php
@@ -34,7 +34,7 @@ final readonly class WatchRunner
             $parallelCallbacks = [];
 
             foreach ($path as $p) {
-                $parallelCallbacks[] = static fn () => self::watch($p, $function, $context);
+                $parallelCallbacks[] = fn () => $this->watch($p, $function, $context);
             }
 
             $this->parallelRunner->parallel(...$parallelCallbacks);

--- a/tests/WatchRunnerTest.php
+++ b/tests/WatchRunnerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Castor\Tests;
+
+use Castor\Console\Application;
+use Castor\Console\Output\SectionOutput;
+use Castor\Context;
+use Castor\ContextRegistry;
+use Castor\Helper\Architecture;
+use Castor\Helper\Installation;
+use Castor\Runner\ParallelRunner;
+use Castor\Runner\ProcessRunner;
+use Castor\Runner\WatchRunner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Process\Process;
+
+class WatchRunnerTest extends TestCase
+{
+    public function testWatchingASinglePathStartsOneWatcher(): void
+    {
+        $this->assertSame(['/path/to/watch'], $this->getWatchedPaths('/path/to/watch'));
+    }
+
+    public function testWatchingAnArrayOfPathsStartsOneWatcherPerPath(): void
+    {
+        $this->assertSame(['/path/to/watch', '/another/path'], $this->getWatchedPaths(['/path/to/watch', '/another/path']));
+    }
+
+    /**
+     * Runs the watcher on the given path(s), and returns the paths the spawned
+     * watcher processes would have watched. The watcher binary is never really
+     * started.
+     *
+     * @param string|non-empty-array<string> $path
+     *
+     * @return list<string>
+     */
+    private function getWatchedPaths(string|array $path): array
+    {
+        $watchedPaths = [];
+
+        $installation = $this->createStub(Installation::class);
+        $installation->method('getArchitecture')->willReturn(Architecture::Amd64);
+
+        $processRunner = $this->createStub(ProcessRunner::class);
+        $processRunner
+            ->method('run')
+            ->willReturnCallback(static function (array $command) use (&$watchedPaths): Process {
+                $watchedPaths[] = $command[1];
+
+                return new Process($command);
+            })
+        ;
+
+        new WatchRunner(
+            $this->createStub(ContextRegistry::class),
+            new ParallelRunner($this->createStub(Application::class), new NullOutput()),
+            $processRunner,
+            $this->createStub(SectionOutput::class),
+            $installation,
+        )->watch($path, static function (): void {}, new Context());
+
+        return $watchedPaths;
+    }
+}


### PR DESCRIPTION
calling `self::watch()` in a `static` closure was failing because `watch()` is not static, so calling it needs a context where `$this` is available. 