### PR TITLE
Tighten the CI and release tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+    # Security updates only: the dependencies are updated by hand with "castor update"
+    - package-ecosystem: 'composer'
+      directory: '/'
+      target-branch: 'main'
+      schedule:
+          interval: 'monthly'
+      open-pull-requests-limit: 0
+
     - package-ecosystem: 'github-actions'
       directory: '/'
       schedule:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [ main ]
 
+# The build jobs attest their artifacts, only the snapshot job needs to write
+# to the repository (see below)
 permissions:
-  contents: write # zizmor: ignore[excessive-permissions]
+  contents: read
   id-token: write # zizmor: ignore[excessive-permissions]
   attestations: write # zizmor: ignore[excessive-permissions]
 
@@ -265,6 +267,8 @@ jobs:
     needs: [checksums]
     name: Publish the snapshot pre-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # zizmor: ignore[excessive-permissions]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,36 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Composer Validate
-        uses: docker://composer:2.7.1
+      - name: Setup PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
-          args: validate
+          php-version: 8.4
+          coverage: none
+
+      - name: Composer Validate
+        run: composer validate
+
+  check-composer-audit:
+    name: Composer audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        with:
+          php-version: 8.4
+          coverage: none
+
+      - name: Composer audit (castor)
+        run: composer audit --locked
+
+      - name: Composer audit (phar tooling)
+        run: composer audit --locked
+        working-directory: tools/phar
 
   markdown:
     name: Lint markdown files

--- a/tools/release/castor.php
+++ b/tools/release/castor.php
@@ -153,10 +153,11 @@ function checkCi(array $run): void
     io()->comment("{$run['name']}'s run id <comment>{$run['databaseId']}</comment>");
 
     if ('completed' === $run['status']) {
-        if ('failure' === $run['conclusion']) {
+        // Anything but a success (failure, cancelled, timed_out...) must not be released
+        if ('success' !== $run['conclusion']) {
             run(['gh', 'run', 'view', $run['databaseId']]);
 
-            throw new ProblemException("The CI {$run['name']} has failed. Please fix it before releasing.");
+            throw new ProblemException("The CI {$run['name']} has not succeeded (conclusion: {$run['conclusion']}). Please fix it before releasing.");
         }
     } else {
         $process = run(['gh', 'run', 'watch', $run['databaseId'], '--exit-status'], context: context()->toInteractive());


### PR DESCRIPTION
- The Artifacts workflow no longer grants `contents: write` to every job: only the `snapshot` job, which publishes the pre-release, gets it. The build jobs keep `id-token` and `attestations` to attest their artifacts (the `checksums` job of #860 will need them too).
- The Composer validation runs with the PHP of `setup-php`, pinned by commit like the other actions, instead of a Docker image pinned by a mutable tag.
- A new CI job runs `composer audit --locked` on the Castor and phar tooling lock files, and Dependabot now watches the Composer dependencies for security updates only (`open-pull-requests-limit: 0`, version updates stay manual with `castor update`).
- The release tool refuses to release a commit whose CI run did not succeed, whatever the conclusion: only an explicit `failure` was blocking, a `cancelled` or `timed_out` run was not.
