### PR TITLE
Fix run() timeout being ignored inside parallel()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released yet
 
+### Fixes
+
+* Fix `run()` ignoring the timeout when executed inside `parallel()`: the process was waited for in its own fiber loop, so Symfony's timeout check never ran and the process could run forever
+
 ## 1.7.0 (2026-08-03)
 
 ### Features

--- a/bin/generate-tests.php
+++ b/bin/generate-tests.php
@@ -202,6 +202,7 @@ add_test(['hello'], 'FunctionsResolvedMount', '{{ base }}/tests/fixtures/valid/f
 add_test(['list'], 'LayoutWithFolder', '{{ base }}/tests/fixtures/valid/layout-with-folder');
 add_test([], 'ImportSamePackageWithDefaultVersion', '{{ base }}/tests/fixtures/valid/import-same-package-with-default-version', needRemote: true, needResetVendor: true);
 add_test(['fs-watch'], 'WatchWithForcedTimeout', '{{ base }}/tests/fixtures/valid/watch-with-forced-timeout');
+add_test(['parallel-timeout'], 'ParallelTimeout', '{{ base }}/tests/fixtures/valid/parallel-timeout');
 add_test([], 'DefaultTask', '{{ base }}/tests/fixtures/valid/default-task');
 add_test([], 'ContextRunWithoutContext', '{{ base }}/tests/fixtures/valid/context-run-without-context');
 add_test(['--castor-file', 'idonotexist', 'hello'], 'CastorFileDoesNotExist');

--- a/src/Runner/ProcessRunner.php
+++ b/src/Runner/ProcessRunner.php
@@ -114,15 +114,16 @@ class ProcessRunner
 
         $this->eventDispatcher->dispatch(new ProcessStartEvent($process));
 
-        if (\Fiber::getCurrent()) {
-            while ($process->isRunning()) {
-                $this->sectionOutput->tickProcess($process);
-                \Fiber::suspend();
-                usleep(20_000);
-            }
-        }
-
         try {
+            if (\Fiber::getCurrent()) {
+                while ($process->isRunning()) {
+                    $this->sectionOutput->tickProcess($process);
+                    $process->checkTimeout();
+                    \Fiber::suspend();
+                    usleep(20_000);
+                }
+            }
+
             $exitCode = $process->wait();
         } finally {
             $this->sectionOutput->finishProcess($process);

--- a/tests/Generated/ParallelTimeoutTest.php
+++ b/tests/Generated/ParallelTimeoutTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class ParallelTimeoutTest extends TaskTestCase
+{
+    // parallel-timeout
+    public function test(): void
+    {
+        $process = $this->runTask(['parallel-timeout'], '{{ base }}/tests/fixtures/valid/parallel-timeout');
+
+        if (1 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFileWithCleaning(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertStringEqualsFileWithCleaning(__FILE__ . '.err.txt', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/ParallelTimeoutTest.php.err.txt
+++ b/tests/Generated/ParallelTimeoutTest.php.err.txt
@@ -1,0 +1,15 @@
+In castor.php line XXXX:
+
+  The process "sleep 30" exceeded the timeout of 1 seconds.
+
+
+parallel-timeout
+
+
+In castor.php line XXXX:
+
+  One or more exceptions were thrown in parallel.
+
+
+parallel-timeout
+

--- a/tests/fixtures/valid/parallel-timeout/castor.php
+++ b/tests/fixtures/valid/parallel-timeout/castor.php
@@ -1,0 +1,15 @@
+<?php
+
+use Castor\Attribute\AsTask;
+
+use function Castor\context;
+use function Castor\parallel;
+use function Castor\run;
+
+#[AsTask()]
+function parallel_timeout(): void
+{
+    parallel(
+        static fn () => run('sleep 30', context: context()->withTimeout(1)),
+    );
+}


### PR DESCRIPTION
When `run()` is called inside a `parallel()` block, the process is awaited in a
dedicated fiber loop instead of `Process::wait()`. That loop never called
`checkTimeout()`, so the timeout was silently ignored: by the time `wait()` was
finally reached the process was already finished, and Symfony's `checkTimeout()`
returns immediately when the status is no longer `STATUS_STARTED`.

Concretely, `run('sleep 30', context: context()->withTimeout(1))` ran for 30
seconds and exited successfully.

The fix adds `$process->checkTimeout()` to the fiber loop, and moves the loop
inside the existing `try`/`finally` — since the loop can now throw
`ProcessTimedOutException`, the cleanup (`finishProcess()` and
`ProcessTerminateEvent`) must still run.

A `parallel-timeout` fixture and its generated test cover the regression: on
`main` the test errors after 30s with `Expected a failed process, but the given
process was successful.`, and passes in ~1.5s with the fix.