### PR TITLE
feat: allow to trap signals when running commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `self-update` command to update Castor to the latest version
 * Publish a `snapshot` pre-release of the `main` branch on each push, installable with the installer `--version=snapshot` option or `castor self-update --snapshot`
 * Phars and static binaries built from a commit that is not a release now report a snapshot version, like `v1.7.0-14-g4531440`
+* Add a `withTrappedSignals()` method on the context, to forward the signals received by Castor (like the `SIGINT` of a `CTRL+C`) to the process being run, instead of interrupting Castor itself
 
 ### Security
 

--- a/castor.composer.lock
+++ b/castor.composer.lock
@@ -170,7 +170,7 @@
             "version": "v1.0.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:pyrech/castor-example-package-not-published.git",
+                "url": "https://github.com/pyrech/castor-example-package-not-published.git",
                 "reference": "e87fa3f71b9784800caadca8ca3e001bb646f201"
             },
             "dist": {
@@ -183,6 +183,10 @@
             "license": [
                 "MIT"
             ],
+            "support": {
+                "source": "https://github.com/pyrech/castor-example-package-not-published/tree/v1.0.0",
+                "issues": "https://github.com/pyrech/castor-example-package-not-published/issues"
+            },
             "time": "2024-02-26T13:09:56+00:00"
         },
         {

--- a/doc/docs/getting-started/context.md
+++ b/doc/docs/getting-started/context.md
@@ -424,6 +424,36 @@ function foo(): void
 }
 ```
 
+### Trapping signals
+
+By default, a signal sent to Castor - like the `SIGINT` triggered by a `CTRL+C` -
+stops Castor itself. You can ask Castor to trap some signals and forward them to
+the process it runs, with the `withTrappedSignals` method:
+
+```php
+use Castor\Attribute\AsTask;
+
+use function Castor\context;
+use function Castor\run;
+
+#[AsTask()]
+function foo(): void
+{
+    // A CTRL+C stops the server, but not the task
+    run('./my-server', context: context()->withTrappedSignals()->withAllowFailure());
+
+    run('echo "the server has been stopped"');
+}
+```
+
+Without any argument, this method traps `SIGINT` and `SIGTERM`. You can also
+pass the list of signals you want to trap, like
+`withTrappedSignals([\SIGINT, \SIGQUIT])`. `SIGKILL` and `SIGSTOP` cannot be
+caught, and are rejected with an `InvalidArgumentException`.
+
+See [the signals documentation](../going-further/interacting-with-castor/signals.md#trapping-signals-sent-to-castor)
+for more information.
+
 ### Interactive environment
 
 Some commands (a shell, `vim`, an interactive prompt, ...) only make sense

--- a/doc/docs/going-further/interacting-with-castor/signals.md
+++ b/doc/docs/going-further/interacting-with-castor/signals.md
@@ -51,3 +51,74 @@ function onSigUsr2(int $signal): int|false
     return false;
 }
 ```
