### PR TITLE
Restrict the cache directory to its owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Quote the remote `path` of `ssh_run()`, and reject a `host`, `user`, `jump_host`, `path_private_key` or `multiplexing_control_path` containing a shell metacharacter: they end up in a local shell command line, so a value coming from user input could run a command instead of opening a connection
 * Pass the container name of `wait_for_docker_container()` to `docker` as an argument instead of building a shell command with it
 * Extract the watcher binary used by `watch()` in the phar and static builds to the user cache directory, under the Castor version, instead of a fixed path in the system temporary directory shared by all users, and replace it when its content is not the expected one
+* Create the cache directory readable by its owner only (mode `0700`), and restrict an existing one, as the cache may hold data written by the tasks; honor `XDG_CACHE_HOME` for its default location, and fall back to a per-user directory in the system temporary directory, instead of one shared by all users, when the home directory cannot be determined
 * Fix architecture detection on Linux ARM64 (`aarch64`), which made the watcher and the update hints pick the amd64 binaries
 * Fix `run()` ignoring the timeout when executed inside `parallel()`: the process was waited for in its own fiber loop, so Symfony's timeout check never ran and the process could run forever
 

--- a/doc/docs/going-further/helpers/cache.md
+++ b/doc/docs/going-further/helpers/cache.md
@@ -56,13 +56,17 @@ $result = cache('a-key', expansive_call(...), true);
 
 ## Cache location on the filesystem
 
-By default, Castor caches items on the filesystem, in the `<home directory>/.cache/castor`
-directory. If you want to change the cache directory, you can set the `CASTOR_CACHE_DIR`
+By default, Castor caches items on the filesystem, in the `$XDG_CACHE_HOME/castor`
+directory, or `<home directory>/.cache/castor` when `XDG_CACHE_HOME` is not set.
+If you want to change the cache directory, you can set the `CASTOR_CACHE_DIR`
 environment variable.
 
 ```bash
 CASTOR_CACHE_DIR=/tmp/castor-cache castor foo
 ```
+
+The cache directory is created readable by its owner only (mode `0700`), as
+it may hold data written by your tasks.
 
 ## The `get_cache()` function
 

--- a/src/Helper/PlatformHelper.php
+++ b/src/Helper/PlatformHelper.php
@@ -40,16 +40,31 @@ final class PlatformHelper
         return $result ??= AgentDetector::detect()->isAgent;
     }
 
