### PR TITLE
Publish the checksums of the release binaries and verify them in self-update

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -229,8 +229,40 @@ jobs:
           path: ./castor.darwin-arm64
           if-no-files-found: error
 
-  snapshot:
+  checksums:
     needs: [phars, static-linux-amd64, static-linux-arm64, static-darwin-amd64, static-darwin-arm64]
+    name: Publish the checksums of the artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      # One "<sha256>  <file name>" line per artifact, verified by the
+      # installer and by self-update against the downloaded binary
+      - name: Compute the checksums
+        run: |
+          set -e
+          sha256sum castor.* > SHA256SUMS
+          cat SHA256SUMS
+        working-directory: artifacts
+
+      - name: Attest the checksums provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: artifacts/SHA256SUMS
+
+      - name: Upload the checksums
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SHA256SUMS
+          path: artifacts/SHA256SUMS
+          if-no-files-found: error
+
+  snapshot:
+    needs: [checksums]
     name: Publish the snapshot pre-release
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer, in `self-update` and in `castor:repack` when the GitHub CLI is installed and authenticated
 * Restrict the file name chosen by the server in `http_download()`: only the last segment of the `Content-Disposition` file name (or of the URL path) is kept, so the download always lands in the project directory
 * Never download the remote packages during a shell completion: the packages already installed are used, and the completion goes on without the remote imports when there is none
+* Publish a `SHA256SUMS` file, attested too, with each release and the snapshot pre-release, and verify the checksum of the downloaded binary in `self-update`
+* Only accept attestations signed by the Artifacts workflow when verifying the provenance of a binary, and skip the verification with a GitHub CLI too old to know about attestations instead of failing
 
 ### Fixes
 

--- a/doc/installation/installer.md
+++ b/doc/installation/installer.md
@@ -72,10 +72,18 @@ castor self-update
 - `--no-backup`: Skip creating a backup of the current binary
 - `--rollback` or `-r`: Rollback to the previous version
 
