### PR TITLE
Document what running a remote package implies

### DIFF
--- a/doc/docs/getting-started/remote.md
+++ b/doc/docs/getting-started/remote.md
@@ -21,6 +21,11 @@ This will download the package and its dependencies, and then run the first
 binary command it finds in the package. In this case, it will run the `php-cs-fixer`
 binary command with the `fix` argument.
 
+> [!WARNING]
+> Like `npx` or `pipx run`, this downloads code from Packagist and runs it on
+> your machine, with your permissions. Only execute packages you trust, and
+> pin their version (see below) to know exactly what runs.
+
 All options after the package name will be passed to the binary command.
 
 ## Specific binary of package


### PR DESCRIPTION
`castor execute` downloads a package from Packagist and runs it on the machine, like `npx` or `pipx run` do. The documentation now says so where the command is introduced, and advises to only run trusted packages and to pin their version.

The remote imports page gets a similar note in #864.
