### PR TITLE
chore(ci): group dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,14 @@ version: 2
 updates:
     - package-ecosystem: 'github-actions'
       directory: '/'
-      target-branch: 'main'
       schedule:
           interval: 'monthly'
       groups:
           github-actions:
+              patterns:
+                  - '*'
+          github-actions-security:
+              applies-to: security-updates
               patterns:
                   - '*'
       cooldown:


### PR DESCRIPTION
Dependabot groups only apply to version updates unless a group declares `applies-to: security-updates`, so security fixes were opened as one PR per dependency. This adds a `<ecosystem>-security` group to each entry so alerts land in a single PR per ecosystem.

`target-branch: 'main'` is removed: it is redundant since `main` is the default branch, and per the Dependabot docs an entry's settings do not apply to security updates where `target-branch` is used.