### PR TITLE
Publish snapshot builds of main and add self-update --snapshot

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # The tags are needed to compute the snapshot version
+          fetch-depth: 0
 
       - uses: ./.github/actions/install
         with:
@@ -226,3 +228,35 @@ jobs:
           name: castor.darwin-arm64
           path: ./castor.darwin-arm64
           if-no-files-found: error
+
+  snapshot:
+    needs: [phars, static-linux-amd64, static-linux-arm64, static-darwin-amd64, static-darwin-arm64]
+    name: Publish the snapshot pre-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Retrieve all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Publish the artifacts to the snapshot pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          version=$(git describe --tags --match 'v*')
+          notes="Snapshot of the main branch, built from ${GITHUB_SHA}. Install it with \`--version=snapshot\` or \`castor self-update --snapshot\`."
+          if gh release view snapshot >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/snapshot" -f sha="${GITHUB_SHA}" -F force=true
+            gh release edit snapshot --prerelease --title "${version}" --notes "${notes}"
+          else
+            gh release create snapshot --target "${GITHUB_SHA}" --prerelease --title "${version}" --notes "${notes}"
+          fi
+          gh release upload snapshot artifacts/* --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Add `self-update` command to update Castor to the latest version
 * Publish a `snapshot` pre-release of the `main` branch on each push, installable with the installer `--version=snapshot` option or `castor self-update --snapshot`
 * Phars and static binaries built from a commit that is not a release now report a snapshot version, like `v1.7.0-14-g4531440`
+
+### Security
+
 * Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer, in `self-update` and in `castor:repack` when the GitHub CLI is installed and authenticated
 
 ### Fixes
@@ -46,15 +49,15 @@
 * Remove castor header and upgrade output when running inside an ai agent
 * Add support for `.castor.context` file to set the default context (lowest precedence after `--context` flag and `CASTOR_CONTEXT` env var)
 
-## Security
+### Security
 
 * Harden the security of our GitHub Actions Workflows
 
-## Fixes
+### Fixes
 
 * Fix option mode detection from Symfony command definition
 
-## Internal
+### Internal
 
 * Upgrade to Symfony 8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features
 
 * Add `self-update` command to update Castor to the latest version
+* Publish a `snapshot` pre-release of the `main` branch on each push, installable with the installer `--version=snapshot` option or `castor self-update --snapshot`
+* Phars and static binaries built from a commit that is not a release now report a snapshot version, like `v1.7.0-14-g4531440`
 * Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer, in `self-update` and in `castor:repack` when the GitHub CLI is installed and authenticated
 
 ### Fixes

--- a/doc/installation/installer.md
+++ b/doc/installation/installer.md
@@ -102,6 +102,11 @@ A snapshot reports a version like `v1.7.0-14-g4531440`: the last release, the
 number of commits since, and the commit it was built from. To go back to the
 latest release, run `castor self-update` without `--snapshot`.
 
+> [!NOTE]
+> Right after a push, the installer may still get the previous snapshot for a
+> few minutes: GitHub caches the release downloads by name. `self-update`
+> is not affected.
+
 ## Other installation methods
 
 If you cannot use the installer, see

--- a/doc/installation/installer.md
+++ b/doc/installation/installer.md
@@ -83,6 +83,25 @@ Castor's own GitHub Actions workflow.
 > `self-update` runs `composer global update` under the hood. For project
 > dependencies, use `composer update jolicode/castor` instead.
 
+## Snapshot builds
+
+Every push on the `main` branch publishes a `snapshot` pre-release, so you can
+try what is coming next before it is released. Install it with:
+
+```bash
+curl "https://castor.jolicode.com/install" | bash -s -- --version=snapshot
+```
+
+or, from an existing installation:
+
+```bash
+castor self-update --snapshot
+```
+
+A snapshot reports a version like `v1.7.0-14-g4531440`: the last release, the
+number of commits since, and the commit it was built from. To go back to the
+latest release, run `castor self-update` without `--snapshot`.
+
 ## Other installation methods
 
 If you cannot use the installer, see

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -42,6 +42,15 @@ class Application extends SymfonyApplication
     }
 
     /**
+     * Whether this build comes from a commit that is not a release: the phar
+     * build then sets a version like "v1.7.0-14-g4531440".
+     */
+    public static function isSnapshot(): bool
+    {
+        return str_contains(self::VERSION, '-');
+    }
+
+    /**
      * @return ($allowNull is true ? ?Command : Command)
      */
     public function getCommand(bool $allowNull = false): ?Command

