### PR TITLE
Update Composer to 2.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Security
 
 * Publish [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) for the phars and static binaries, and verify them in the installer, in `self-update` and in `castor:repack` when the GitHub CLI is installed and authenticated
+* Update the embedded Composer to 2.10.3, which fixes an arbitrary command execution through the Perforce source URL of a malicious package ([GHSA-rvx4-ffvw-m9q3](https://github.com/advisories/GHSA-rvx4-ffvw-m9q3))
 
 ### Fixes
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require": {
         "php": ">=8.4",
-        "composer/composer": "^2.10.2",
+        "composer/composer": "^2.10.3",
         "jolicode/jolinotif": "^3.3.1",
         "jolicode/php-os-helper": "^0.3.0",
         "laravel/agent-detector": "^2.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d65638f633662aebd8132110eb8730e7",
+    "content-hash": "acc9087b1d4d1a9df560c5ef1e4db343",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -149,16 +149,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.10.2",
+            "version": "2.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "8d4439f572a97670a9edc039eb3b093cc976b4bc"
+                "reference": "f0de0bf90226853b841672f086d8b58b02332504"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/8d4439f572a97670a9edc039eb3b093cc976b4bc",
-                "reference": "8d4439f572a97670a9edc039eb3b093cc976b4bc",
+                "url": "https://api.github.com/repos/composer/composer/zipball/f0de0bf90226853b841672f086d8b58b02332504",
+                "reference": "f0de0bf90226853b841672f086d8b58b02332504",
                 "shasum": ""
             },
             "require": {
@@ -169,6 +169,8 @@
                 "composer/semver": "^3.3",
                 "composer/spdx-licenses": "^1.5.7",
                 "composer/xdebug-handler": "^2.0.2 || ^3.0.3",
+                "ext-filter": "*",
+                "ext-hash": "*",
                 "ext-json": "*",
                 "justinrainbow/json-schema": "^6.5.1",
                 "php": "^7.2.5 || ^8.0",
@@ -246,7 +248,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.10.2"
+                "source": "https://github.com/composer/composer/tree/2.10.3"
             },
             "funding": [
                 {
@@ -258,7 +260,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-01T09:24:45+00:00"
+            "time": "2026-08-27T11:34:23+00:00"
         },
         {
             "name": "composer/metadata-minifier",


### PR DESCRIPTION
Castor embeds Composer to install the remote packages and to run `castor execute`. Version 2.10.3 fixes an arbitrary command execution through the Perforce source URL of a malicious package ([GHSA-rvx4-ffvw-m9q3](https://github.com/advisories/GHSA-rvx4-ffvw-m9q3)), reported by Dependabot on this repository.

The embedded Composer tests (`castor composer`, remote imports) pass, and `composer audit` is clean.
