### PR TITLE
Pass the script run by run_php() as an argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Verify the SHA-256 checksum of the static-php-cli archive downloaded by `castor:compile`: the checksums of the default `--spc-version` are known, any other version needs the new `--spc-sha256` option
 * Verify the checksum of the binary downloaded by the installer against the `SHA256SUMS` file of the release, download it to a private temporary file removed whatever happens, and read the whole installer script before running anything
 * Prefer the PHP zip extension over the zip binary in `zip()` when a password is given: the binary gets the password as a command line argument, readable by every user of the machine while the archive is created. `zip_binary()` still does, and now warns about it
+* Pass the script run by `run_php()` to the Castor process as an argument instead of the `CASTOR_PHP_REPLACE` environment variable, which made any Castor process include an arbitrary file when set in its environment
 
 ### Fixes
 

--- a/bin/castor
+++ b/bin/castor
@@ -16,10 +16,17 @@ if ($memoryLimit && function_exists('ini_set')) {
     ini_set('memory_limit', $memoryLimit);
 }
 
-$phpFile = $_SERVER['CASTOR_PHP_REPLACE'] ?? false;
-if ($phpFile) {
-    // Avoid infinite loop if we exec castor inside castor
-    unset($_SERVER['CASTOR_PHP_REPLACE']);
+// run_php() runs a PHP script or phar through this very binary, which is the
+// only PHP available with the static build. The script is given as the first
+// argument, then removed from argv so the script sees its own arguments.
+$phpReplacePrefix = '--castor-php-replace=';
+if (isset($_SERVER['argv'][1]) && str_starts_with($_SERVER['argv'][1], $phpReplacePrefix)) {
+    $phpFile = substr($_SERVER['argv'][1], strlen($phpReplacePrefix));
+
+    array_splice($_SERVER['argv'], 1, 1);
+    $_SERVER['argc'] = count($_SERVER['argv']);
+    $argv = $_SERVER['argv'];
+    $argc = $_SERVER['argc'];
 
     // override script filename env var
     $_SERVER['SCRIPT_FILENAME'] = $phpFile;

--- a/src/Runner/PhpRunner.php
+++ b/src/Runner/PhpRunner.php
@@ -31,8 +31,7 @@ class PhpRunner
         $castorPath = $_SERVER['argv'][0];
         $context ??= $this->contextRegistry->getCurrentContext();
 
-        return $this->processRunner->run([$castorPath, ...$arguments], context: $context->withEnvironment([
-            'CASTOR_PHP_REPLACE' => $phpPath,
-        ]), callback: $callback);
+        // See bin/castor
+        return $this->processRunner->run([$castorPath, '--castor-php-replace=' . $phpPath, ...$arguments], context: $context, callback: $callback);
     }
 }


### PR DESCRIPTION
`run_php()` runs a PHP script or phar through the Castor binary itself, which is the only PHP available with the static build, and told it which file to include through the `CASTOR_PHP_REPLACE` environment variable. Any Castor process started with that variable in its environment (by a wrapper, `sudo` with `env_keep`, a service...) thus included an arbitrary file before doing anything else.

The script is now given as the first argument of the spawned process (`castor --castor-php-replace=/path/to/script ...`), and removed from `argv` so the script still sees its own arguments, as before. The environment variable is not honored anymore.

The `run_php()` example test and the Symfony task tests, which go through the same runner, pass.