+    /**
+     * $XDG_CACHE_HOME/castor, or ~/.cache/castor. When the home directory
+     * cannot be determined, a per-user directory in the system temporary
+     * directory is used: the cache holds data written by the tasks, it must
+     * not be shared with the other users of the machine.
+     */
     public static function getDefaultCacheDirectory(): string
     {
-        try {
-            $home = self::getUserDirectory();
-            $directory = $home ? $home . '/.cache' : sys_get_temp_dir();
-        } catch (\RuntimeException) {
-            $directory = sys_get_temp_dir();
+        if ($xdgCacheHome = self::getEnv('XDG_CACHE_HOME')) {
+            return $xdgCacheHome . '/castor';
         }
 
-        return $directory . '/castor';
+        try {
+            $home = self::getUserDirectory();
+        } catch (\RuntimeException) {
+            $home = '';
+        }
+
+        if ($home) {
+            return $home . '/.cache/castor';
+        }
+
+        $uid = \function_exists('posix_getuid') ? posix_getuid() : get_current_user();
+
+        return sys_get_temp_dir() . '/castor-' . $uid;
     }
 
     /**

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -39,6 +39,8 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -121,6 +123,8 @@ final class Kernel extends AbstractKernel
         // KernelTrait aliases self::class to the synthetic "kernel" service
         $container->set('kernel', $this);
         $container->set(ContainerInterface::class, $container);
+
+        $this->restrictCacheDirectory($this->getCacheDir());
     }
 
     public function init(InputInterface $input, OutputInterface $output): void
@@ -288,6 +292,33 @@ final class Kernel extends AbstractKernel
         $bundle = new ServicesBundle();
 
         $this->bundles = [$bundle->getName() => $bundle];
+    }
+
+    /**
+     * The cache holds data written by the tasks, and what the update check
+     * fetched: it is only readable by its owner. An existing directory that
+     * is more permissive is restricted, when it belongs to the current user.
+     * Failures are left to the cache adapter, which reports them when it
+     * cannot write.
+     */
+    private function restrictCacheDirectory(string $directory): void
+    {
+        $filesystem = new Filesystem();
+
+        try {
+            if (!is_dir($directory)) {
+                $filesystem->mkdir($directory, 0o700);
+
+                return;
+            }
+
+            $ownedByCurrentUser = !\function_exists('posix_getuid') || fileowner($directory) === posix_getuid();
+
+            if ($ownedByCurrentUser && 0 !== (fileperms($directory) & 0o077)) {
+                $filesystem->chmod($directory, 0o700);
+            }
+        } catch (IOExceptionInterface) {
+        }
     }
 
     private function mount(InputInterface $input, OutputInterface $output): void

--- a/tests/CacheDirectoryTest.php
+++ b/tests/CacheDirectoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Castor\Tests;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class CacheDirectoryTest extends TaskTestCase
+{
+    public function testTheCacheDirectoryIsOnlyReadableByItsOwner(): void
+    {
+        if (\DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('File modes are not supported on Windows.');
+        }
+
+        // runTask() removes the cache directory first, so Castor creates it
+        $process = $this->runTask(['list']);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertDirectoryExists(self::$castorCacheDir);
+        $this->assertSame(0o700, fileperms(self::$castorCacheDir) & 0o777);
+
+        // An existing, too permissive, directory is restricted
+        chmod(self::$castorCacheDir, 0o755);
+        $process = $this->runTask(['list'], needResetCache: false);
+
+        if (0 !== $process->getExitCode()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $this->assertSame(0o700, fileperms(self::$castorCacheDir) & 0o777);
+    }
+}

--- a/tests/Helper/PlatformHelperTest.php
+++ b/tests/Helper/PlatformHelperTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Castor\Tests\Helper;
+
+use Castor\Helper\PlatformHelper;
+use PHPUnit\Framework\TestCase;
+
+class PlatformHelperTest extends TestCase
+{
+    private const array VARIABLES = ['XDG_CACHE_HOME', 'HOME'];
+
+    /** @var array<string, array{server: ?string, env: ?string, process: string|false}> */
+    private array $originalEnvironment = [];
+
+    protected function setUp(): void
+    {
+        foreach (self::VARIABLES as $name) {
+            $this->originalEnvironment[$name] = [
+                'server' => $_SERVER[$name] ?? null,
+                'env' => $_ENV[$name] ?? null,
+                'process' => getenv($name),
+            ];
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnvironment as $name => $original) {
+            if (null === $original['server']) {
+                unset($_SERVER[$name]);
+            } else {
+                $_SERVER[$name] = $original['server'];
+            }
+
+            if (null === $original['env']) {
+                unset($_ENV[$name]);
+            } else {
+                $_ENV[$name] = $original['env'];
+            }
+
+            putenv(false === $original['process'] ? $name : "{$name}={$original['process']}");
+        }
+    }
+
+    public function testTheCacheDirectoryHonorsXdgCacheHome(): void
+    {
+        self::setEnvironmentVariable('XDG_CACHE_HOME', '/xdg/cache');
+
+        $this->assertSame('/xdg/cache/castor', PlatformHelper::getDefaultCacheDirectory());
+    }
+
+    public function testTheCacheDirectoryDefaultsToTheHomeDirectory(): void
+    {
+        self::setEnvironmentVariable('XDG_CACHE_HOME', null);
+        self::setEnvironmentVariable('HOME', '/home/castor');
+
+        $this->assertSame('/home/castor/.cache/castor', PlatformHelper::getDefaultCacheDirectory());
+    }
+
+    /**
+     * PlatformHelper::getEnv() reads $_SERVER, then $_ENV, then the process
+     * environment: all three are set, and restored by tearDown().
+     */
+    private static function setEnvironmentVariable(string $name, ?string $value): void
+    {
+        if (null === $value) {
+            unset($_SERVER[$name], $_ENV[$name]);
+            putenv($name);
+
+            return;
+        }
+
+        $_SERVER[$name] = $value;
+        $_ENV[$name] = $value;
+        putenv("{$name}={$value}");
+    }
+}


### PR DESCRIPTION
The cache directory holds data written by the tasks through `cache()` and `fingerprint()`, and was created with the default mode, usually readable by everyone on the machine. It is now created with mode `0700`, and an existing directory owned by the current user is restricted the same way. Failures are ignored there and left to the cache adapter, which reports them when it cannot write.

Its default location now honors `XDG_CACHE_HOME` (`$XDG_CACHE_HOME/castor`), and when the home directory cannot be determined, a per-user directory in the system temporary directory (`/tmp/castor-<uid>`) is used instead of `/tmp/castor`, shared by all the users.

A functional test checks the mode of the created directory and the restriction of an existing one, and a unit test the default locations.
