### PR TITLE
Derive the encryption key with the moderate limits of libsodium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Prefer the PHP zip extension over the zip binary in `zip()` when a password is given: the binary gets the password as a command line argument, readable by every user of the machine while the archive is created. `zip_binary()` still does, and now warns about it
 * Pass the script run by `run_php()` to the Castor process as an argument instead of the `CASTOR_PHP_REPLACE` environment variable, which made any Castor process include an arbitrary file when set in its environment
 * Refuse a Castor phar without provenance attestation in `castor:repack`, like `self-update` does, unless the new `--allow-unattested` option is passed for a release published before attestations existed
+* Derive the key of `encrypt_with_password()` and `encrypt_file_with_password()` with the "moderate" limits of libsodium (Argon2id, 3 passes, 256 MiB) instead of the "interactive" ones, and store the limits in the encrypted payload. Content encrypted by previous versions is still decrypted, but content encrypted by this version needs it, or a later one, to be decrypted
 
 ### Fixes
 

--- a/doc/docs/going-further/helpers/crypto.md
+++ b/doc/docs/going-further/helpers/crypto.md
@@ -29,7 +29,11 @@ function encrypt(#[AsArgument()] string $content = "Hello you!"): void
 ```
 
 > [!NOTE]
-> Under the hood, Castor use libsodium for encryption.
+> Under the hood, Castor use libsodium for encryption: the key is derived from
+> the password with Argon2id, using the "moderate" limits of libsodium (3
+> passes, 256 MiB of memory), and the content is sealed with XSalsa20-Poly1305.
+> Content encrypted by an older version of Castor is still decrypted, but
+> decrypting needs a Castor at least as recent as the one that encrypted.
 
 ## The `decrypt_with_password()` function
 

--- a/src/Helper/SymmetricCrypto.php
+++ b/src/Helper/SymmetricCrypto.php
@@ -5,10 +5,20 @@ namespace Castor\Helper;
 use Psr\Log\LoggerInterface;
 
 /**
+ * Password-based encryption with libsodium: the key is derived from the
+ * password with Argon2id, the content is sealed with XSalsa20-Poly1305.
+ *
+ * The payload is base64("castor-crypto-v2\0" . opslimit . memlimit . nonce . salt . ciphertext),
+ * the limits being 32-bit big-endian integers. The payloads produced before
+ * this header existed are base64(nonce . salt . ciphertext), with the
+ * "interactive" limits of libsodium, and are still decrypted.
+ *
  * @internal
  */
 class SymmetricCrypto
 {
+    private const string MAGIC = "castor-crypto-v2\0";
+
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
@@ -28,12 +38,17 @@ class SymmetricCrypto
 
         $salt = random_bytes(\SODIUM_CRYPTO_PWHASH_SALTBYTES);
 
+        // The "moderate" limits of libsodium: the content is stored, so the
+        // derivation is worth more than the "interactive" limits meant for logins
+        $opslimit = \SODIUM_CRYPTO_PWHASH_OPSLIMIT_MODERATE;
+        $memlimit = \SODIUM_CRYPTO_PWHASH_MEMLIMIT_MODERATE;
+
         $key = sodium_crypto_pwhash(
             \SODIUM_CRYPTO_SECRETBOX_KEYBYTES,
             $password,
             $salt,
-            \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE,
-            \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE
+            $opslimit,
+            $memlimit,
         );
 
         sodium_memzero($password);
@@ -43,7 +58,7 @@ class SymmetricCrypto
         sodium_memzero($content);
         sodium_memzero($key);
 
-        return base64_encode($nonce . $salt . $encrypted);
+        return base64_encode(self::MAGIC . pack('NN', $opslimit, $memlimit) . $nonce . $salt . $encrypted);
     }
 
     public function decrypt(string $encoded, #[\SensitiveParameter] string $password): string
@@ -53,6 +68,33 @@ class SymmetricCrypto
         }
 
         $decoded = base64_decode($encoded);
+
+        if (str_starts_with($decoded, self::MAGIC)) {
+            $header = unpack('Nopslimit/Nmemlimit', substr($decoded, \strlen(self::MAGIC), 8));
+
+            if (!$header) {
+                throw new \RuntimeException('Failed to decrypt the content. Impossible to extract the key derivation limits.');
+            }
+
+            $opslimit = $header['opslimit'];
+            $memlimit = $header['memlimit'];
+
+            // The limits come from the payload: a crafted one must not be
+            // able to exhaust the memory or the CPU, and nothing weaker than
+            // the "interactive" limits was ever produced
+            if (
+                $opslimit < \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE || $opslimit > \SODIUM_CRYPTO_PWHASH_OPSLIMIT_SENSITIVE
+                || $memlimit < \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE || $memlimit > \SODIUM_CRYPTO_PWHASH_MEMLIMIT_SENSITIVE
+            ) {
+                throw new \RuntimeException('Failed to decrypt the content. The key derivation limits are not supported.');
+            }
+
+            $decoded = substr($decoded, \strlen(self::MAGIC) + 8);
+        } else {
+            // Encrypted before the header existed
+            $opslimit = \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE;
+            $memlimit = \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE;
+        }
 
         $nonce = substr($decoded, 0, \SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
         if (\SODIUM_CRYPTO_SECRETBOX_NONCEBYTES !== \strlen($nonce)) {
@@ -70,8 +112,8 @@ class SymmetricCrypto
             \SODIUM_CRYPTO_SECRETBOX_KEYBYTES,
             $password,
             $salt,
-            \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE,
-            \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE
+            $opslimit,
+            $memlimit,
         );
 
         sodium_memzero($password);

--- a/tests/Examples/CryptoEncryptTest.php
+++ b/tests/Examples/CryptoEncryptTest.php
@@ -21,7 +21,7 @@ class CryptoEncryptTest extends TaskTestCase
 
         $output = OutputCleaner::cleanOutput($process->getOutput());
 
-        $this->assertSame(93, \strlen($output));
+        $this->assertSame(125, \strlen($output));
         $this->assertSame('hello there', new SymmetricCrypto(new NullLogger())->decrypt($output, 'my super secret password'));
         $this->assertSame('', $process->getErrorOutput());
     }

--- a/tests/Helper/SymmetricCryptoTest.php
+++ b/tests/Helper/SymmetricCryptoTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Castor\Tests\Helper;
+
+use Castor\Helper\SymmetricCrypto;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class SymmetricCryptoTest extends TestCase
+{
+    private const string PASSWORD = 'my super secret password';
+
+    // Encrypted "hello there" with the format that predates the header
+    private const string LEGACY_PAYLOAD = 'rEg3vPkg1De1I91jmK4cuYlP5Pov1Fm0CVqkG3kFFtwjbSM6zi5yB5UugNppdFkOtiyzcbKr1QbCkF+qa2ymgL8PRw==';
+
+    protected function setUp(): void
+    {
+        if (!\extension_loaded('sodium')) {
+            $this->markTestSkipped('The sodium extension is not loaded.');
+        }
+    }
+
+    public function testRoundTrip(): void
+    {
+        $crypto = new SymmetricCrypto(new NullLogger());
+
+        $encrypted = $crypto->encrypt('hello there', self::PASSWORD);
+
+        $this->assertStringStartsWith("castor-crypto-v2\0", (string) base64_decode($encrypted, true));
+        $this->assertSame('hello there', $crypto->decrypt($encrypted, self::PASSWORD));
+    }
+
+    public function testTheKeyIsDerivedWithTheModerateLimits(): void
+    {
+        $crypto = new SymmetricCrypto(new NullLogger());
+
+        $header = unpack('Nopslimit/Nmemlimit', substr((string) base64_decode($crypto->encrypt('hello there', self::PASSWORD), true), \strlen("castor-crypto-v2\0"), 8));
+
+        $this->assertSame(\SODIUM_CRYPTO_PWHASH_OPSLIMIT_MODERATE, $header['opslimit'] ?? null);
+        $this->assertSame(\SODIUM_CRYPTO_PWHASH_MEMLIMIT_MODERATE, $header['memlimit'] ?? null);
+    }
+
+    public function testContentEncryptedBeforeTheHeaderExistedIsStillDecrypted(): void
+    {
+        $this->assertSame('hello there', new SymmetricCrypto(new NullLogger())->decrypt(self::LEGACY_PAYLOAD, self::PASSWORD));
+    }
+
+    public function testAWrongPasswordIsRejected(): void
+    {
+        $crypto = new SymmetricCrypto(new NullLogger());
+        $encrypted = $crypto->encrypt('hello there', self::PASSWORD);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to decrypt the content.');
+
+        $crypto->decrypt($encrypted, 'not the password');
+    }
+
+    public function testUnsupportedKeyDerivationLimitsAreRejected(): void
+    {
+        $crypto = new SymmetricCrypto(new NullLogger());
+        $decoded = (string) base64_decode($crypto->encrypt('hello there', self::PASSWORD), true);
+
+        // 2 GiB of memory, twice the "sensitive" limit of libsodium
+        $crafted = base64_encode(substr($decoded, 0, \strlen("castor-crypto-v2\0")) . pack('NN', 3, 2 * 1024 ** 3) . substr($decoded, \strlen("castor-crypto-v2\0") + 8));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('key derivation limits are not supported');
+
+        $crypto->decrypt($crafted, self::PASSWORD);
+    }
+}


### PR DESCRIPTION
`encrypt_with_password()` derived the key from the password with the "interactive" limits of libsodium (Argon2id, 2 passes, 64 MiB), meant for logins where the delay matters. The encrypted content is stored, often committed, so the "moderate" limits (3 passes, 256 MiB, about a second per operation) are used from now on.

The limits are stored in the payload, behind a `castor-crypto-v2\0` header, so they can change again later without breaking anything:

- a payload without the header, produced by the previous versions, is decrypted with the interactive limits it was encrypted with (the existing decrypt test with a fixed payload still passes);
- a payload produced by this version needs a Castor at least as recent to be decrypted, which the changelog and the documentation state;
- the limits read from a payload are bounded between the interactive and the "sensitive" ones, so a crafted payload cannot make the derivation exhaust the memory or the CPU.

Unit tests cover the round trip, the limits written in the header, the legacy payload, a wrong password and an out-of-bounds header.
