### PR TITLE
Attest the provenance of the release binaries and verify it in self-update

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: write # zizmor: ignore[excessive-permissions]
+  id-token: write # zizmor: ignore[excessive-permissions]
+  attestations: write # zizmor: ignore[excessive-permissions]
 
 jobs:
   phars:
@@ -23,6 +25,11 @@ jobs:
           composer-flags: --no-dev
 
       - uses: ./.github/actions/phar
+
+      - name: Attest the phars provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: tools/phar/build/castor.*.phar
 
       - name: Upload the Linux phar (linux-amd64)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -88,6 +95,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Attest the static binary provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ./castor.linux-amd64
+
       - name: Upload the Linux amd64 static binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -122,6 +134,11 @@ jobs:
           os: linux-arm64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest the static binary provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ./castor.linux-arm64
 
       - name: Upload the Linux arm64 static binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -158,6 +175,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Attest the static binary provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ./castor.darwin-amd64
+
       - name: Upload the MacOs amd64 static binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -192,6 +214,11 @@ jobs:
           os: darwin-arm64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest the static binary provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ./castor.darwin-arm64
 
       - name: Upload the MacOs arm64 static binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 * Add `self-update` command to update Castor to the latest version
-* Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer and in `self-update` when the GitHub CLI is installed and authenticated
+* Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer, in `self-update` and in `castor:repack` when the GitHub CLI is installed and authenticated
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 * Add `self-update` command to update Castor to the latest version
-* Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in `self-update` when the GitHub CLI is installed and authenticated
+* Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer and in `self-update` when the GitHub CLI is installed and authenticated
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * Add `self-update` command to update Castor to the latest version
+* Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in `self-update` when the GitHub CLI is installed and authenticated
 
 ### Fixes
 

--- a/doc/docs/going-further/extending-castor/repack.md
+++ b/doc/docs/going-further/extending-castor/repack.md
@@ -43,6 +43,11 @@ castor repack
 > If some classes are missing in your phar, it might be because they are
 > excluded by castor's `box.json` file. In this case, you should override the
 > default configuration with a local `box.json` file