+
+## Trapping signals sent to Castor
+
+By default, a signal sent to Castor - like the `SIGINT` triggered by a `CTRL+C` -
+interrupts Castor itself, and the task is not executed any further.
+
+If you want to stop only the process currently running, and let the task
+continue, you can ask the context to trap the signals with the
+`withTrappedSignals()` method. When Castor receives one of these signals while
+running a process, it forwards it to that process instead of being interrupted:
+
+```php
+{% include "/examples/advanced/signal/trap.php" start="<?php\n\nnamespace signal;\n\n" %}
+```
+
+Without any argument, `withTrappedSignals()` traps `SIGINT` and `SIGTERM`. You
+can trap other signals by passing the list you want:
+
+```php
+use Castor\Attribute\AsTask;
+
+use function Castor\context;
+use function Castor\run;
+
+#[AsTask()]
+function foo(): void
+{
+    run('./my-server', context: context()->withTrappedSignals([\SIGINT, \SIGQUIT]));
+}
+```
+
+`SIGKILL` and `SIGSTOP` cannot be caught by a process: passing one of them to
+`withTrappedSignals()` throws an `InvalidArgumentException`.
+
+Since the process is stopped by a signal, it exits with a non-zero exit code
+(`130` for a `SIGINT`, `143` for a `SIGTERM`, ...). As for any other failure,
+Castor throws a `ProcessFailedException`, unless you use the
+[`withAllowFailure()`](../../getting-started/context.md#failure) method.
+
+As the trap is only installed while a process is running, a signal received
+between two `run()` calls keeps its usual behavior and stops Castor.
+
+Signals are forwarded to the process started by Castor only, not to the
+processes this one may have started itself. Note also that a `CTRL+C` is sent by
+the terminal to every process of the foreground process group, so the process
+usually receives it directly too.
+
+### Combining a trap with the `onSignals` handlers
+
+A trapped signal is consumed by Castor: while the process is running, the
+`onSignals` handler of the task is not called for this signal, as the signal is
+meant for the process. Once the process is finished, the trap is released and
+the handler of the task gets the signals again:
+
+```php
+{% include "/examples/advanced/signal/trap_with_on_signals.php" start="<?php\n\nnamespace signal;\n\n" %}
+```
+
+This example sends the signals to itself, but hitting `CTRL+C` once while the
+process runs, then once after it, has the same effect and outputs:
+
+```text
+The process has been stopped with the exit code 130
+SIGINT received by the task itself
+And Castor is still running!
+```
+
+> [!WARNING]
+> Trapping signals requires the `pcntl` extension. When it is not available -
+> on Windows, for instance - the signals are not trapped, and Castor keeps its
+> default behavior.

--- a/examples/advanced/signal/trap.php
+++ b/examples/advanced/signal/trap.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace signal;
+
+use Castor\Attribute\AsTask;
+
+use function Castor\context;
+use function Castor\io;
+use function Castor\run;
+
+#[AsTask(description: 'Traps SIGINT and forwards it to the running process')]
+function trap(): void
+{
+    $pid = posix_getpid();
+
+    io()->writeln('Running a process that sends a SIGINT to Castor, like a CTRL+C would do');
+
+    $process = run(
+        // "exec" makes the "sleep" process replace the shell, so it is the one
+        // Castor forwards the signal to
+        ['sh', '-c', "(sleep 1; kill -INT {$pid}) & exec sleep 10"],
+        context: context()
+            ->withTrappedSignals()
+            ->withAllowFailure()
+            ->withPty(false),
+    );
+
+    io()->writeln('The process has been stopped with the exit code ' . $process->getExitCode());
+    io()->writeln('And Castor is still running!');
+}

--- a/examples/advanced/signal/trap_with_on_signals.php
+++ b/examples/advanced/signal/trap_with_on_signals.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace signal;
+
+use Castor\Attribute\AsTask;
+
+use function Castor\context;
+use function Castor\io;
+use function Castor\run;
+
+if (!\defined('SIGINT')) {
+    \define('SIGINT', 2);
+}
+
+#[AsTask(description: 'Combines a trapped signal and an "onSignals" handler', onSignals: [\SIGINT => 'signal\onSigInt'])]
+function trap_with_on_signals(): void
+{
+    $pid = posix_getpid();
+
+    // While the process runs, the trap wins: the SIGINT is forwarded to the
+    // process and the "onSignals" handler of the task is not called
+    $process = run(
+        ['sh', '-c', "(sleep 1; kill -INT {$pid}) & exec sleep 10"],
+        context: context()
+            ->withTrappedSignals()
+            ->withAllowFailure()
+            ->withPty(false),
+    );
+
+    io()->writeln('The process has been stopped with the exit code ' . $process->getExitCode());
+
+    // Once the process is finished, the trap is released and the "onSignals"
+    // handler of the task gets the signals again
+    posix_kill($pid, \SIGINT);
+    usleep(100_000);
+
+    io()->writeln('And Castor is still running!');
+}
+
+/**
+ * @return false
+ */
+function onSigInt(int $signal): bool
+{
+    io()->writeln('SIGINT received by the task itself');
+
+    return false;
+}

--- a/src/Context.php
+++ b/src/Context.php
@@ -20,6 +20,8 @@ class Context implements \ArrayAccess
      * @param ?bool                                              $supportsInteraction Whether the surrounding environment supports interactive
      *                                                                                commands. When null (default), it is auto-detected from
      *                                                                                well-known signals (CI env var, STDIN being a TTY).
+     * @param int[]                                              $trappedSignals      A list of signals Castor must trap and forward to the
+     *                                                                                process it runs, instead of being interrupted by them
      *
      * @phpstan-param ContextData $data The input parameter accepts an array or an Object
      */
@@ -43,6 +45,7 @@ class Context implements \ArrayAccess
         public readonly array $verboseArguments = [],
         public readonly mixed $input = null,
         ?bool $supportsInteraction = null,
+        public readonly array $trappedSignals = [],
     ) {
         $this->workingDirectory = $workingDirectory ?? PathHelper::getRoot(false);
         $this->supportsInteraction = $supportsInteraction ?? self::detectSupportsInteraction();
@@ -65,6 +68,7 @@ class Context implements \ArrayAccess
             'verbosityLevel' => $this->verbosityLevel,
             'notificationTitle' => $this->notificationTitle,
             'supportsInteraction' => $this->supportsInteraction,
+            'trappedSignals' => $this->trappedSignals,
         ];
     }
 