-When the [GitHub CLI](https://cli.github.com/) is installed and authenticated,
-the installer and `self-update` also verify the provenance of the downloaded
-binary: they check, with `gh attestation verify`, that the binary was built by
-Castor's own GitHub Actions workflow.
+Each release ships a `SHA256SUMS` file listing the checksum of every binary:
+`self-update` refuses a downloaded binary whose checksum does not match it.
+
+When the [GitHub CLI](https://cli.github.com/) (2.49 or later) is installed and
+authenticated, the installer and `self-update` also verify the provenance of the
+downloaded binary: they check, with `gh attestation verify`, that the binary was
+built by Castor's own GitHub Actions workflow. The `SHA256SUMS` file is attested
+too, so its provenance can be verified the same way:
+
+```bash
+gh attestation verify SHA256SUMS --repo jolicode/castor
+```
 
 > [!NOTE]
 > The `self-update` command is not available for source installations or Composer

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /** @internal */
 #[AsCommand(
@@ -29,6 +30,7 @@ final readonly class SelfUpdateCommand
         private ReleaseHelper $releaseHelper,
         private AttestationHelper $attestationHelper,
         private HttpDownloader $httpDownloader,
+        private HttpClientInterface $httpClient,
         private Installation $installation,
         private Filesystem $filesystem,
     ) {
@@ -149,7 +151,7 @@ final readonly class SelfUpdateCommand
             $this->httpDownloader->download($asset['url'], $tempFile, options: ['headers' => ['Accept' => 'application/octet-stream']]);
             $this->filesystem->chmod($tempFile, 0o755);
 
-            if (!$this->verifyProvenance($io, $tempFile)) {
+            if (!$this->verifyChecksum($io, $latestVersion, $asset['name'], $tempFile) || !$this->verifyProvenance($io, $tempFile)) {
                 $this->filesystem->remove($tempFile);
 
                 return Command::FAILURE;
@@ -185,6 +187,42 @@ final readonly class SelfUpdateCommand
     }
 
     /**
+     * Compares the SHA-256 checksum of the downloaded binary with the one
+     * listed in the SHA256SUMS asset of the release. Releases published
+     * before that file existed are updated without this check.
+     *
+     * @param array<string, mixed> $release
+     */
+    private function verifyChecksum(SymfonyStyle $io, array $release, string $assetName, string $binary): bool
+    {
+        $io->text('Verifying the binary checksum...');
+
+        $checksumsAsset = $this->releaseHelper->getChecksumsAsset($release);
+
+        if (null === $checksumsAsset) {
+            $io->warning(\sprintf('This release has no %s file, so the checksum of the downloaded binary cannot be verified.', ReleaseHelper::CHECKSUMS_FILE));
+
+            return true;
+        }
+
+        $checksums = $this->httpClient
+            ->request('GET', $checksumsAsset['url'], ['headers' => ['Accept' => 'application/octet-stream'], 'timeout' => 10])
+            ->getContent()
+        ;
+
+        $expected = $this->releaseHelper->getExpectedChecksum($checksums, $assetName);
+        $actual = hash_file('sha256', $binary);
+
+        if (!hash_equals($expected, (string) $actual)) {
+            $io->error(\sprintf('The checksum of the downloaded binary does not match the one listed in %s. Update aborted.', ReleaseHelper::CHECKSUMS_FILE));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Aborts the update when the binary has no attestation: the latest release
      * always has one, so a missing attestation means this is not our build.
      * Without an authenticated GitHub CLI, the update goes on unverified.
@@ -195,7 +233,7 @@ final readonly class SelfUpdateCommand
 
         switch ($this->attestationHelper->verify($binary)) {
             case AttestationStatus::Skipped:
-                $io->note('Install and log in to the GitHub CLI (gh) to verify the provenance of the downloaded binary.');
+                $io->warning('Install and log in to the GitHub CLI (gh 2.49 or later) to verify the provenance of the downloaded binary.');
 
                 return true;
             case AttestationStatus::Verified:

--- a/src/Helper/AttestationHelper.php
+++ b/src/Helper/AttestationHelper.php
@@ -9,13 +9,17 @@ use Symfony\Component\Process\Process;
  * Checks that a file was built by the Castor GitHub Actions workflow, using
  * the artifact attestation published with each build.
  *
- * This needs the GitHub CLI, installed and authenticated: the attestations API
- * rejects anonymous requests.
+ * This needs the GitHub CLI (2.49 or later, for the attestation command),
+ * installed and authenticated: the attestations API rejects anonymous
+ * requests.
  *
  * @internal
  */
 final readonly class AttestationHelper
 {
+    /** The only workflow building and attesting the artifacts */
+    private const string SIGNER_WORKFLOW = 'jolicode/castor/.github/workflows/artifacts.yml';
+
     /**
      * @throws \RuntimeException when the attestation exists but does not match
      */
@@ -27,7 +31,7 @@ final readonly class AttestationHelper
             return AttestationStatus::Skipped;
         }
 
-        $process = new Process([$gh, 'attestation', 'verify', $file, '--repo', 'jolicode/castor']);
+        $process = new Process([$gh, 'attestation', 'verify', $file, '--repo', 'jolicode/castor', '--signer-workflow', self::SIGNER_WORKFLOW]);
         $process->setTimeout(60);
         $process->run();
 
@@ -36,6 +40,11 @@ final readonly class AttestationHelper
         }
 
         $error = trim($process->getErrorOutput());
+
+        // A GitHub CLI too old to know about attestations
+        if (str_contains($error, 'unknown command "attestation"')) {
+            return AttestationStatus::Skipped;
+        }
 
         if (str_contains($error, 'HTTP 404') || str_contains($error, 'no attestations found')) {
             return AttestationStatus::NotAttested;

--- a/src/Helper/ReleaseHelper.php
+++ b/src/Helper/ReleaseHelper.php
@@ -16,6 +16,9 @@ final readonly class ReleaseHelper
     /** The rolling pre-release of the main branch, see the Artifacts workflow */
     public const string SNAPSHOT_TAG = 'snapshot';
 
+    /** Release asset listing the SHA-256 checksum of every other asset */
+    public const string CHECKSUMS_FILE = 'SHA256SUMS';
+
     private const string API_URL = 'https://api.github.com/repos/jolicode/castor/releases';
 
     public function __construct(
@@ -93,6 +96,42 @@ final readonly class ReleaseHelper
         }
 
         return array_first($assets);
+    }
+
+    /**
+     * Returns the asset holding the SHA-256 checksums of all the release assets,
+     * or null for releases published without it.
+     *
+     * @param array<string, mixed> $release
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getChecksumsAsset(array $release): ?array
+    {
+        foreach ($release['assets'] ?? [] as $asset) {
+            if (self::CHECKSUMS_FILE === ($asset['name'] ?? null)) {
+                return $asset;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the expected SHA-256 checksum of the given asset, as listed in
+     * the SHA256SUMS file (one "<checksum>  <file name>" line per asset).
+     *
+     * @throws \RuntimeException when the file has no entry for the asset
+     */
+    public function getExpectedChecksum(string $checksumsFileContent, string $assetName): string
+    {
+        foreach (preg_split('/\R/', $checksumsFileContent) ?: [] as $line) {
+            if (preg_match('/^(?<checksum>[0-9a-f]{64})\s+\*?(?<name>.+)$/i', trim($line), $matches) && $matches['name'] === $assetName) {
+                return strtolower($matches['checksum']);
+            }
+        }
+
+        throw new \RuntimeException(\sprintf('The %s file has no entry for "%s".', self::CHECKSUMS_FILE, $assetName));
     }
 
     /**

--- a/tests/Helper/ReleaseHelperTest.php
+++ b/tests/Helper/ReleaseHelperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Castor\Tests\Helper;
+
+use Castor\Helper\ReleaseHelper;
+use PHPUnit\Framework\TestCase;
+
+class ReleaseHelperTest extends TestCase
+{
+    private const string CHECKSUMS = <<<'TXT'
+        1111111111111111111111111111111111111111111111111111111111111111  castor.linux-amd64
+        2222222222222222222222222222222222222222222222222222222222222222  castor.linux-amd64.phar
+        3333333333333333333333333333333333333333333333333333333333333333 *castor.darwin-arm64
+        TXT;
+
+    public function testTheChecksumOfAnAssetIsFound(): void
+    {
+        $helper = $this->createHelper();
+
+        $this->assertSame(str_repeat('1', 64), $helper->getExpectedChecksum(self::CHECKSUMS, 'castor.linux-amd64'));
+        $this->assertSame(str_repeat('2', 64), $helper->getExpectedChecksum(self::CHECKSUMS, 'castor.linux-amd64.phar'));
+        $this->assertSame(str_repeat('3', 64), $helper->getExpectedChecksum(self::CHECKSUMS, 'castor.darwin-arm64'));
+    }
+
+    public function testAnUnlistedAssetIsRejected(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('no entry for "castor.windows-amd64.phar"');
+
+        $this->createHelper()->getExpectedChecksum(self::CHECKSUMS, 'castor.windows-amd64.phar');
+    }
+
+    public function testTheChecksumsAssetIsFoundByName(): void
+    {
+        $helper = $this->createHelper();
+        $release = ['assets' => [
+            ['name' => 'castor.linux-amd64', 'url' => 'https://example.com/binary'],
+            ['name' => 'SHA256SUMS', 'url' => 'https://example.com/checksums'],
+        ]];
+
+        $this->assertSame('https://example.com/checksums', $helper->getChecksumsAsset($release)['url'] ?? null);
+        $this->assertNull($helper->getChecksumsAsset(['assets' => [['name' => 'castor.linux-amd64']]]));
+    }
+
+    private function createHelper(): ReleaseHelper
+    {
+        // The tested methods do not use the constructor dependencies
+        return new \ReflectionClass(ReleaseHelper::class)->newInstanceWithoutConstructor();
+    }
+}

--- a/tests/Helper/fixtures/http/self-update/checksums.php
+++ b/tests/Helper/fixtures/http/self-update/checksums.php
@@ -1,0 +1,28 @@
+<?php
+
+// Serves the SHA256SUMS file of the fake release: every asset is the binary
+// served by binary.php. When SelfUpdateCommandTest creates the
+// "corrupt-checksums" file, the listed checksums are wrong.
+
+$dir = sys_get_temp_dir() . '/castor-test-self-update';
+$file = $dir . '/castor.new';
+
+if (!is_file($file)) {
+    http_response_code(404);
+
+    exit;
+}
+
+$checksum = file_exists($dir . '/corrupt-checksums') ? str_repeat('0', 64) : hash_file('sha256', $file);
+
+$names = [];
+foreach (['linux-amd64', 'linux-arm64', 'darwin-amd64', 'darwin-arm64'] as $platform) {
+    $names[] = "castor.{$platform}";
+    $names[] = "castor.{$platform}.phar";
+}
+$names[] = 'castor.windows-amd64.phar';
+
+header('Content-Type: text/plain');
+foreach ($names as $name) {
+    echo "{$checksum}  {$name}\n";
+}

--- a/tests/Helper/fixtures/http/self-update/release.php
+++ b/tests/Helper/fixtures/http/self-update/release.php
@@ -13,6 +13,9 @@ foreach (['linux-amd64', 'linux-arm64', 'darwin-amd64', 'darwin-arm64'] as $plat
 }
 $assets[] = ['name' => 'castor.windows-amd64.phar', 'url' => $binaryUrl, 'browser_download_url' => $binaryUrl];
 
+$checksumsUrl = 'http://' . $_SERVER['HTTP_HOST'] . '/self-update/checksums.php';
+$assets[] = ['name' => 'SHA256SUMS', 'url' => $checksumsUrl, 'browser_download_url' => $checksumsUrl];
+
 $release = '/tags/snapshot' === ($_SERVER['PATH_INFO'] ?? '/latest')
     ? ['tag_name' => 'snapshot', 'name' => 'v99.0.0-3-gabcdef0']
     : ['tag_name' => 'v99.0.0', 'name' => 'v99.0.0'];

--- a/tests/Slow/SelfUpdateCommandTest.php
+++ b/tests/Slow/SelfUpdateCommandTest.php
@@ -29,9 +29,18 @@ class SelfUpdateCommandTest extends TaskTestCase
         $fs->chmod($castor, 0o755);
         $inode = fileinode($castor);
 
+        // The checksums file of the fake release does not match the binary
+        touch($dir . '/corrupt-checksums');
+        $process = $this->runSelfUpdate($castor);
+        $this->assertSame(1, $process->getExitCode(), $process->getOutput() . $process->getErrorOutput());
+        $this->assertStringContainsString('checksum of the downloaded binary does not match', $process->getOutput());
+        $this->assertSame($inode, fileinode($castor), 'The binary has not been replaced');
+        $this->assertFileDoesNotExist($castor . '.tmp');
+        unlink($dir . '/corrupt-checksums');
+
         $process = $this->runSelfUpdate($castor);
         $this->assertSame(0, $process->getExitCode(), $process->getOutput() . $process->getErrorOutput());
-        $this->assertStringContainsString('to verify the provenance', $process->getOutput());
+        $this->assertStringContainsString('log in to the GitHub CLI', $process->getOutput());
         $this->assertStringContainsString('to v99.0.0!', $process->getOutput());
         $this->assertNotSame($inode, fileinode($castor), 'The binary has been replaced');
         $this->assertFileEquals(self::$castorBin, $castor);

--- a/tools/release/castor.php
+++ b/tools/release/castor.php
@@ -11,13 +11,15 @@ use Symfony\Component\Process\ExecutableFinder;
 use function Castor\capture;
 use function Castor\check;
 use function Castor\context;
+use function Castor\exit_code;
 use function Castor\finder;
 use function Castor\fs;
 use function Castor\io;
 use function Castor\run;
 
 const REPO = 'jolicode/castor';
-const EXPECTED_ARTIFACTS = 9;
+// 9 binaries and their SHA256SUMS file
+const EXPECTED_ARTIFACTS = 10;
 
 #[AsTask(description: 'Release a new version of castor', aliases: ['release'])]
 function release(): int
@@ -115,9 +117,15 @@ function release(): int
         'Some artifacts are empty.',
         static fn () => !array_filter(
             iterator_to_array($files),
-            // A least 3MB
-            static fn (SplFileInfo $file) => 3_000_000 > $file->getSize()
+            // A least 3MB, except the checksums file
+            static fn (SplFileInfo $file) => 'SHA256SUMS' !== $file->getFilename() && 3_000_000 > $file->getSize()
         ),
+    );
+
+    check(
+        'Check the artifacts checksums',
+        'The artifacts do not match their SHA256SUMS file.',
+        static fn () => 0 === exit_code(['sha256sum', '--check', '--quiet', 'SHA256SUMS'], context: context()->withWorkingDirectory($artifactsDir)->withQuiet()),
     );
 
     io()->write('Publishing the release');


### PR DESCRIPTION
Each run of the Artifacts workflow now produces a `SHA256SUMS` file listing the checksum of the nine binaries. It is attested like them, published with the snapshot pre-release, and included in each release by the release tool, which also checks the artifacts against it before publishing.

`self-update` downloads that file and refuses a binary whose checksum does not match, whether or not the GitHub CLI is available to verify the attestation. Releases published before the file existed (all the current ones) are updated with a warning instead.

The attestation check itself changes in two ways:

- it now requires the attestation to be signed by the Artifacts workflow (`--signer-workflow`), not just by any workflow of the repository;
- a GitHub CLI too old to know about `gh attestation` (before 2.49) skips the check, like a missing CLI, instead of failing the update with `unknown command "attestation"`.

The functional test covers a checksum mismatch (update refused, binary untouched) and the regular update. The installer will verify the same file in a follow-up.