+<!-- -->
+> [!NOTE]
+> The Castor phar embedded in your application is downloaded from the GitHub
+> releases. When the [GitHub CLI](https://cli.github.com/) is installed and
+> authenticated, its provenance is verified with `gh attestation verify`.
 
 {% include-markdown "/build/command_castor-repack.md" start="`castor:repack`\n---------------" %}
 

--- a/doc/installation/installer.md
+++ b/doc/installation/installer.md
@@ -73,9 +73,9 @@ castor self-update
 - `--rollback` or `-r`: Rollback to the previous version
 
 When the [GitHub CLI](https://cli.github.com/) is installed and authenticated,
-`self-update` also verifies the provenance of the downloaded binary: it checks,
-with `gh attestation verify`, that the binary was built by Castor's own GitHub
-Actions workflow.
+the installer and `self-update` also verify the provenance of the downloaded
+binary: they check, with `gh attestation verify`, that the binary was built by
+Castor's own GitHub Actions workflow.
 
 > [!NOTE]
 > The `self-update` command is not available for source installations or Composer

--- a/doc/installation/installer.md
+++ b/doc/installation/installer.md
@@ -72,6 +72,11 @@ castor self-update
 - `--no-backup`: Skip creating a backup of the current binary
 - `--rollback` or `-r`: Rollback to the previous version
 
+When the [GitHub CLI](https://cli.github.com/) is installed and authenticated,
+`self-update` also verifies the provenance of the downloaded binary: it checks,
+with `gh attestation verify`, that the binary was built by Castor's own GitHub
+Actions workflow.
+
 > [!NOTE]
 > The `self-update` command is not available for source installations or Composer
 > project dependencies. For global Composer installs (`composer global require`),

--- a/installer/bash-installer
+++ b/installer/bash-installer
@@ -200,6 +200,25 @@ if [ $http_code != 200 ]; then
     exit 1
 fi
 
+# Verify the binary provenance with the GitHub CLI when it is installed and
+# authenticated (the attestations API rejects anonymous requests).
+output "\nProvenance check" "heading"
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    if verify_output=$(gh attestation verify "${CASTOR_TMPDIR}/${CASTOR_TMP_NAME}" --repo jolicode/castor 2>&1); then
+        output "  [*] The binary was built by the Castor GitHub Actions workflow" "success"
+    elif [[ "${verify_output}" == *"HTTP 404"* || "${verify_output}" == *"no attestations found"* ]]; then
+        # Releases published before attestations were introduced have none
+        output "  [ ] WARNING: no attestation found for this binary, its provenance cannot be verified" "warning"
+    else
+        output "  [ ] ERROR: the provenance of the downloaded binary could not be verified" "error"
+        output "${verify_output}" "error"
+        rm "${CASTOR_TMPDIR}/${CASTOR_TMP_NAME}"
+        exit 1
+    fi
+else
+    output "  [ ] Provenance not verified: install and log in to the GitHub CLI (gh) to verify downloads" "warning"
+fi
+
 if [ ! -d "${binary_dest}" ]; then
     # Backward-compatible quick fix: if --install-dir points to the castor binary path,
     # install into its parent directory.

--- a/src/Console/Command/RepackCommand.php
+++ b/src/Console/Command/RepackCommand.php
@@ -3,6 +3,8 @@
 namespace Castor\Console\Command;
 
 use Castor\Console\Application;
+use Castor\Helper\AttestationHelper;
+use Castor\Helper\AttestationStatus;
 use Castor\Helper\PathHelper;
 use Castor\Import\Importer;
 use Castor\Import\Remote\Composer;
@@ -32,6 +34,7 @@ class RepackCommand extends Command
         private readonly Filesystem $fs,
         #[Autowire(lazy: true)]
         private readonly SymfonyStyle $io,
+        private readonly AttestationHelper $attestationHelper,
     ) {
         parent::__construct();
     }
@@ -274,6 +277,8 @@ class RepackCommand extends Command
             ;
 
             $this->fs->dumpFile($pharPath, $pharContent);
+
+            $this->verifyProvenance($pharPath);
         }
 
         $this->io->comment('Extracting Castor phar...');
@@ -289,5 +294,22 @@ class RepackCommand extends Command
         $this->io->comment('Castor sources extracted to .castor-vendor');
 
         return $extractDir;
+    }
+
+    private function verifyProvenance(string $pharPath): void
+    {
+        try {
+            $status = $this->attestationHelper->verify($pharPath);
+        } catch (\RuntimeException $e) {
+            $this->fs->remove($pharPath);
+
+            throw $e;
+        }
+
+        match ($status) {
+            AttestationStatus::Verified => $this->io->comment('Castor phar provenance verified.'),
+            AttestationStatus::NotAttested => $this->io->warning('No attestation found for this Castor release, its provenance cannot be verified.'),
+            AttestationStatus::Skipped => $this->io->comment('Install and log in to the GitHub CLI (gh) to verify the provenance of the downloaded Castor phar.'),
+        };
     }
 }

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /** @internal */
@@ -128,6 +129,12 @@ final readonly class SelfUpdateCommand
             $this->httpDownloader->download($downloadUrl, $tempFile);
             $this->filesystem->chmod($tempFile, 0o755);
 
+            if (!$this->verifyProvenance($io, $tempFile)) {
+                $this->filesystem->remove($tempFile);
+
+                return Command::FAILURE;
+            }
+
             $io->text('Verifying new binary...');
             $verifyProcess = new Process([$tempFile, '--version']);
             $verifyProcess->run();
@@ -155,6 +162,44 @@ final readonly class SelfUpdateCommand
         $io->text('Replacing current binary...');
 
         $this->replaceRunningBinary($tempFile, $currentPath, \sprintf('Castor has been updated from %s to %s!', $currentVersion, $latestTag));