@@ -197,6 +201,33 @@ class Context implements \ArrayAccess
         ]);
     }
 
+    /**
+     * Traps the given signals: when Castor receives one of them while running a
+     * process with this context, the signal is forwarded to that process
+     * instead of interrupting Castor itself.
+     *
+     * This allows, for example, to stop a long running process with CTRL+C
+     * without killing Castor, and to keep executing the rest of the task.
+     *
+     * @param int[]|null $signals The signals to trap. Defaults to SIGINT and
+     *                            SIGTERM. Pass an empty array to restore the
+     *                            default behavior.
+     *
+     * @throws \InvalidArgumentException When one of the signals cannot be caught (SIGKILL, SIGSTOP)
+     */
+    public function withTrappedSignals(?array $signals = null): self
+    {
+        $signals ??= \defined('SIGINT') && \defined('SIGTERM') ? [\SIGINT, \SIGTERM] : [];
+
+        foreach ($signals as $signal) {
+            $this->assertSignalCanBeTrapped($signal);
+        }
+
+        return $this->clone([
+            'trappedSignals' => array_values(array_unique($signals)),
+        ]);
+    }
+
     public function supportsInteraction(): bool
     {
         return $this->supportsInteraction;
@@ -246,6 +277,15 @@ class Context implements \ArrayAccess
     public function offsetUnset(mixed $offset): void
     {
         throw new \LogicException('Context is immutable.');
+    }
+
+    private function assertSignalCanBeTrapped(int $signal): void
+    {
+        foreach (['SIGKILL', 'SIGSTOP'] as $name) {
+            if (\defined($name) && \constant($name) === $signal) {
+                throw new \InvalidArgumentException(\sprintf('The signal "%s" cannot be trapped: the operating system does not allow it to be caught.', $name));
+            }
+        }
     }
 
     /**

--- a/src/Runner/ProcessRunner.php
+++ b/src/Runner/ProcessRunner.php
@@ -17,6 +17,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Process;
 
 use function Symfony\Component\String\u;
@@ -31,6 +32,7 @@ class ProcessRunner
         private readonly Notifier $notifier,
         private readonly LoggerInterface $logger,
         private readonly SymfonyStyle $io,
+        private readonly SignalTrapper $signalTrapper,
     ) {
     }
 
@@ -112,6 +114,8 @@ class ProcessRunner
             }
         });
 
+        $this->signalTrapper->trap($process, $context->trappedSignals);
+
         $this->eventDispatcher->dispatch(new ProcessStartEvent($process));
 
         try {
@@ -125,7 +129,14 @@ class ProcessRunner
             }
 
             $exitCode = $process->wait();
+        } catch (ProcessSignaledException $e) {
+            if (!\in_array($e->getSignal(), $context->trappedSignals, true)) {
+                throw $e;
+            }
+
+            $exitCode = $process->getExitCode() ?? 128 + $e->getSignal();
         } finally {
+            $this->signalTrapper->release($process, $context->trappedSignals);
             $this->sectionOutput->finishProcess($process);
             $this->eventDispatcher->dispatch(new ProcessTerminateEvent($process));
         }

--- a/src/Runner/SignalTrapper.php
+++ b/src/Runner/SignalTrapper.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Castor\Runner;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Traps signals sent to Castor and forwards them to the processes currently
+ * running, instead of letting them interrupt Castor itself.
+ *
+ * @internal
+ */
+class SignalTrapper
+{
+    /** @var array<int, array<int, Process>> */
+    private array $processes = [];
+
+    /** @var array<int, callable|int> */
+    private array $previousHandlers = [];
+
+    private bool $unsupportedWarningSent = false;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param int[] $signals
+     */
+    public function trap(Process $process, array $signals): void
+    {
+        if (!$signals) {
+            return;
+        }
+
+        if (!$this->isSupported()) {
+            if (!$this->unsupportedWarningSent) {
+                $this->unsupportedWarningSent = true;
+                $this->logger->warning('Cannot trap signals: the "pcntl" extension is not available.');
+            }
+
+            return;
+        }
+
+        pcntl_async_signals(true);
+
+        foreach ($signals as $signal) {
+            if (!isset($this->processes[$signal])) {
+                $this->processes[$signal] = [];
+
+                $this->previousHandlers[$signal] = pcntl_signal_get_handler($signal);
+
+                pcntl_signal($signal, $this->handle(...));
+            }
+
+            $this->processes[$signal][spl_object_id($process)] = $process;
+        }
+
+        $this->logger->debug(\sprintf('Trapping signals "%s" for the running process.', implode('", "', $signals)));
+    }
+
+    /**
+     * @param int[] $signals
+     */
+    public function release(Process $process, array $signals): void
+    {
+        foreach ($signals as $signal) {
+            if (!isset($this->processes[$signal])) {
+                continue;
+            }
+
+            unset($this->processes[$signal][spl_object_id($process)]);
+
+            if ($this->processes[$signal]) {
+                continue;
+            }
+
+            unset($this->processes[$signal]);
+
+            if ($this->isSupported()) {
+                pcntl_signal($signal, $this->previousHandlers[$signal] ?? \SIG_DFL);
+            }
+
+            unset($this->previousHandlers[$signal]);
+        }
+    }
+
+    private function isSupported(): bool
+    {
+        return \function_exists('pcntl_signal')
+            && \function_exists('pcntl_signal_get_handler')
+            && \function_exists('pcntl_async_signals');
+    }
+
+    private function handle(int $signal): void
+    {
+        foreach ($this->processes[$signal] ?? [] as $process) {
+            try {
+                if (!$process->isRunning()) {
+                    continue;
+                }
+
+                $process->signal($signal);
+            } catch (\Throwable $e) {
+                // The process may have finished between the isRunning() call and
+                // the signal() one: there is nothing we can do about it.
+                $this->logger->debug(\sprintf('Could not forward signal "%d" to the process: %s', $signal, $e->getMessage()));
+            }
+        }
+    }
+}

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -55,6 +55,59 @@ class ContextTest extends TestCase
         $context->toInteractive();
     }
 
