### PR TITLE
Never download the remote packages during a shell completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer, in `self-update` and in `castor:repack` when the GitHub CLI is installed and authenticated
 * Restrict the file name chosen by the server in `http_download()`: only the last segment of the `Content-Disposition` file name (or of the URL path) is kept, so the download always lands in the project directory
+* Never download the remote packages during a shell completion: the packages already installed are used, and the completion goes on without the remote imports when there is none
 
 ### Fixes
 

--- a/doc/docs/going-further/extending-castor/remote-imports.md
+++ b/doc/docs/going-further/extending-castor/remote-imports.md
@@ -59,6 +59,12 @@ castor composer update
 
 ## Preventing remote imports
 
+Remote packages are code downloaded from Packagist (or the repositories
+declared in `castor.composer.json`) and executed on your machine, like the
+`castor.php` file itself. They are installed the first time Castor runs in the
+project, whatever the command (`castor list` included), except during a shell
+completion, which never downloads anything.
+
 In case you have trouble with the imported functions (or if you don't trust
 them), you can prevent Castor from importing and running any of them. Add the
 `--no-remote` option when calling any Castor tasks:

--- a/doc/docs/going-further/interacting-with-castor/autocomplete.md
+++ b/doc/docs/going-further/interacting-with-castor/autocomplete.md
@@ -26,6 +26,13 @@ shells and their dedicated instructions, run:
 castor completion --help
 ```
 
+> [!NOTE]
+> To know the tasks to suggest, the completion loads the `castor.php` file of
+> the current directory, so its code runs each time you press <kbd>Tab</kbd>.
+> The [remote packages](../extending-castor/remote-imports.md) are never
+> downloaded by the completion though: when they are not installed yet, the
+> tasks they provide are simply not suggested.
+
 ## Autocomplete arguments
 
 You have two options to make your arguments autocompleted.

--- a/doc/help/faq.md
+++ b/doc/help/faq.md
@@ -106,6 +106,22 @@ Usually, tasks are very small, like 1 or 2 lines of code. So you probably don't
 want to waste your project with ops command that are not strictly related to the
 business.
 
+## Is it safe to run Castor in a project I do not trust?
+
+No more than running `make`, `composer install` or `npm install` there: the
+`castor.php` file is PHP code, and Castor runs it to discover the tasks. So
+**every** Castor command runs it, including `castor list`, `castor --help` and
+the shell completion, before any task is executed. The same goes for the
+[remote packages](../docs/going-further/extending-castor/remote-imports.md)
+declared in `castor.composer.json`, which are downloaded and loaded the first
+time Castor runs in the project (never during a shell completion).
+
+So, before running Castor in a project you just cloned, read its `castor.php`
+file, and its `castor.composer.json` and `castor.composer.lock` files, like you
+would read a `Makefile` or a `composer.json`. The `--no-remote` option, or the
+`CASTOR_NO_REMOTE` environment variable, keeps Castor from installing and
+loading the remote packages.
+
 ## Why "Castor"?
 
 Castor means "beaver" in french. It's an animal building stuff. And this is what

--- a/src/Import/Exception/RemoteNotAllowed.php
+++ b/src/Import/Exception/RemoteNotAllowed.php
@@ -4,4 +4,11 @@ namespace Castor\Import\Exception;
 
 class RemoteNotAllowed extends \RuntimeException
 {
+    /**
+     * @param bool $silent Whether the skipped import is expected, and not worth a warning
+     */
+    public function __construct(string $message, public readonly bool $silent = false)
+    {
+        parent::__construct($message);
+    }
 }

--- a/src/Import/Importer.php
+++ b/src/Import/Importer.php
@@ -7,6 +7,7 @@ use Castor\Import\Exception\RemoteNotAllowed;
 use Castor\Import\Remote\Composer;
 use JoliCode\PhpOsHelper\OsHelper;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\Finder\Finder;
 
 use function Castor\Internal\castor_require;
@@ -48,7 +49,7 @@ class Importer
             } catch (ImportError $e) {
                 throw $this->createImportException($package, $e->getMessage());
             } catch (RemoteNotAllowed $e) {
-                $this->logger->warning(\sprintf('Could not import "%s": %s', $path, $e->getMessage()));
+                $this->logger->log($e->silent ? LogLevel::DEBUG : LogLevel::WARNING, \sprintf('Could not import "%s": %s', $path, $e->getMessage()));
 
                 return;
             }

--- a/src/Import/Remote/Composer.php
+++ b/src/Import/Remote/Composer.php
@@ -24,6 +24,9 @@ class Composer
 {
     public const VENDOR_DIR = '.castor/vendor';
 
+    /** Whether the remote packages were needed, but not installed, by a shell completion */
+    private bool $skippedForCompletion = false;
+
     public function __construct(
         private readonly Kernel $kernel,
         private readonly InputInterface $input,
@@ -37,7 +40,7 @@ class Composer
 
     public function isRemoteAllowed(): bool
     {
-        if ($this->disableRemote) {
+        if ($this->disableRemote || $this->skippedForCompletion) {
             return false;
         }
 
@@ -68,6 +71,16 @@ class Composer
         $vendorDirectory = $entrypointDirectory . '/' . self::VENDOR_DIR;
 
         if (!$update && $this->isInstalled($vendorDirectory, $composerLockFile)) {
+            return;
+        }
+
+        // A shell completion must not download and run anything: the packages
+        // already installed, even outdated, are used, and the completion goes
+        // on without the remote imports when there is none
+        if ('_complete' === $this->input->getFirstArgument()) {
+            $this->skippedForCompletion = !file_exists($vendorDirectory . '/autoload.php');
+            $this->logger->debug('The remote packages are not installed during a shell completion.');
+
             return;
         }
 
@@ -109,6 +122,10 @@ class Composer
 
     public function importFromPackage(string $scheme, string $package, ?string $file = null): void
     {
+        if ($this->skippedForCompletion) {
+            throw new RemoteNotAllowed('Remote packages are not installed during a shell completion.', silent: true);
+        }
+
         if (!$this->isRemoteAllowed()) {
             throw new RemoteNotAllowed('Remote imports are disabled.');
         }

--- a/tests/CompletionWithoutRemotePackagesTest.php
+++ b/tests/CompletionWithoutRemotePackagesTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Castor\Tests;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class CompletionWithoutRemotePackagesTest extends TaskTestCase
+{
+    private const string FIXTURE = '{{ base }}/tests/fixtures/valid/import-same-package-with-default-version';
+
+    /**
+     * A shell completion must never download anything: when the remote
+     * packages are not installed, the completion runs without them.
+     */
+    public function test(): void
+    {
+        $process = $this->runTask(
+            ['_complete', '--no-interaction', '-sbash', '-c1', '-a1', '-icastor', '-il'],
+            self::FIXTURE,
+            needRemote: true,
+            needResetVendor: true,
+        );
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertDirectoryDoesNotExist(str_replace('{{ base }}', __DIR__ . '/..', self::FIXTURE) . '/.castor/vendor');
+        $this->assertStringNotContainsString('remote packages', $process->getOutput());
+        $this->assertStringNotContainsString('Could not import', $process->getOutput());
+        $this->assertStringContainsString('list', $process->getOutput());
+    }
+}


### PR DESCRIPTION
Like any other command, a shell completion loads the `castor.php` file and, when the project declares remote packages, runs `composer install` first: pressing Tab in a freshly cloned project was enough to download and run code from Packagist.

The completion now uses the packages already installed, even outdated, and simply goes on without the remote imports when there is none: the tasks they would provide are not suggested, and no warning is printed (a warning would end up in the suggestions, since the logs go to the standard output).

The documentation now states what running Castor in a project implies (a new FAQ entry, plus notes in the autocomplete and remote imports pages): `castor.php` and the remote packages are code, run by every command including `list`, `--help` and the completion, and `--no-remote` / `CASTOR_NO_REMOTE` keep the remote packages out.

A functional test runs the completion in a fixture with remote packages and no vendor directory, and checks that nothing is installed.