--- a/src/Console/Command/RepackCommand.php
+++ b/src/Console/Command/RepackCommand.php
@@ -6,6 +6,7 @@ use Castor\Console\Application;
 use Castor\Helper\AttestationHelper;
 use Castor\Helper\AttestationStatus;
 use Castor\Helper\PathHelper;
+use Castor\Helper\ReleaseHelper;
 use Castor\Import\Importer;
 use Castor\Import\Remote\Composer;
 use Symfony\Component\Console\Command\Command;
@@ -48,7 +49,7 @@ class RepackCommand extends Command
             ->addOption('app-version', null, InputOption::VALUE_REQUIRED, 'The version of the phar application', '1.0.0')
             ->addOption('os', null, InputOption::VALUE_REQUIRED, 'The targeted OS', 'linux', ['linux', 'darwin', 'windows'])
             ->addOption('arch', null, InputOption::VALUE_REQUIRED, 'The targeted CPU architecture', 'amd64', ['amd64', 'arm64'])
-            ->addOption('castor-version', null, InputOption::VALUE_REQUIRED, 'The Castor version to use (vX.Y.Z)', Application::VERSION)
+            ->addOption('castor-version', null, InputOption::VALUE_REQUIRED, 'The Castor version to use (vX.Y.Z, or snapshot)', Application::isSnapshot() ? ReleaseHelper::SNAPSHOT_TAG : Application::VERSION)
             ->addOption('castor-phar', null, InputOption::VALUE_REQUIRED, 'A specific castor phar to use (/path/to/castor.phar)')
             ->addOption('no-logo', null, InputOption::VALUE_NONE, 'Hide Castor logo')
             ->addOption('logo-file', null, InputOption::VALUE_OPTIONAL, 'Path to a PHP file that returns a logo as a string, or a closure that returns a logo as a string')

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -42,6 +42,8 @@ final readonly class SelfUpdateCommand
         bool $noBackup = false,
         #[Option(description: 'Rollback to the previous version', shortcut: 'r')]
         bool $rollback = false,
+        #[Option(description: 'Update to the latest snapshot of the main branch')]
+        bool $snapshot = false,
     ): int {
         $installationMethod = $this->installation->getMethod();
         $currentPath = $this->installation->getPath();
@@ -58,7 +60,7 @@ final readonly class SelfUpdateCommand
             return $this->updateViaComposer($io);
         }
 
-        return $this->updateBinary($io, $force, $noBackup, $currentPath);
+        return $this->updateBinary($io, $force, $noBackup, $snapshot, $currentPath);
     }
 
     private function updateViaComposer(SymfonyStyle $io): int
@@ -76,13 +78,15 @@ final readonly class SelfUpdateCommand
         return Command::SUCCESS;
     }
 