+    public function testTrappedSignalsAreEmptyByDefault(): void
+    {
+        $this->assertSame([], new Context()->trappedSignals);
+    }
+
+    public function testWithTrappedSignalsDefaultsToSigintAndSigterm(): void
+    {
+        $context = new Context()->withTrappedSignals();
+
+        $this->assertSame([\SIGINT, \SIGTERM], $context->trappedSignals);
+    }
+
+    public function testWithTrappedSignalsAcceptsACustomListOfSignals(): void
+    {
+        $context = new Context()->withTrappedSignals([\SIGUSR1, \SIGUSR1, \SIGHUP]);
+
+        $this->assertSame([\SIGUSR1, \SIGHUP], $context->trappedSignals);
+    }
+
+    public function testWithTrappedSignalsCanRestoreTheDefaultBehavior(): void
+    {
+        $context = new Context()->withTrappedSignals()->withTrappedSignals([]);
+
+        $this->assertSame([], $context->trappedSignals);
+    }
+
+    public function testWithTrappedSignalsRejectsSignalsThatCannotBeCaught(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The signal "SIGKILL" cannot be trapped');
+
+        new Context()->withTrappedSignals([\SIGINT, \SIGKILL]);
+    }
+
+    public function testWithTrappedSignalsRejectsSigstop(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The signal "SIGSTOP" cannot be trapped');
+
+        new Context()->withTrappedSignals([\SIGSTOP]);
+    }
+
+    public function testTrappedSignalsArePreservedAcrossOtherWithers(): void
+    {
+        $context = new Context()
+            ->withTrappedSignals([\SIGINT])
+            ->withQuiet()
+            ->withWorkingDirectory('/tmp')
+        ;
+
+        $this->assertSame([\SIGINT], $context->trappedSignals);
+    }
+
     public function testToInteractiveCanBypassTheCheck(): void
     {
         $context = new Context(supportsInteraction: false)->toInteractive(throwOnNonInteractiveEnv: false);

--- a/tests/Examples/BashCompletionTest.php.output.txt
+++ b/tests/Examples/BashCompletionTest.php.output.txt
@@ -91,6 +91,8 @@ run:with-process-helper
 shell:bash
 shell:sh
 signal:sigusr2
+signal:trap
+signal:trap-with-on-signals
 ssh:download
 ssh:ls
 ssh:real-time-output

--- a/tests/Generated/ListTest.php.output.txt
+++ b/tests/Generated/ListTest.php.output.txt
@@ -123,6 +123,8 @@ run:variables                                            Run a sub-process with 
 run:verbose-arguments                                    A failing task that will suggest to re-run with verbose arguments
 run:working-directory-override                           Changes directory
 signal:sigusr2                                           Captures SIGUSR2 signal
+signal:trap                                              Traps SIGINT and forwards it to the running process
+signal:trap-with-on-signals                              Combines a trapped signal and an "onSignals" handler
 slug:slugify                                             Slugify strings
 ssh:download                                             Downloads a file from the remote server
 ssh:ls                                                   Lists content of /var/www directory on the remote server

--- a/tests/Generated/SignalTrapTest.php
+++ b/tests/Generated/SignalTrapTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class SignalTrapTest extends TaskTestCase
+{
+    // signal:trap
+    public function test(): void
+    {
+        $process = $this->runTask(['signal:trap']);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFileWithCleaning(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertSame('', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/SignalTrapTest.php.output.txt
+++ b/tests/Generated/SignalTrapTest.php.output.txt
@@ -1,0 +1,3 @@
+Running a process that sends a SIGINT to Castor, like a CTRL+C would do
+The process has been stopped with the exit code 130
+And Castor is still running!

--- a/tests/Generated/SignalTrapWithOnSignalsTest.php
+++ b/tests/Generated/SignalTrapWithOnSignalsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Castor\Tests\Generated;
+
+use Castor\Tests\TaskTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class SignalTrapWithOnSignalsTest extends TaskTestCase
+{
+    // signal:trap-with-on-signals
+    public function test(): void
+    {
+        $process = $this->runTask(['signal:trap-with-on-signals']);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertStringEqualsFileWithCleaning(__FILE__ . '.output.txt', $process->getOutput());
+        $this->assertSame('', $process->getErrorOutput());
+    }
+}

--- a/tests/Generated/SignalTrapWithOnSignalsTest.php.output.txt
+++ b/tests/Generated/SignalTrapWithOnSignalsTest.php.output.txt
@@ -1,0 +1,3 @@
+The process has been stopped with the exit code 130
+SIGINT received by the task itself
+And Castor is still running!


### PR DESCRIPTION
The goal of this feature is to be able to make CTRL + C only kill the current running sub processes without killing castor task so we can do more, can be useful in long running process with after cleanup.

(Obviously this only works with signal that can be trapped, SIGKILL would never work)

It was already possible but only when tty was enabled, this now allow to make this work in all modes (even without pty / tty) 


