### PR TITLE
Document that the context environment is displayed when a process fails

### DIFF
--- a/doc/docs/getting-started/context.md
+++ b/doc/docs/getting-started/context.md
@@ -354,6 +354,14 @@ function foo(): void
 }
 ```
 
+> [!WARNING]
+> The environment variables of the context are displayed, with their values,
+> in the command Castor reports when a process fails, and in the verbose logs
+> (`-v`). Keep secrets out of `withEnvironment()` when that output can be read
+> by others, in CI logs for instance. Variables inherited from the parent
+> process (exported in your shell, or loaded with `load_dot_env()`) are passed
+> to the process too, but are never displayed.
+
 ### Timeout
 
 By default, Castor allow your `run()` calls to go indefinitly.

--- a/doc/docs/getting-started/run.md
+++ b/doc/docs/getting-started/run.md
@@ -109,3 +109,9 @@ expose sensitive data (like passwords) in command line arguments:
 
 The `input` option accepts a string, a `\Stringable`, a resource, or an
 `\Iterator<string>`.
+
+> [!WARNING]
+> Environment variables set with `withEnvironment()` are not a safe place for
+> secrets either: they are displayed, with their values, when the process fails
+> and in the verbose logs. See the [context
+> documentation](context.md#environment-variables).


### PR DESCRIPTION
The environment variables set with `withEnvironment()` are part of the command Castor prints when a process fails (`The following process did not finish successfully`), and of the verbose logs. A token put there ends up in the CI logs as soon as a command fails.

This documents that behavior in the context and `run()` pages, and points to the inherited environment (exported variables, `load_dot_env()`) as the alternative, since inherited variables are passed to the process but never displayed.
