### PR TITLE
Refuse an unattested Castor phar in repack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Verify the checksum of the binary downloaded by the installer against the `SHA256SUMS` file of the release, download it to a private temporary file removed whatever happens, and read the whole installer script before running anything
 * Prefer the PHP zip extension over the zip binary in `zip()` when a password is given: the binary gets the password as a command line argument, readable by every user of the machine while the archive is created. `zip_binary()` still does, and now warns about it
 * Pass the script run by `run_php()` to the Castor process as an argument instead of the `CASTOR_PHP_REPLACE` environment variable, which made any Castor process include an arbitrary file when set in its environment
+* Refuse a Castor phar without provenance attestation in `castor:repack`, like `self-update` does, unless the new `--allow-unattested` option is passed for a release published before attestations existed
 
 ### Fixes
 

--- a/doc/docs/going-further/extending-castor/repack.md
+++ b/doc/docs/going-further/extending-castor/repack.md
@@ -46,8 +46,12 @@ castor repack
 <!-- -->
 > [!NOTE]
 > The Castor phar embedded in your application is downloaded from the GitHub
-> releases. When the [GitHub CLI](https://cli.github.com/) is installed and
-> authenticated, its provenance is verified with `gh attestation verify`.
+> releases, with the `GITHUB_TOKEN` environment variable as credentials when it
+> is set (it raises the API rate limit in CI). When the
+> [GitHub CLI](https://cli.github.com/) is installed and authenticated, the
+> provenance of the phar is verified with `gh attestation verify`, and a phar
+> without attestation is refused: pass the `--allow-unattested` option to
+> embed a Castor release published before attestations existed.
 
 {% include-markdown "/build/command_castor-repack.md" start="`castor:repack`\n---------------" %}
 

--- a/src/Console/Command/RepackCommand.php
+++ b/src/Console/Command/RepackCommand.php
@@ -51,6 +51,7 @@ class RepackCommand extends Command
             ->addOption('arch', null, InputOption::VALUE_REQUIRED, 'The targeted CPU architecture', 'amd64', ['amd64', 'arm64'])
             ->addOption('castor-version', null, InputOption::VALUE_REQUIRED, 'The Castor version to use (vX.Y.Z, or snapshot)', Application::isSnapshot() ? ReleaseHelper::SNAPSHOT_TAG : Application::VERSION)
             ->addOption('castor-phar', null, InputOption::VALUE_REQUIRED, 'A specific castor phar to use (/path/to/castor.phar)')
+            ->addOption('allow-unattested', null, InputOption::VALUE_NONE, 'Accept a Castor phar downloaded from GitHub without provenance attestation (releases published before attestations existed)')
             ->addOption('no-logo', null, InputOption::VALUE_NONE, 'Hide Castor logo')
             ->addOption('logo-file', null, InputOption::VALUE_OPTIONAL, 'Path to a PHP file that returns a logo as a string, or a closure that returns a logo as a string')
             ->addOption('output-directory', null, InputOption::VALUE_REQUIRED, 'Path to the directory where the phar will be generated', '')
@@ -98,7 +99,7 @@ class RepackCommand extends Command
         }
 
         // Download and extract castor phar from GitHub
-        $castorSourceDir = $this->downloadAndExtractCastorPhar($os, $arch, $input->getOption('castor-version'), $input->getOption('castor-phar'));
+        $castorSourceDir = $this->downloadAndExtractCastorPhar($os, $arch, $input->getOption('castor-version'), $input->getOption('castor-phar'), $input->getOption('allow-unattested'));
 
         $appName = $input->getOption('app-name');
         $appVersion = $input->getOption('app-version');
@@ -218,7 +219,7 @@ class RepackCommand extends Command
         };
     }
 
-    private function downloadAndExtractCastorPhar(string $os, string $arch, string $version, ?string $pharPath): string
+    private function downloadAndExtractCastorPhar(string $os, string $arch, string $version, ?string $pharPath, bool $allowUnattested): string
     {
         $extractDir = PathHelper::getRoot() . '/.castor-vendor';
 
@@ -279,7 +280,7 @@ class RepackCommand extends Command
 
             $this->fs->dumpFile($pharPath, $pharContent);
 
-            $this->verifyProvenance($pharPath);
+            $this->verifyProvenance($pharPath, $allowUnattested);
         }
 
         $this->io->comment('Extracting Castor phar...');
@@ -297,7 +298,13 @@ class RepackCommand extends Command
         return $extractDir;
     }
 
-    private function verifyProvenance(string $pharPath): void
+    /**
+     * The downloaded phar gets embedded in the application and distributed
+     * with it, so a phar without attestation is refused: the releases
+     * published before attestations existed need --allow-unattested. Without
+     * an authenticated GitHub CLI, the phar is used unverified.
+     */
+    private function verifyProvenance(string $pharPath, bool $allowUnattested): void
     {
         try {
             $status = $this->attestationHelper->verify($pharPath);
@@ -307,10 +314,16 @@ class RepackCommand extends Command
             throw $e;
         }
 
+        if (AttestationStatus::NotAttested === $status && !$allowUnattested) {
+            $this->fs->remove($pharPath);
+
+            throw new \RuntimeException('No attestation found on GitHub for the downloaded Castor phar, so it cannot be trusted as a Castor build. Pass --allow-unattested to accept a release published before attestations existed.');
+        }
+
         match ($status) {
             AttestationStatus::Verified => $this->io->comment('Castor phar provenance verified.'),
-            AttestationStatus::NotAttested => $this->io->warning('No attestation found for this Castor release, its provenance cannot be verified.'),
-            AttestationStatus::Skipped => $this->io->comment('Install and log in to the GitHub CLI (gh) to verify the provenance of the downloaded Castor phar.'),
+            AttestationStatus::NotAttested => $this->io->warning('No attestation found for this Castor release, its provenance cannot be verified. It is accepted because of --allow-unattested.'),
+            AttestationStatus::Skipped => $this->io->warning('Install and log in to the GitHub CLI (gh 2.49 or later) to verify the provenance of the downloaded Castor phar.'),
         };
     }
 }

--- a/tests/Slow/RepackHelper.php
+++ b/tests/Slow/RepackHelper.php
@@ -85,6 +85,8 @@ class RepackHelper
         if ($useGithubRelease) {
             $command[] = '--castor-version';
             $command[] = 'v1.2.0';
+            // This release predates the attestations
+            $command[] = '--allow-unattested';
         } else {
             $castorPhar = __DIR__ . '/../../tools/phar/build/castor.linux-amd64.phar';
             if (!file_exists($castorPhar)) {


### PR DESCRIPTION
The Castor phar downloaded by `repack` gets embedded in the application and distributed with it, yet a phar without provenance attestation was accepted with a warning, while `self-update` refuses it. Both now behave the same: the phar is refused and removed, and the releases published before attestations existed can still be embedded with the new `--allow-unattested` option (the repack test uses it for v1.2.0).

As before, the phar is used unverified, with a warning, when the GitHub CLI is not installed or not authenticated.

The documentation also mentions that the `GITHUB_TOKEN` environment variable is used as credentials for the download when it is set.
