### PR TITLE
Keep the zip password off the command line when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Only accept attestations signed by the Artifacts workflow when verifying the provenance of a binary, and skip the verification with a GitHub CLI too old to know about attestations instead of failing
 * Verify the SHA-256 checksum of the static-php-cli archive downloaded by `castor:compile`: the checksums of the default `--spc-version` are known, any other version needs the new `--spc-sha256` option
 * Verify the checksum of the binary downloaded by the installer against the `SHA256SUMS` file of the release, download it to a private temporary file removed whatever happens, and read the whole installer script before running anything
+* Prefer the PHP zip extension over the zip binary in `zip()` when a password is given: the binary gets the password as a command line argument, readable by every user of the machine while the archive is created. `zip_binary()` still does, and now warns about it
 
 ### Fixes
 

--- a/doc/docs/going-further/helpers/archive.md
+++ b/doc/docs/going-further/helpers/archive.md
@@ -30,6 +30,8 @@ function compress_file(string $file, string $destination): void
 
 > [!NOTE]
 > The `zip()` function automatically selects the best available method (binary or PHP) based on your system configuration.
+> When a password is given, the PHP zip extension is preferred: it encrypts with AES-256 and keeps the password private,
+> while the zip binary takes it as a command line argument (see `zip_binary()` below).
 >
 > The `source` parameter can be either a file path or a directory path. Both are fully supported.
 <!-- -->
@@ -39,6 +41,10 @@ function compress_file(string $file, string $destination): void
 ## The `zip_binary()` function
 
 Castor provides a `zip_binary()` function to compress files using the native zip binary:
+
+> [!WARNING]
+> The zip binary only accepts a password as a command line argument, which is readable by every user of the machine
+> (in `ps` for instance) while the archive is created. Use `zip()` or `zip_php()` when the password must stay private.
 
 ```php
 use Castor\Attribute\AsArgument;

--- a/src/Helper/ZipArchiver.php
+++ b/src/Helper/ZipArchiver.php
@@ -25,16 +25,24 @@ class ZipArchiver
         int $compressionLevel = 6,
         bool $overwrite = false,
     ): void {
-        if ($this->isZipBinaryAvailable() && CompressionMethod::ZSTD !== $compressionMethod) {
-            $this->zipWithBinary($source, $destination, $password, $compressionMethod, $compressionLevel, $overwrite);
+        $zipBinaryAvailable = CompressionMethod::ZSTD !== $compressionMethod && $this->isZipBinaryAvailable();
+        $zipExtensionAvailable = class_exists(\ZipArchive::class);
+
+        // The zip binary gets the password as a command line argument, readable
+        // by every user of the machine while the archive is created: PHP keeps
+        // it private, so it comes first when there is a password
+        if ($zipExtensionAvailable && (null !== $password || !$zipBinaryAvailable)) {
+            if (!$zipBinaryAvailable) {
+                $this->logger->notice('Native zip binary not available or ZSTD compression method is requested, falling back to PHP ZipArchive');
+            }
+
+            $this->zipWithPhp($source, $destination, $password, $compressionMethod, $compressionLevel, $overwrite);
 
             return;
         }
 
-        $this->logger->notice('Native zip binary not available or ZSTD compression method is requested, falling back to PHP ZipArchive');
-
-        if (class_exists(\ZipArchive::class)) {
-            $this->zipWithPhp($source, $destination, $password, $compressionMethod, $compressionLevel, $overwrite);
+        if ($zipBinaryAvailable) {
+            $this->zipWithBinary($source, $destination, $password, $compressionMethod, $compressionLevel, $overwrite);
 
             return;
         }
@@ -57,7 +65,11 @@ class ZipArchiver
         $zipCommand = ['zip', '-r', $destination, '-Z', $compressionMethod->value, '-' . $compressionLevel];
 
         if (null !== $password) {
-            // @todo improve security by using -e instead, when run() will allow input to be set before running the command
+            // The zip binary only takes a password as an argument (-e reads it
+            // from the terminal, not from stdin), so it shows up in the process
+            // list until the archive is created
+            $this->logger->warning('The password is passed to the zip binary as a command line argument, readable by every user of the machine while the archive is created. Use zip_php() to keep it private.');
+
             $zipCommand = [...$zipCommand, '-P', $password];
         }
 


### PR DESCRIPTION
The zip binary only takes a password as a command line argument (`-P`, since `-e` reads it from the terminal, not from stdin), which is readable by every user of the machine, in the process list, while the archive is created.

`zip()` now prefers the PHP zip extension, which keeps the password private and encrypts with AES-256, as soon as a password is given, and only falls back to the binary when the extension is missing. Without a password, the binary is still preferred as before. `zip_binary()` still has no other choice, and now logs a warning about it; the documentation says so too.

The archive tests pass, and with a password `zip()` no longer spawns the `zip` binary.