+    }
+
+    /**
+     * Checks that the binary was built by our GitHub Actions workflow, using
+     * the artifact attestation published with each build.
+     *
+     * This needs the GitHub CLI, installed and authenticated: the attestations
+     * API rejects anonymous requests. Without it, the update goes on unverified.
+     */
+    private function verifyProvenance(SymfonyStyle $io, string $binary): bool
+    {
+        $gh = new ExecutableFinder()->find('gh');
+
+        if (null === $gh || 0 !== new Process([$gh, 'auth', 'status'])->run()) {
+            $io->note('Install and log in to the GitHub CLI (gh) to verify the provenance of the downloaded binary.');
+
+            return true;
+        }
+
+        $io->text('Verifying the binary provenance...');
+
+        $process = new Process([$gh, 'attestation', 'verify', $binary, '--repo', 'jolicode/castor']);
+        $process->setTimeout(60);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            $error = trim($process->getErrorOutput());
+
+            if (str_contains($error, 'HTTP 404') || str_contains($error, 'no attestations found')) {
+                $io->error('No attestation found on GitHub for the downloaded binary, so it cannot be trusted as a Castor build. Update aborted.');
+            } else {
+                $io->error(['The provenance of the downloaded binary could not be verified. Update aborted.', $error]);
+            }
+
+            return false;
+        }
+
+        return true;
     }
 
     private function handleUnsupportedInstallationMethod(SymfonyStyle $io, InstallationMethod $installationMethod): int

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -3,6 +3,8 @@
 namespace Castor\Console\Command;
 
 use Castor\Console\Application;
+use Castor\Helper\AttestationHelper;
+use Castor\Helper\AttestationStatus;
 use Castor\Helper\Installation;
 use Castor\Helper\InstallationMethod;
 use Castor\Helper\ReleaseHelper;
