### PR TITLE
Restrict the file name chosen by the server in http_download()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Security
 
 * Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer, in `self-update` and in `castor:repack` when the GitHub CLI is installed and authenticated
+* Restrict the file name chosen by the server in `http_download()`: only the last segment of the `Content-Disposition` file name (or of the URL path) is kept, so the download always lands in the project directory
 
 ### Fixes
 

--- a/src/Http/HttpDownloader.php
+++ b/src/Http/HttpDownloader.php
@@ -156,6 +156,11 @@ class HttpDownloader
         return \sprintf('%.2f %s', $size, $units[$pow - 1]);
     }
 
+    /**
+     * The file name comes from the remote server (Content-Disposition header,
+     * or the URL path): only its last path segment is kept, so the server can
+     * never make the download land outside the target directory.
+     */
     private function extractFileName(ResponseInterface $response, string $url): string
     {
         $disposition = $response->getHeaders(false)['content-disposition'][0] ?? null;
@@ -166,7 +171,14 @@ class HttpDownloader
             if (!\is_string($parsedUrl)) {
                 throw new \RuntimeException(\sprintf('Could not extract file name from URL: %s', $url));
             }
-            $filename = basename($parsedUrl);
+            $filename = $parsedUrl;
+        }
+
+        $filename = basename(str_replace('\\', '/', $filename));
+        $filename = (string) preg_replace('/[\x00-\x1F\x7F]/', '', $filename);
+
+        if ('' === $filename || '.' === $filename || '..' === $filename) {
+            throw new \RuntimeException(\sprintf('Could not determine a valid file name for the download of "%s", pass the file path explicitly.', $url));
         }
 
         return $filename;

--- a/tests/Http/HttpDownloaderTest.php
+++ b/tests/Http/HttpDownloaderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Castor\Tests\Http;
+
+use Castor\Http\HttpDownloader;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class HttpDownloaderTest extends TestCase
+{
+    #[DataProvider('provideFileNames')]
+    public function testFileNameIsRestrictedToItsLastSegment(string $url, ?string $contentDisposition, string $expected): void
+    {
+        $this->assertSame($expected, $this->extractFileName($url, $contentDisposition));
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string, string}>
+     */
+    public static function provideFileNames(): iterable
+    {
+        yield 'from the URL' => ['https://example.com/dist/archive.tar.gz', null, 'archive.tar.gz'];
+        yield 'from the URL, ignoring the query string' => ['https://example.com/dist/archive.tar.gz?token=abc', null, 'archive.tar.gz'];
+        yield 'from a directory URL' => ['https://example.com/dist/', null, 'dist'];
+        yield 'from the header' => ['https://example.com/download?id=42', 'attachment; filename="report.pdf"', 'report.pdf'];
+        yield 'from the header, with a relative path' => ['https://example.com/download', 'attachment; filename="../../.bashrc"', '.bashrc'];
+        yield 'from the header, with an absolute path' => ['https://example.com/download', 'attachment; filename="/etc/passwd"', 'passwd'];
+        yield 'from the header, with a Windows path' => ['https://example.com/download', 'attachment; filename="..\..\evil.txt"', 'evil.txt'];
+        yield 'from the header, with control characters' => ['https://example.com/download', "attachment; filename=\"evil\r\n.txt\"", 'evil.txt'];
+    }
+
+    #[DataProvider('provideInvalidFileNames')]
+    public function testInvalidFileNamesAreRejected(string $url, ?string $contentDisposition): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $this->extractFileName($url, $contentDisposition);
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string}>
+     */
+    public static function provideInvalidFileNames(): iterable
+    {
+        yield 'no path in the URL' => ['https://example.com', null];
+        yield 'parent directory in the header' => ['https://example.com/download', 'attachment; filename=".."'];
+        yield 'root in the header' => ['https://example.com/download', 'attachment; filename="/"'];
+    }
+
+    private function extractFileName(string $url, ?string $contentDisposition): string
+    {
+        $headers = null === $contentDisposition ? [] : ['Content-Disposition' => $contentDisposition];
+        $client = new MockHttpClient(new MockResponse('', ['response_headers' => $headers]));
+        $downloader = new HttpDownloader($client, new Filesystem());
+
+        return new \ReflectionMethod(HttpDownloader::class, 'extractFileName')->invoke($downloader, $client->request('GET', $url), $url);
+    }
+}


### PR DESCRIPTION
When no file path is given, `http_download()` names the file after the `Content-Disposition` header, or after the URL path, and writes it in the project directory. That name was used as is, so a server answering `filename="../../.bashrc"` had the download written anywhere the user can write.

Only the last path segment of the name is kept now, control characters are stripped, and an empty, `.` or `..` name is rejected with an error asking for an explicit file path.

A unit test covers the header and URL cases.