-    private function updateBinary(SymfonyStyle $io, bool $force, bool $noBackup, string $currentPath): int
+    private function updateBinary(SymfonyStyle $io, bool $force, bool $noBackup, bool $snapshot, string $currentPath): int
     {
         $io->section('Checking for updates...');
 
         // Always hit GitHub here: the user explicitly asked for an update, a
         // day-old cached release would be misleading
-        $latestVersion = $this->releaseHelper->getLatest(useCache: false, timeout: 10);
+        $latestVersion = $snapshot
+            ? $this->releaseHelper->getRelease(ReleaseHelper::SNAPSHOT_TAG, useCache: false, timeout: 10)
+            : $this->releaseHelper->getLatest(useCache: false, timeout: 10);
 
         if (null === $latestVersion) {
             $io->error('Failed to fetch latest version information from GitHub.');
@@ -90,22 +94,35 @@ final readonly class SelfUpdateCommand
             return Command::FAILURE;
         }
 
-        $latestTag = $latestVersion['tag_name'];
+        // Releases are named after their tag, the snapshot pre-release after
+        // the version it was built from (e.g. v1.7.0-14-g4531440)
+        $latestTag = $snapshot ? $latestVersion['name'] : $latestVersion['tag_name'];
         $currentVersion = Application::VERSION;
 
         $io->text(\sprintf('Current version: <info>%s</info>', $currentVersion));
-        $io->text(\sprintf('Latest version:  <info>%s</info>', $latestTag));
+        $io->text(\sprintf('Latest %s: <info>%s</info>', $snapshot ? 'snapshot' : 'version', $latestTag));
         $io->newLine();
 
-        if (!$force && version_compare($latestTag, $currentVersion, '<=')) {
+        // Snapshot versions do not compare with releases: a snapshot is only
+        // up to date when it is the latest one, and a release is always "newer"
+        // than a snapshot for someone leaving the snapshots
+        $upToDate = $snapshot || Application::isSnapshot()
+            ? $latestTag === $currentVersion
+            : version_compare($latestTag, $currentVersion, '<=');
+
+        if (!$force && $upToDate) {
             $io->success('You are already using the latest version of Castor.');
 
             return Command::SUCCESS;
         }
 
-        $downloadUrl = $this->releaseHelper->getDownloadUrl($latestVersion);
+        if (Application::isSnapshot() && !$snapshot) {
+            $io->note('You are running a snapshot: switching back to the latest release. Use --snapshot to stay on the snapshots.');
+        }
 
-        if (null === $downloadUrl) {
+        $asset = $this->releaseHelper->getDownloadAsset($latestVersion);
+
+        if (null === $asset) {
             $io->error('Could not find a suitable download for your platform.');
 
             return Command::FAILURE;
@@ -120,7 +137,7 @@ final readonly class SelfUpdateCommand
             return Command::FAILURE;
         }
 
-        $io->text(\sprintf('Downloading from: <comment>%s</comment>', $downloadUrl));
+        $io->text(\sprintf('Downloading <comment>%s</comment>', $asset['browser_download_url']));
 
         // Download next to the current binary: the final rename() must happen
         // on the same filesystem, and the temp dir is often a different one
@@ -128,7 +145,8 @@ final readonly class SelfUpdateCommand
         $backupPath = $noBackup ? null : $currentPath . '.backup';
 
         try {
-            $this->httpDownloader->download($downloadUrl, $tempFile);
+            // Through the API URL of the asset, see ReleaseHelper::getDownloadAsset()
+            $this->httpDownloader->download($asset['url'], $tempFile, options: ['headers' => ['Accept' => 'application/octet-stream']]);
             $this->filesystem->chmod($tempFile, 0o755);
 
             if (!$this->verifyProvenance($io, $tempFile)) {

--- a/src/Helper/ReleaseHelper.php
+++ b/src/Helper/ReleaseHelper.php
@@ -13,6 +13,11 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /** @internal */
 final readonly class ReleaseHelper
 {
+    /** The rolling pre-release of the main branch, see the Artifacts workflow */
+    public const string SNAPSHOT_TAG = 'snapshot';
+
+    private const string API_URL = 'https://api.github.com/repos/jolicode/castor/releases';
+
     public function __construct(
         private CacheItemPoolInterface&CacheInterface $cache,
         private HttpClientInterface $httpClient,
@@ -30,32 +35,18 @@ final readonly class ReleaseHelper
      */
     public function getLatest(bool $useCache = true, float $timeout = 1): ?array
     {
-        $item = $this->cache->getItem('castor-releases');
+        return $this->fetch('/latest', 'castor-releases', $useCache, $timeout);
+    }
 
-        if ($item->isHit() && $useCache) {
-            return $item->get();
-        }
-
-        $latestVersion = null;
-        $item->expiresAfter(60 * 60 * 24);
-
-        try {
-            $latestVersion = $this
-                ->httpClient
-                ->request('GET', PlatformHelper::getEnv('CASTOR_RELEASES_URL') ?: 'https://api.github.com/repos/jolicode/castor/releases/latest', [
-                    'timeout' => $timeout,
-                ])
-                ->toArray()
-            ;
-        } catch (ExceptionInterface) {
-            $this->logger->info('Failed to fetch latest Castor version from GitHub.');
-
-            $item->expiresAfter(60 * 10);
-        }
-
-        $this->cache->save($item->set($latestVersion));
-
-        return $latestVersion;
+    /**
+     * Returns the GitHub release payload of the given tag, or null if it could
+     * not be fetched. Same caching as getLatest().
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getRelease(string $tag, bool $useCache = true, float $timeout = 1): ?array
+    {
+        return $this->fetch('/tags/' . $tag, 'castor-release-' . $tag, $useCache, $timeout);
     }
 
     /**
@@ -65,6 +56,23 @@ final readonly class ReleaseHelper
      * @param array<string, mixed> $release
      */
     public function getDownloadUrl(array $release): ?string
+    {
+        return $this->getDownloadAsset($release)['browser_download_url'] ?? null;
+    }
+
+    /**
+     * Returns the release asset matching the current OS, architecture and
+     * installation method (phar or static binary).
+     *
+     * Its "url" is the API URL of the asset: unlike "browser_download_url",
+     * it is not cached by name by the GitHub CDN, which matters for the
+     * snapshot whose assets are replaced on each push.
+     *
+     * @param array<string, mixed> $release
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getDownloadAsset(array $release): ?array
     {
         $assets = $release['assets'] ?? [];
 
@@ -84,6 +92,40 @@ final readonly class ReleaseHelper
             $assets = array_filter($assets, static fn (array $asset): bool => str_ends_with((string) $asset['name'], '.phar'));
         }
 
-        return array_first($assets)['browser_download_url'] ?? null;
+        return array_first($assets);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function fetch(string $path, string $cacheKey, bool $useCache, float $timeout): ?array
+    {
+        $item = $this->cache->getItem($cacheKey);
+
+        if ($item->isHit() && $useCache) {
+            return $item->get();
+        }
+
+        $release = null;
+        $item->expiresAfter(60 * 60 * 24);
+
+        try {
+            $release = $this
+                ->httpClient
+                // The base URL can be overridden, e.g. by the test suite
+                ->request('GET', (PlatformHelper::getEnv('CASTOR_RELEASES_URL') ?: self::API_URL) . $path, [
+                    'timeout' => $timeout,
+                ])
+                ->toArray()
+            ;
+        } catch (ExceptionInterface) {
+            $this->logger->info(\sprintf('Failed to fetch the Castor release "%s" from GitHub.', $path));
+
+            $item->expiresAfter(60 * 10);
+        }
+
+        $this->cache->save($item->set($release));
+
+        return $release;
     }
 }

--- a/src/Listener/UpdateCastorListener.php
+++ b/src/Listener/UpdateCastorListener.php
@@ -86,6 +86,12 @@ class UpdateCastorListener
 
     private function displayUpdateWarningIfNeeded(InputInterface $input, OutputInterface $output, bool $useCache = true): void
     {
+        if (Application::isSnapshot()) {
+            $this->displaySnapshotUpdateWarningIfNeeded($input, $output, $useCache);
+
+            return;
+        }
+
         $latestVersion = $this->releaseHelper->getLatest($useCache);
 
         if (!$latestVersion) {
@@ -127,5 +133,22 @@ class UpdateCastorListener
             $symfonyStyle->block('Run the following command to update Castor:');
             $symfonyStyle->block('<comment>castor self-update</comment>', escape: false);
         }
+    }
+
+    private function displaySnapshotUpdateWarningIfNeeded(InputInterface $input, OutputInterface $output, bool $useCache): void
+    {
+        $snapshot = $this->releaseHelper->getRelease(ReleaseHelper::SNAPSHOT_TAG, $useCache);
+
+        // The snapshot pre-release is named after the version it was built from
+        if (!$snapshot || ($snapshot['name'] ?? null) === Application::VERSION) {
+            return;
+        }
+
+        $symfonyStyle = new SymfonyStyle($input, $output);
+
+        $symfonyStyle->block(\sprintf('<info>A new Castor snapshot is available</info> (<comment>%s</comment>, currently running <comment>%s</comment>).', $snapshot['name'], Application::VERSION), escape: false);
+        $symfonyStyle->block('Run the following command to update Castor:');
+        $symfonyStyle->block('<comment>castor self-update --snapshot</comment>', escape: false);
+        $symfonyStyle->newLine();
     }
 }

--- a/tests/Generated/CastorSelfUpdateTest.php
+++ b/tests/Generated/CastorSelfUpdateTest.php
@@ -10,7 +10,7 @@ class CastorSelfUpdateTest extends TaskTestCase
     // castor:self-update
     public function test(): void
     {
-        $process = $this->runTask(['castor:self-update', '--force', '--no-backup', '--rollback']);
+        $process = $this->runTask(['castor:self-update', '--force', '--no-backup', '--rollback', '--snapshot']);
 
         if (1 !== $process->getExitCode()) {
             throw new ProcessFailedException($process);

--- a/tests/Helper/OutputCleaner.php
+++ b/tests/Helper/OutputCleaner.php
@@ -58,7 +58,7 @@ final class OutputCleaner
         $string = preg_replace('{Composer version \d+.\d+.\d+ \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}}', 'Composer version 1.2.3', $string);
 
         // castor version
-        $string = preg_replace('{you are using v\d+.\d+.\d+.}m', 'you are using vX.Y.Z.', $string);
+        $string = preg_replace('{you are using v\d+\.\d+\.\d+(-\d+-g[0-9a-f]+)?\.}m', 'you are using vX.Y.Z.', $string);
 
         // binary
         $string = str_replace('tests/../', '', $string);
@@ -66,6 +66,6 @@ final class OutputCleaner
         $string = str_replace('.../castor', 'castor', $string);
         $string = preg_replace('#\S+?tools/phar/build/castor\S*#', 'castor', $string);
 
-        return preg_replace('{castor v\d+.\d+.\d+}m', 'castor v.X.Y.Z', $string);
+        return preg_replace('{castor v\d+\.\d+\.\d+(-\d+-g[0-9a-f]+)?}m', 'castor v.X.Y.Z', $string);
     }
 }

--- a/tests/Helper/fixtures/http/self-update/release.php
+++ b/tests/Helper/fixtures/http/self-update/release.php
@@ -1,16 +1,21 @@
 <?php
 
-// Fake "latest release" payload used by SelfUpdateCommandTest: every asset
-// points to the same binary, served by binary.php
+// Fake GitHub releases API used by SelfUpdateCommandTest: "/latest" is the
+// latest release, "/tags/snapshot" the snapshot pre-release. Every asset points
+// to the same binary, served by binary.php
 
 $binaryUrl = 'http://' . $_SERVER['HTTP_HOST'] . '/self-update/binary.php';
 
 $assets = [];
 foreach (['linux-amd64', 'linux-arm64', 'darwin-amd64', 'darwin-arm64'] as $platform) {
-    $assets[] = ['name' => "castor.{$platform}", 'browser_download_url' => $binaryUrl];
-    $assets[] = ['name' => "castor.{$platform}.phar", 'browser_download_url' => $binaryUrl];
+    $assets[] = ['name' => "castor.{$platform}", 'url' => $binaryUrl, 'browser_download_url' => $binaryUrl];
+    $assets[] = ['name' => "castor.{$platform}.phar", 'url' => $binaryUrl, 'browser_download_url' => $binaryUrl];
 }
-$assets[] = ['name' => 'castor.windows-amd64.phar', 'browser_download_url' => $binaryUrl];
+$assets[] = ['name' => 'castor.windows-amd64.phar', 'url' => $binaryUrl, 'browser_download_url' => $binaryUrl];
+
+$release = '/tags/snapshot' === ($_SERVER['PATH_INFO'] ?? '/latest')
+    ? ['tag_name' => 'snapshot', 'name' => 'v99.0.0-3-gabcdef0']
+    : ['tag_name' => 'v99.0.0', 'name' => 'v99.0.0'];
 
 header('Content-Type: application/json');
-echo json_encode(['tag_name' => 'v99.0.0', 'assets' => $assets]);
+echo json_encode($release + ['assets' => $assets]);

--- a/tests/Slow/SelfUpdateCommandTest.php
+++ b/tests/Slow/SelfUpdateCommandTest.php
@@ -48,6 +48,12 @@ class SelfUpdateCommandTest extends TaskTestCase
         $this->assertSame(1, $process->getExitCode());
         $this->assertStringContainsString('No backup found', $process->getOutput());
 
+        $process = $this->runSelfUpdate($castor, '--snapshot');
+        $this->assertSame(0, $process->getExitCode(), $process->getOutput() . $process->getErrorOutput());
+        $this->assertStringContainsString('Latest snapshot: v99.0.0-3-gabcdef0', $process->getOutput());
+        $this->assertStringContainsString('to v99.0.0-3-gabcdef0!', $process->getOutput());
+        new Process([$castor, '--version'])->mustRun();
+
         $fs->remove($dir);
     }
 
@@ -62,6 +68,7 @@ class SelfUpdateCommandTest extends TaskTestCase
                 'GH_CONFIG_DIR' => \dirname($castor) . '/gh-config',
                 'GH_TOKEN' => false,
                 'GITHUB_TOKEN' => false,
+                // Base URL of the fake releases API, see release.php
                 'CASTOR_RELEASES_URL' => $_SERVER['ENDPOINT'] . '/self-update/release.php',
                 'CASTOR_CACHE_DIR' => self::$castorCacheDir,
                 'CASTOR_DISABLE_AGENT_DETECTION' => 'true',

--- a/tools/phar/castor.php
+++ b/tools/phar/castor.php
@@ -3,7 +3,10 @@
 namespace castor\phar;
 
 use Castor\Attribute\AsTask;
+use Castor\Console\Application;
 
+use function Castor\capture;
+use function Castor\context;
 use function Castor\io;
 use function Castor\parallel;
 use function Castor\run;
@@ -65,10 +68,42 @@ function compile(callable $compiler): void
     $composerData = json_decode($composerJson, true);
     $composerData['config']['autoloader-suffix'] = 'CastorPharb0674093dafe41cab39902efe0941c3f';
 
+    // A build that is not a release gets a snapshot version, like "v1.7.0-14-g4531440"
+    $applicationFile = __DIR__ . '/../../src/Console/Application.php';
+    $applicationSource = file_get_contents($applicationFile);
+    $snapshotVersion = snapshot_version();
+
     try {
         file_put_contents($composerFile, json_encode($composerData, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        if ($snapshotVersion) {
+            io()->comment("Building a snapshot, version {$snapshotVersion}");
+            file_put_contents($applicationFile, str_replace(
+                "public const VERSION = '" . Application::VERSION . "';",
+                "public const VERSION = '{$snapshotVersion}';",
+                $applicationSource,
+            ));
+        }
         $compiler();
     } finally {
         file_put_contents($composerFile, $composerJson);
+        file_put_contents($applicationFile, $applicationSource);
     }
+}
+
+/**
+ * The release commit is built before its tag is created (see tools/release),
+ * so as long as Application::VERSION is not tagged, this is a release build
+ * that keeps its version. Once the tag exists, every later commit is a
+ * snapshot, versioned by git describe: last release, number of commits since,
+ * and commit hash.
+ */
+function snapshot_version(): ?string
+{
+    $context = context()->withQuiet()->withAllowFailure();
+
+    if (!run(['git', 'rev-parse', '-q', '--verify', 'refs/tags/' . Application::VERSION], context: $context)->isSuccessful()) {
+        return null;
+    }
+
+    return trim(capture(['git', 'describe', '--tags', '--match', 'v*'], context: $context)) ?: null;
 }


### PR DESCRIPTION
Follow-up of #851 and #852, to try what is coming next before it is released.

- Phars (and the static binaries built from them) get a version from `git describe` when the commit is not a release, e.g. `v1.7.0-14-g4531440`: last release, commits since, commit hash. It compares as newer than that release and older than the next one, so `guard_min_version()` and the update check keep working. The release commit itself is built before its tag exists and keeps `Application::VERSION`.
- The Artifacts workflow ends with a job that publishes the 9 binaries to a rolling `snapshot` pre-release (title = that version), once all the build jobs passed. Pre-releases are ignored by `/releases/latest`, so the stable channel is unaffected. Installable with `--version=snapshot` (no change in the installer) or `castor self-update --snapshot`. A snapshot build is notified of newer snapshots instead of releases, and `castor:repack` defaults to the snapshot when running one.
- `self-update` now downloads the asset through its API URL: the public download URL is cached by name by the GitHub CDN for a few minutes, which would serve the previous snapshot right after a push. The installer keeps the public URL; the possible delay is documented for `--version=snapshot`.

Why "snapshot" rather than "nightly": it is the vocabulary of Composer (`composer self-update --snapshot`, next to `--stable` and `--preview`), with the same meaning (the latest build of the main branch). It also promises nothing about the cadence: the build happens on each push, since the workflow already runs there and it makes a merged PR testable right away, without the "rebuild only if something changed" logic a real nightly would need.

Tested on `pyrech/castor-test` (https://github.com/pyrech/castor-test/actions/runs/32953806969 and the following run): pre-release created then updated, asset attested and downloadable anonymously, `self-update --snapshot` run end to end against the fork API.