@@ -13,7 +15,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /** @internal */
@@ -26,6 +27,7 @@ final readonly class SelfUpdateCommand
 {
     public function __construct(
         private ReleaseHelper $releaseHelper,
+        private AttestationHelper $attestationHelper,
         private HttpDownloader $httpDownloader,
         private Installation $installation,
         private Filesystem $filesystem,
@@ -165,41 +167,26 @@ final readonly class SelfUpdateCommand
     }
 
     /**
-     * Checks that the binary was built by our GitHub Actions workflow, using
-     * the artifact attestation published with each build.
-     *
-     * This needs the GitHub CLI, installed and authenticated: the attestations
-     * API rejects anonymous requests. Without it, the update goes on unverified.
+     * Aborts the update when the binary has no attestation: the latest release
+     * always has one, so a missing attestation means this is not our build.
+     * Without an authenticated GitHub CLI, the update goes on unverified.
      */
     private function verifyProvenance(SymfonyStyle $io, string $binary): bool
     {
-        $gh = new ExecutableFinder()->find('gh');
-
-        if (null === $gh || 0 !== new Process([$gh, 'auth', 'status'])->run()) {
-            $io->note('Install and log in to the GitHub CLI (gh) to verify the provenance of the downloaded binary.');
-
-            return true;
-        }
-
         $io->text('Verifying the binary provenance...');
 
-        $process = new Process([$gh, 'attestation', 'verify', $binary, '--repo', 'jolicode/castor']);
-        $process->setTimeout(60);
-        $process->run();
+        switch ($this->attestationHelper->verify($binary)) {
+            case AttestationStatus::Skipped:
+                $io->note('Install and log in to the GitHub CLI (gh) to verify the provenance of the downloaded binary.');
 
-        if (!$process->isSuccessful()) {
-            $error = trim($process->getErrorOutput());
-
-            if (str_contains($error, 'HTTP 404') || str_contains($error, 'no attestations found')) {
+                return true;
+            case AttestationStatus::Verified:
+                return true;
+            case AttestationStatus::NotAttested:
                 $io->error('No attestation found on GitHub for the downloaded binary, so it cannot be trusted as a Castor build. Update aborted.');
-            } else {
-                $io->error(['The provenance of the downloaded binary could not be verified. Update aborted.', $error]);
-            }
 
-            return false;
+                return false;
         }
-
-        return true;
     }
 
     private function handleUnsupportedInstallationMethod(SymfonyStyle $io, InstallationMethod $installationMethod): int

--- a/src/Helper/AttestationHelper.php
+++ b/src/Helper/AttestationHelper.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Castor\Helper;
+
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * Checks that a file was built by the Castor GitHub Actions workflow, using
+ * the artifact attestation published with each build.
+ *
+ * This needs the GitHub CLI, installed and authenticated: the attestations API
+ * rejects anonymous requests.
+ *
+ * @internal
+ */
+final readonly class AttestationHelper
+{
+    /**
+     * @throws \RuntimeException when the attestation exists but does not match
+     */
+    public function verify(string $file): AttestationStatus
+    {
+        $gh = new ExecutableFinder()->find('gh');
+
+        if (null === $gh || 0 !== new Process([$gh, 'auth', 'status'])->run()) {
+            return AttestationStatus::Skipped;
+        }
+
+        $process = new Process([$gh, 'attestation', 'verify', $file, '--repo', 'jolicode/castor']);
+        $process->setTimeout(60);
+        $process->run();
+
+        if ($process->isSuccessful()) {
+            return AttestationStatus::Verified;
+        }
+
+        $error = trim($process->getErrorOutput());
+
+        if (str_contains($error, 'HTTP 404') || str_contains($error, 'no attestations found')) {
+            return AttestationStatus::NotAttested;
+        }
+
+        throw new \RuntimeException(\sprintf("The provenance of \"%s\" could not be verified:\n%s", $file, $error));
+    }
+}

--- a/src/Helper/AttestationStatus.php
+++ b/src/Helper/AttestationStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Castor\Helper;
+
+/** @internal */
+enum AttestationStatus
+{
+    /** The GitHub CLI is not installed or not authenticated: no check possible */
+    case Skipped;
+    case Verified;
+    /** No attestation exists for this file (e.g. a release published before attestations) */
+    case NotAttested;
+}

--- a/tests/Slow/SelfUpdateCommandTest.php
+++ b/tests/Slow/SelfUpdateCommandTest.php
@@ -31,6 +31,7 @@ class SelfUpdateCommandTest extends TaskTestCase
 
         $process = $this->runSelfUpdate($castor);
         $this->assertSame(0, $process->getExitCode(), $process->getOutput() . $process->getErrorOutput());
+        $this->assertStringContainsString('to verify the provenance', $process->getOutput());
         $this->assertStringContainsString('to v99.0.0!', $process->getOutput());
         $this->assertNotSame($inode, fileinode($castor), 'The binary has been replaced');
         $this->assertFileEquals(self::$castorBin, $castor);
@@ -56,6 +57,11 @@ class SelfUpdateCommandTest extends TaskTestCase
             [$castor, 'castor:self-update', '--no-ansi', ...$args],
             cwd: \dirname($castor),
             env: [
+                // Make sure gh is not authenticated: the fake release has no
+                // attestation, so the provenance check must be skipped
+                'GH_CONFIG_DIR' => \dirname($castor) . '/gh-config',
+                'GH_TOKEN' => false,
+                'GITHUB_TOKEN' => false,
                 'CASTOR_RELEASES_URL' => $_SERVER['ENDPOINT'] . '/self-update/release.php',
                 'CASTOR_CACHE_DIR' => self::$castorCacheDir,
                 'CASTOR_DISABLE_AGENT_DETECTION' => 'true',


### PR DESCRIPTION
Follow-up of #851.

- The Artifacts workflow attests the phars and static binaries with `actions/attest-build-provenance`: SLSA provenance signed with the workflow identity, bound to the file digest, no key to manage. Anyone can check a release asset with `gh attestation verify castor.linux-amd64.phar --repo jolicode/castor`.
- `castor:self-update`, the installer and `castor:repack` (for the Castor phar it downloads from the releases and embeds in the application) run that check on the downloaded file when the GitHub CLI is installed and authenticated. It cannot be mandatory: the attestations API rejects anonymous requests. `self-update` aborts on any failure; the installer and `repack` fail on a verification failure but only warn when no attestation exists, since older releases have none.

Tested on `pyrech/castor-test` (https://github.com/pyrech/castor-test/actions/runs/32903785919): the attested phar and static binary verify, and both `self-update` paths were exercised against them.

The workflow change must land before or together with the others.