### PR TITLE
Extract the watcher binary to the user cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * Quote the remote `path` of `ssh_run()`, and reject a `host`, `user`, `jump_host`, `path_private_key` or `multiplexing_control_path` containing a shell metacharacter: they end up in a local shell command line, so a value coming from user input could run a command instead of opening a connection
 * Pass the container name of `wait_for_docker_container()` to `docker` as an argument instead of building a shell command with it
+* Extract the watcher binary used by `watch()` in the phar and static builds to the user cache directory, under the Castor version, instead of a fixed path in the system temporary directory shared by all users, and replace it when its content is not the expected one
 * Fix architecture detection on Linux ARM64 (`aarch64`), which made the watcher and the update hints pick the amd64 binaries
 * Fix `run()` ignoring the timeout when executed inside `parallel()`: the process was waited for in its own fiber loop, so Symfony's timeout check never ran and the process could run forever
 

--- a/src/Runner/WatchRunner.php
+++ b/src/Runner/WatchRunner.php
@@ -2,12 +2,14 @@
 
 namespace Castor\Runner;
 
+use Castor\Console\Application;
 use Castor\Console\Output\SectionOutput;
 use Castor\Context;
 use Castor\ContextRegistry;
 use Castor\Helper\Architecture;
 use Castor\Helper\Installation;
 use JoliCode\PhpOsHelper\OsHelper;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
 /** @internal */
@@ -19,6 +21,8 @@ final readonly class WatchRunner
         private ProcessRunner $processRunner,
         private SectionOutput $sectionOutput,
         private Installation $installation,
+        private Filesystem $filesystem,
+        private string $cacheDir,
     ) {
     }
 
@@ -59,15 +63,7 @@ final readonly class WatchRunner
         $binaryPath = __DIR__ . '/../../tools/watcher/bin/' . $binary;
 
         if (str_starts_with(__FILE__, 'phar:')) {
-            static $tmpPath;
-
-            if (null === $tmpPath) {
-                $tmpPath = sys_get_temp_dir() . '/' . $binary;
-                copy($binaryPath, $tmpPath);
-                chmod($tmpPath, 0o755);
-            }
-
-            $binaryPath = $tmpPath;
+            $binaryPath = $this->extractBinary($binaryPath, $binary);
         }
 
         $watchContext = $context->withTty(false)->withPty(false)->withTimeout(null);
@@ -109,5 +105,23 @@ final readonly class WatchRunner
                 $this->sectionOutput->writeProcessOutput($type, $bytes, $process);
             }
         });
+    }
+
+    /**
+     * A binary cannot be executed from inside a phar: the watcher is extracted
+     * to the user cache directory, under the Castor version, and reused on the
+     * next runs as long as its content is the expected one.
+     */
+    private function extractBinary(string $binaryPath, string $binary): string
+    {
+        $target = $this->cacheDir . '/watcher/' . Application::VERSION . '/' . $binary;
+
+        if (!is_file($target) || hash_file('sha256', $target) !== hash_file('sha256', $binaryPath)) {
+            $this->filesystem->mkdir(\dirname($target), 0o700);
+            $this->filesystem->copy($binaryPath, $target, true);
+            $this->filesystem->chmod($target, 0o755);
+        }
+
+        return $target;
     }
 }

--- a/tests/Helper/OutputCleaner.php
+++ b/tests/Helper/OutputCleaner.php
@@ -52,7 +52,7 @@ final class OutputCleaner
 
         // Fix the watcher path when running the tests with local project VS in the phar / static
         $string = str_replace('.../src/Runner/../../tools/watcher/bin/watcher-linux-amd64', 'watcher', $string);
-        $string = str_replace('/tmp/watcher-linux-amd64', 'watcher', $string);
+        $string = preg_replace('{[^\s\'"]+/watcher/[^/\'"]+/watcher-linux-amd64}', 'watcher', $string);
 
         // composer version
         $string = preg_replace('{Composer version \d+.\d+.\d+ \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}}', 'Composer version 1.2.3', $string);

--- a/tests/WatchRunnerTest.php
+++ b/tests/WatchRunnerTest.php
@@ -13,6 +13,7 @@ use Castor\Runner\ProcessRunner;
 use Castor\Runner\WatchRunner;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
 class WatchRunnerTest extends TestCase
@@ -25,6 +26,45 @@ class WatchRunnerTest extends TestCase
     public function testWatchingAnArrayOfPathsStartsOneWatcherPerPath(): void
     {
         $this->assertSame(['/path/to/watch', '/another/path'], $this->getWatchedPaths(['/path/to/watch', '/another/path']));
+    }
+
+    /**
+     * In a phar, the watcher binary is extracted to the cache directory, and
+     * put back when the extracted file does not match anymore.
+     */
+    public function testTheWatcherBinaryIsExtractedToTheCacheDirectory(): void
+    {
+        $fs = new Filesystem();
+        $cacheDir = sys_get_temp_dir() . '/castor-test-watch-' . uniqid();
+        $fs->remove($cacheDir);
+
+        $source = $cacheDir . '-source';
+        $fs->dumpFile($source, 'the watcher binary');
+
+        $runner = new WatchRunner(
+            $this->createStub(ContextRegistry::class),
+            new ParallelRunner($this->createStub(Application::class), new NullOutput()),
+            $this->createStub(ProcessRunner::class),
+            $this->createStub(SectionOutput::class),
+            $this->createStub(Installation::class),
+            $fs,
+            $cacheDir,
+        );
+        $extract = new \ReflectionMethod(WatchRunner::class, 'extractBinary');
+
+        $target = $extract->invoke($runner, $source, 'watcher-test');
+
+        $this->assertSame($cacheDir . '/watcher/' . Application::VERSION . '/watcher-test', $target);
+        $this->assertFileEquals($source, $target);
+        $this->assertTrue(is_executable($target));
+        $this->assertSame(0o700, fileperms(\dirname($target)) & 0o777);
+
+        // A tampered or outdated extracted binary is replaced
+        $fs->dumpFile($target, 'something else');
+        $this->assertSame($target, $extract->invoke($runner, $source, 'watcher-test'));
+        $this->assertFileEquals($source, $target);
+
+        $fs->remove([$cacheDir, $source]);
     }
 
     /**
@@ -59,6 +99,8 @@ class WatchRunnerTest extends TestCase
             $processRunner,
             $this->createStub(SectionOutput::class),
             $installation,
+            new Filesystem(),
+            sys_get_temp_dir() . '/castor-test-watch',
         )->watch($path, static function (): void {}, new Context());
 
         return $watchedPaths;


### PR DESCRIPTION
In the phar and static builds, `watch()` copies the watcher binary to a fixed path in the system temporary directory (`/tmp/watcher-linux-amd64`), shared by all the users of the machine, and runs it from there without checking the copy: a file or a symbolic link left at that path by someone else breaks `watch()`, or gets overwritten.

The binary is now extracted to the user cache directory (`~/.cache/castor/watcher/<version>/watcher-<os>-<arch>`), in a directory created with mode 0700, and is replaced whenever its content is not the one embedded in the phar. The copy and chmod failures are reported instead of being ignored.

A unit test covers the extraction and the replacement of a tampered copy. The watch functional test passes with the phar (the output cleaner of the test suite knows the new location).
