### PR TITLE
Update JoliNotif to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Security
 
 * Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer, in `self-update` and in `castor:repack` when the GitHub CLI is installed and authenticated
+* Update JoliNotif to 3.4.0, which fixes a script injection in its AppleScript and PowerShell drivers: the content of a notification, like the command line of a process sent with `notify`, could break out of the generated script
 
 ### Fixes
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "php": ">=8.4",
         "composer/composer": "^2.10.2",
-        "jolicode/jolinotif": "^3.3.1",
+        "jolicode/jolinotif": "^3.4.0",
         "jolicode/php-os-helper": "^0.3.0",
         "laravel/agent-detector": "^2.0.2",
         "monolog/monolog": "^3.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d65638f633662aebd8132110eb8730e7",
+    "content-hash": "e674d70bec075fcb04ea0f1333698c43",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -622,23 +622,22 @@
         },
         {
             "name": "jolicode/jolinotif",
-            "version": "v3.3.1",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jolicode/JoliNotif.git",
-                "reference": "fd188c41fdf2d0659a6e48bac705e0615e6eefdb"
+                "reference": "531b7a42837050eb8f6ee69150dd70a5cadb917d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jolicode/JoliNotif/zipball/fd188c41fdf2d0659a6e48bac705e0615e6eefdb",
-                "reference": "fd188c41fdf2d0659a6e48bac705e0615e6eefdb",
+                "url": "https://api.github.com/repos/jolicode/JoliNotif/zipball/531b7a42837050eb8f6ee69150dd70a5cadb917d",
+                "reference": "531b7a42837050eb8f6ee69150dd70a5cadb917d",
                 "shasum": ""
             },
             "require": {
                 "jolicode/php-os-helper": "^0.3",
                 "php": ">=8.3",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
-                "symfony/deprecation-contracts": "^3",
                 "symfony/process": "^6.4 || ^7.3 || ^8.0"
             },
             "require-dev": {
@@ -683,7 +682,7 @@
             ],
             "support": {
                 "issues": "https://github.com/jolicode/JoliNotif/issues",
-                "source": "https://github.com/jolicode/JoliNotif/tree/v3.3.1"
+                "source": "https://github.com/jolicode/JoliNotif/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -691,7 +690,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-22T08:53:38+00:00"
+            "time": "2026-09-09T11:32:52+00:00"
         },
         {
             "name": "jolicode/php-os-helper",


### PR DESCRIPTION
[JoliNotif 3.4.0](https://github.com/jolicode/JoliNotif/releases/tag/v3.4.0) fixes a script injection in the AppleScript and PowerShell drivers: the content of a notification, like the command line of a process sent by the `notify` option of the context, could break out of the generated script (jolicode/JoliNotif#142).

It also makes the libnotify driver rely on the dynamic linker to find the library, adding support for non x86_64 Linux distributions.
